### PR TITLE
Implement a multiplexer for the tx settlement skill

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,6 +99,7 @@ fix-abci-app-specs:
 	autonomy analyse fsm-specs --update --app-class MarketManagerAbciApp --package packages/valory/skills/market_manager_abci
 	autonomy analyse fsm-specs --update --app-class DecisionMakerAbciApp --package packages/valory/skills/decision_maker_abci
 	autonomy analyse fsm-specs --update --app-class TraderAbciApp --package packages/valory/skills/trader_abci
+	autonomy analyse fsm-specs --update --app-class TxSettlementMultiplexerAbciApp --package packages/valory/skills/tx_settlement_multiplexer_abci
 	echo "Successfully validated abcis!"
 
 protolint_install:

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -1,12 +1,13 @@
 {
     "dev": {
-        "skill/valory/market_manager_abci/0.1.0": "bafybeieheaq7jgndahj6mqqee53epgbtu3frf3qmab6o3brwwill5ftvaq",
-        "skill/valory/decision_maker_abci/0.1.0": "bafybeigi6bjrgnzk34xpxah46ewovuijjxnqjwnrk6gl7iasxupfluuf5y",
-        "skill/valory/trader_abci/0.1.0": "bafybeieu4brymqya2sz7i4jwzcyfxtufykfjeetcuik3vg53hdjbrxrmpq",
+        "skill/valory/market_manager_abci/0.1.0": "bafybeiez3sahk7q3akqjpmzathafmgziwfdddddyuggzkbcxxf5mzq3nue",
+        "skill/valory/decision_maker_abci/0.1.0": "bafybeib234rmobhfr6es6e6wouthwu7ssdvxjfhgactgjyhwkeq7wufkwu",
+        "skill/valory/trader_abci/0.1.0": "bafybeiei5p7flqgenpvspfxbjcc4xwbb2rql7bwbp3dzb4ixv3xwkr44gy",
         "contract/valory/market_maker/0.1.0": "bafybeifihhoertnx3itmfzbuf4lazclzjuctxurayajguyn7ggsddolhte",
-        "agent/valory/trader/0.1.0": "bafybeicxmxc6kao53xcjs5w2p7dehso5fzz33zuailsdrvlh4wmxvqidim",
-        "service/valory/trader/0.1.0": "bafybeicc4tz5kkpogzyy5nvguy3p7bqylvqhqmhpbllt26467fzac4zn6e",
-        "contract/valory/erc20/0.1.0": "bafybeico5tbp27ebo7a745ok7duafmgeacyuonq5unjrisaefj6mg3rq7a"
+        "agent/valory/trader/0.1.0": "bafybeicrc5atl2eupc6mwdrnzkotyvhqpfc633s4zaa76glgkabqgi5hhq",
+        "service/valory/trader/0.1.0": "bafybeid3zhftilr7qyqap4hgfzt64cgi637m5vmqcrl3xhrx6qzo45l3c4",
+        "contract/valory/erc20/0.1.0": "bafybeico5tbp27ebo7a745ok7duafmgeacyuonq5unjrisaefj6mg3rq7a",
+        "skill/valory/tx_settlement_multiplexer_abci/0.1.0": "bafybeievmpkawwqrgf6fyqyjwhth62gsvrjgxk7ydyybq772zbz546hcty"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeibqlfmikg5hk4phzak6gqzhpkt6akckx7xppbp53mvwt6r73h7tk4",

--- a/packages/valory/agents/trader/aea-config.yaml
+++ b/packages/valory/agents/trader/aea-config.yaml
@@ -37,9 +37,9 @@ skills:
 - valory/reset_pause_abci:0.1.0:bafybeibqz7y3i4aepuprhijwdydkcsbqjtpeea6gdzpp5fgc6abrvjz25a
 - valory/termination_abci:0.1.0:bafybeieb3gnvjxxsh73g67m7rivzknwb63xu4qeagpkv7f4mqz33ecikem
 - valory/transaction_settlement_abci:0.1.0:bafybeihdpac4ayfgop3ixflimlb3zzyeejlpqtljfptdak6tc7aq4u5fzi
-- valory/market_manager_abci:0.1.0:bafybeieheaq7jgndahj6mqqee53epgbtu3frf3qmab6o3brwwill5ftvaq
-- valory/decision_maker_abci:0.1.0:bafybeigi6bjrgnzk34xpxah46ewovuijjxnqjwnrk6gl7iasxupfluuf5y
-- valory/trader_abci:0.1.0:bafybeieu4brymqya2sz7i4jwzcyfxtufykfjeetcuik3vg53hdjbrxrmpq
+- valory/market_manager_abci:0.1.0:bafybeiez3sahk7q3akqjpmzathafmgziwfdddddyuggzkbcxxf5mzq3nue
+- valory/decision_maker_abci:0.1.0:bafybeib234rmobhfr6es6e6wouthwu7ssdvxjfhgactgjyhwkeq7wufkwu
+- valory/trader_abci:0.1.0:bafybeiei5p7flqgenpvspfxbjcc4xwbb2rql7bwbp3dzb4ixv3xwkr44gy
 default_ledger: ethereum
 required_ledgers:
 - ethereum

--- a/packages/valory/services/trader/service.yaml
+++ b/packages/valory/services/trader/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeigtuothskwyvrhfosps2bu6suauycolj67dpuxqvnicdrdu7yhtvq
 fingerprint_ignore_patterns: []
-agent: valory/trader:0.1.0:bafybeicxmxc6kao53xcjs5w2p7dehso5fzz33zuailsdrvlh4wmxvqidim
+agent: valory/trader:0.1.0:bafybeicrc5atl2eupc6mwdrnzkotyvhqpfc633s4zaa76glgkabqgi5hhq
 number_of_agents: 4
 deployment: {}
 ---

--- a/packages/valory/skills/decision_maker_abci/skill.yaml
+++ b/packages/valory/skills/decision_maker_abci/skill.yaml
@@ -22,7 +22,7 @@ fingerprint:
   payloads.py: bafybeia63qdzl2lhn656yszisrcllg2idm5mjcpnk5mhvxttsbfcdwutdm
   rounds.py: bafybeid6caier4wg4mi3t5zgsrie2oyc7iif6ybicgtjcimhownjr625my
   states/__init__.py: bafybeid23llnyp6j257dluxmrnztugo5llsrog7kua53hllyktz4dqhqoy
-  states/base.py: bafybeifk44bz77zbz65q6vppfsjbxmjqvfeespd5jf6ms333cqrgli2rba
+  states/base.py: bafybeid6jkvqe6mskz3a7yabgylt6rjbx2vzyaca43o3rm4a77qcgneeaq
   states/bet_placement.py: bafybeig5remjdlsuiyla6gismcahnqqq7ooashzcz2m3lalntf37hfj3be
   states/blacklisting.py: bafybeiao747i4z7owk6dmwfuzdijag55m3ryj3nowfoggvczpgk3koza44
   states/decision_maker.py: bafybeiaqehtdzivhswlurqzxx2bxqjnrmeo6bfyvr2zn55ng3qpwbokauy
@@ -40,7 +40,7 @@ protocols:
 - valory/contract_api:1.0.0:bafybeidv6wxpjyb2sdyibnmmum45et4zcla6tl63bnol6ztyoqvpl4spmy
 skills:
 - valory/abstract_round_abci:0.1.0:bafybeiac62ennpw54gns2quk4g3yoaili2mb72nj6c52czobz5dcwj4mwi
-- valory/market_manager_abci:0.1.0:bafybeieheaq7jgndahj6mqqee53epgbtu3frf3qmab6o3brwwill5ftvaq
+- valory/market_manager_abci:0.1.0:bafybeiez3sahk7q3akqjpmzathafmgziwfdddddyuggzkbcxxf5mzq3nue
 - valory/transaction_settlement_abci:0.1.0:bafybeihdpac4ayfgop3ixflimlb3zzyeejlpqtljfptdak6tc7aq4u5fzi
 behaviours:
   main:

--- a/packages/valory/skills/decision_maker_abci/states/base.py
+++ b/packages/valory/skills/decision_maker_abci/states/base.py
@@ -84,6 +84,11 @@ class SynchronizedData(MarketManagerSyncedData, TxSettlementSyncedData):
         return bool(self.db.get_strict("is_profitable"))
 
     @property
+    def tx_submitter(self) -> str:
+        """Get the round that submitted a tx to transaction_settlement_abci."""
+        return str(self.db.get_strict("tx_submitter"))
+
+    @property
     def participant_to_decision(self) -> DeserializedCollection:
         """Get the participants to decision-making."""
         return self._get_deserialized("participant_to_decision")

--- a/packages/valory/skills/market_manager_abci/skill.yaml
+++ b/packages/valory/skills/market_manager_abci/skill.yaml
@@ -106,7 +106,7 @@ models:
       retry_attempts: 400
       retry_timeout: 3
       round_timeout_seconds: 350.0
-      service_id: market_manager_estimation
+      service_id: market_manager
       service_registry_address: null
       setup:
         all_participants:

--- a/packages/valory/skills/trader_abci/skill.yaml
+++ b/packages/valory/skills/trader_abci/skill.yaml
@@ -24,8 +24,8 @@ skills:
 - valory/reset_pause_abci:0.1.0:bafybeibqz7y3i4aepuprhijwdydkcsbqjtpeea6gdzpp5fgc6abrvjz25a
 - valory/transaction_settlement_abci:0.1.0:bafybeihdpac4ayfgop3ixflimlb3zzyeejlpqtljfptdak6tc7aq4u5fzi
 - valory/termination_abci:0.1.0:bafybeieb3gnvjxxsh73g67m7rivzknwb63xu4qeagpkv7f4mqz33ecikem
-- valory/market_manager_abci:0.1.0:bafybeieheaq7jgndahj6mqqee53epgbtu3frf3qmab6o3brwwill5ftvaq
-- valory/decision_maker_abci:0.1.0:bafybeigi6bjrgnzk34xpxah46ewovuijjxnqjwnrk6gl7iasxupfluuf5y
+- valory/market_manager_abci:0.1.0:bafybeiez3sahk7q3akqjpmzathafmgziwfdddddyuggzkbcxxf5mzq3nue
+- valory/decision_maker_abci:0.1.0:bafybeib234rmobhfr6es6e6wouthwu7ssdvxjfhgactgjyhwkeq7wufkwu
 behaviours:
   main:
     args: {}

--- a/packages/valory/skills/trader_abci/skill.yaml
+++ b/packages/valory/skills/trader_abci/skill.yaml
@@ -110,7 +110,7 @@ models:
       retry_attempts: 400
       retry_timeout: 3
       round_timeout_seconds: 350.0
-      service_id: market_manager_estimation
+      service_id: trader
       service_registry_address: null
       setup:
         all_participants:

--- a/packages/valory/skills/tx_settlement_multiplexer_abci/README.md
+++ b/packages/valory/skills/tx_settlement_multiplexer_abci/README.md
@@ -1,0 +1,6 @@
+# Transaction Settlement Multiplexer abci
+
+## Description
+
+This module contains a multiplexer for the transaction settlement skill.
+This is necessary in order to be able to chain the tx settlement multiple times for the FSM.

--- a/packages/valory/skills/tx_settlement_multiplexer_abci/__init__.py
+++ b/packages/valory/skills/tx_settlement_multiplexer_abci/__init__.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+# ------------------------------------------------------------------------------
+#
+#   Copyright 2023 Valory AG
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ------------------------------------------------------------------------------
+
+"""This module contains a skill that acts as a multiplexer for the transaction settlement skill."""
+
+from aea.configurations.base import PublicId
+
+
+PUBLIC_ID = PublicId.from_str("valory/tx_settlement_multiplexer_abci:0.1.0")

--- a/packages/valory/skills/tx_settlement_multiplexer_abci/behaviours.py
+++ b/packages/valory/skills/tx_settlement_multiplexer_abci/behaviours.py
@@ -1,0 +1,63 @@
+# -*- coding: utf-8 -*-
+# ------------------------------------------------------------------------------
+#
+#   Copyright 2023 Valory AG
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ------------------------------------------------------------------------------
+
+"""This package contains the behaviours of the transaction settlement multiplexer."""
+
+from abc import ABC
+from typing import Generator, Set, Type
+
+from packages.valory.skills.abstract_round_abci.behaviours import (
+    AbstractRoundBehaviour,
+    BaseBehaviour,
+)
+from packages.valory.skills.tx_settlement_multiplexer_abci.rounds import (
+    PostTxSettlementRound,
+    SynchronizedData,
+    TxSettlementMultiplexerAbciApp,
+)
+
+
+class PostTxSettlementBehaviour(BaseBehaviour, ABC):
+    """
+    The post transaction settlement behaviour.
+
+    This behaviour should be executed after a tx is settled via the transaction_settlement_abci.
+    """
+
+    matching_round = PostTxSettlementRound
+
+    @property
+    def synchronized_data(self) -> SynchronizedData:
+        """Return the synchronized data."""
+        return SynchronizedData(super().synchronized_data.db)
+
+    def async_act(self) -> Generator:
+        """Simply log that a tx is settled and wait for the round end."""
+        msg = f"The transaction submitted by {self.synchronized_data.tx_submitter} was successfully settled."
+        self.context.logger.info(msg)
+        yield from self.wait_until_round_end()
+        self.set_done()
+
+
+class PostTxSettlementFullBehaviour(AbstractRoundBehaviour):
+    """The post tx settlement full behaviour."""
+
+    initial_behaviour_cls = PostTxSettlementBehaviour
+    abci_app_cls = TxSettlementMultiplexerAbciApp
+    behaviours: Set[Type[BaseBehaviour]] = {PostTxSettlementBehaviour}  # type: ignore

--- a/packages/valory/skills/tx_settlement_multiplexer_abci/dialogues.py
+++ b/packages/valory/skills/tx_settlement_multiplexer_abci/dialogues.py
@@ -1,0 +1,90 @@
+# -*- coding: utf-8 -*-
+# ------------------------------------------------------------------------------
+#
+#   Copyright 2023 Valory AG
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ------------------------------------------------------------------------------
+
+"""This module contains the classes required for dialogue management."""
+
+from packages.valory.skills.abstract_round_abci.dialogues import (
+    AbciDialogue as BaseAbciDialogue,
+)
+from packages.valory.skills.abstract_round_abci.dialogues import (
+    AbciDialogues as BaseAbciDialogues,
+)
+from packages.valory.skills.abstract_round_abci.dialogues import (
+    ContractApiDialogue as BaseContractApiDialogue,
+)
+from packages.valory.skills.abstract_round_abci.dialogues import (
+    ContractApiDialogues as BaseContractApiDialogues,
+)
+from packages.valory.skills.abstract_round_abci.dialogues import (
+    HttpDialogue as BaseHttpDialogue,
+)
+from packages.valory.skills.abstract_round_abci.dialogues import (
+    HttpDialogues as BaseHttpDialogues,
+)
+from packages.valory.skills.abstract_round_abci.dialogues import (
+    IpfsDialogue as BaseIpfsDialogue,
+)
+from packages.valory.skills.abstract_round_abci.dialogues import (
+    IpfsDialogues as BaseIpfsDialogues,
+)
+from packages.valory.skills.abstract_round_abci.dialogues import (
+    LedgerApiDialogue as BaseLedgerApiDialogue,
+)
+from packages.valory.skills.abstract_round_abci.dialogues import (
+    LedgerApiDialogues as BaseLedgerApiDialogues,
+)
+from packages.valory.skills.abstract_round_abci.dialogues import (
+    SigningDialogue as BaseSigningDialogue,
+)
+from packages.valory.skills.abstract_round_abci.dialogues import (
+    SigningDialogues as BaseSigningDialogues,
+)
+from packages.valory.skills.abstract_round_abci.dialogues import (
+    TendermintDialogue as BaseTendermintDialogue,
+)
+from packages.valory.skills.abstract_round_abci.dialogues import (
+    TendermintDialogues as BaseTendermintDialogues,
+)
+
+
+AbciDialogue = BaseAbciDialogue
+AbciDialogues = BaseAbciDialogues
+
+
+HttpDialogue = BaseHttpDialogue
+HttpDialogues = BaseHttpDialogues
+
+
+SigningDialogue = BaseSigningDialogue
+SigningDialogues = BaseSigningDialogues
+
+
+LedgerApiDialogue = BaseLedgerApiDialogue
+LedgerApiDialogues = BaseLedgerApiDialogues
+
+
+ContractApiDialogue = BaseContractApiDialogue
+ContractApiDialogues = BaseContractApiDialogues
+
+TendermintDialogue = BaseTendermintDialogue
+TendermintDialogues = BaseTendermintDialogues
+
+
+IpfsDialogue = BaseIpfsDialogue
+IpfsDialogues = BaseIpfsDialogues

--- a/packages/valory/skills/tx_settlement_multiplexer_abci/fsm_specification.yaml
+++ b/packages/valory/skills/tx_settlement_multiplexer_abci/fsm_specification.yaml
@@ -1,0 +1,23 @@
+alphabet_in:
+- BET_PLACEMENT_DONE
+- DECISION_MAKING_DONE
+- ROUND_TIMEOUT
+- UNRECOGNIZED
+default_start_state: PostTxSettlementRound
+final_states:
+- FailedMultiplexerRound
+- FinishedBetPlacementRound
+- FinishedDecisionMakerRound
+label: TxSettlementMultiplexerAbciApp
+start_states:
+- PostTxSettlementRound
+states:
+- FailedMultiplexerRound
+- FinishedBetPlacementRound
+- FinishedDecisionMakerRound
+- PostTxSettlementRound
+transition_func:
+    (PostTxSettlementRound, BET_PLACEMENT_DONE): FinishedBetPlacementRound
+    (PostTxSettlementRound, DECISION_MAKING_DONE): FinishedDecisionMakerRound
+    (PostTxSettlementRound, ROUND_TIMEOUT): PostTxSettlementRound
+    (PostTxSettlementRound, UNRECOGNIZED): FailedMultiplexerRound

--- a/packages/valory/skills/tx_settlement_multiplexer_abci/handlers.py
+++ b/packages/valory/skills/tx_settlement_multiplexer_abci/handlers.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+# ------------------------------------------------------------------------------
+#
+#   Copyright 2023 Valory AG
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ------------------------------------------------------------------------------
+
+
+"""This module contains the handlers for the skill."""
+
+from packages.valory.skills.abstract_round_abci.handlers import ABCIRoundHandler
+from packages.valory.skills.abstract_round_abci.handlers import (
+    ContractApiHandler as BaseContractApiHandler,
+)
+from packages.valory.skills.abstract_round_abci.handlers import (
+    HttpHandler as BaseHttpHandler,
+)
+from packages.valory.skills.abstract_round_abci.handlers import (
+    IpfsHandler as BaseIpfsHandler,
+)
+from packages.valory.skills.abstract_round_abci.handlers import (
+    LedgerApiHandler as BaseLedgerApiHandler,
+)
+from packages.valory.skills.abstract_round_abci.handlers import (
+    SigningHandler as BaseSigningHandler,
+)
+from packages.valory.skills.abstract_round_abci.handlers import (
+    TendermintHandler as BaseTendermintHandler,
+)
+
+
+TxSettlementMultiplexerHandler = ABCIRoundHandler
+HttpHandler = BaseHttpHandler
+SigningHandler = BaseSigningHandler
+LedgerApiHandler = BaseLedgerApiHandler
+ContractApiHandler = BaseContractApiHandler
+TendermintHandler = BaseTendermintHandler
+IpfsHandler = BaseIpfsHandler

--- a/packages/valory/skills/tx_settlement_multiplexer_abci/models.py
+++ b/packages/valory/skills/tx_settlement_multiplexer_abci/models.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+# ------------------------------------------------------------------------------
+#
+#   Copyright 2023 Valory AG
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ------------------------------------------------------------------------------
+
+
+"""Custom objects for the TxSettlementMultiplexer ABCI application."""
+
+from packages.valory.skills.abstract_round_abci.models import BaseParams
+from packages.valory.skills.abstract_round_abci.models import (
+    BenchmarkTool as BaseBenchmarkTool,
+)
+from packages.valory.skills.abstract_round_abci.models import Requests as BaseRequests
+from packages.valory.skills.abstract_round_abci.models import (
+    SharedState as BaseSharedState,
+)
+from packages.valory.skills.tx_settlement_multiplexer_abci.rounds import (
+    TxSettlementMultiplexerAbciApp,
+)
+
+
+Requests = BaseRequests
+BenchmarkTool = BaseBenchmarkTool
+Params = BaseParams
+
+
+class SharedState(BaseSharedState):
+    """Keep the current shared state of the skill."""
+
+    abci_app_cls = TxSettlementMultiplexerAbciApp

--- a/packages/valory/skills/tx_settlement_multiplexer_abci/rounds.py
+++ b/packages/valory/skills/tx_settlement_multiplexer_abci/rounds.py
@@ -1,0 +1,141 @@
+# -*- coding: utf-8 -*-
+# ------------------------------------------------------------------------------
+#
+#   Copyright 2023 Valory AG
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ------------------------------------------------------------------------------
+
+"""This package contains the rounds of `TxSettlementMultiplexerAbciApp`."""
+
+from enum import Enum
+from typing import Any, Dict, Optional, Set, Tuple
+
+from packages.valory.skills.abstract_round_abci.base import (
+    AbciApp,
+    AbciAppTransitionFunction,
+    AppState,
+    BaseSynchronizedData,
+    CollectSameUntilThresholdRound,
+    DegenerateRound,
+    get_name,
+)
+from packages.valory.skills.decision_maker_abci.states.base import SynchronizedData
+from packages.valory.skills.decision_maker_abci.states.bet_placement import (
+    BetPlacementRound,
+)
+from packages.valory.skills.decision_maker_abci.states.decision_maker import (
+    DecisionMakerRound,
+)
+
+
+class Event(Enum):
+    """Multiplexing events."""
+
+    DECISION_MAKING_DONE = "decision_making_done"
+    BET_PLACEMENT_DONE = "bet_placement_done"
+    ROUND_TIMEOUT = "round_timeout"
+    UNRECOGNIZED = "unrecognized"
+
+
+SUBMITTER_TO_EVENT: Dict[str, Event] = {
+    DecisionMakerRound.auto_round_id(): Event.DECISION_MAKING_DONE,
+    BetPlacementRound.auto_round_id(): Event.BET_PLACEMENT_DONE,
+}
+
+
+class PostTxSettlementRound(CollectSameUntilThresholdRound):
+    """A round that will be called after tx settlement is done."""
+
+    payload_class: Any = object()
+    synchronized_data_class = SynchronizedData
+
+    def end_block(self) -> Optional[Tuple[BaseSynchronizedData, Enum]]:
+        """
+        The end block.
+
+        This is a special type of round. No consensus is necessary here.
+        There is no need to send a tx through, nor to check for a majority.
+        We simply use this round to check which round submitted the tx,
+        and move to the next state in accordance with that.
+        """
+        synced_data = SynchronizedData(self.synchronized_data.db)
+        event = SUBMITTER_TO_EVENT.get(synced_data.tx_submitter, Event.UNRECOGNIZED)
+        return synced_data, event
+
+
+class FinishedDecisionMakerRound(DegenerateRound):
+    """Finished decision maker round."""
+
+
+class FinishedBetPlacementRound(DegenerateRound):
+    """Finished bet placement round."""
+
+
+class FailedMultiplexerRound(DegenerateRound):
+    """Round that represents failure in identifying the transmitter round."""
+
+
+class TxSettlementMultiplexerAbciApp(AbciApp[Event]):
+    """TxSettlementMultiplexerAbciApp
+
+    Initial round: PostTxSettlementRound
+
+    Initial states: {PostTxSettlementRound}
+
+    Transition states:
+        0. PostTxSettlementRound
+            - decision making done: 1.
+            - bet placement done: 2.
+            - round timeout: 0.
+            - unrecognized: 3.
+        1. FinishedDecisionMakerRound
+        2. FinishedBetPlacementRound
+        3. FailedMultiplexerRound
+
+    Final states: {FailedMultiplexerRound, FinishedBetPlacementRound, FinishedDecisionMakerRound}
+
+    Timeouts:
+        round timeout: 30.0
+    """
+
+    initial_round_cls: AppState = PostTxSettlementRound
+    initial_states: Set[AppState] = {PostTxSettlementRound}
+    transition_function: AbciAppTransitionFunction = {
+        PostTxSettlementRound: {
+            Event.DECISION_MAKING_DONE: FinishedDecisionMakerRound,
+            Event.BET_PLACEMENT_DONE: FinishedBetPlacementRound,
+            Event.ROUND_TIMEOUT: PostTxSettlementRound,
+            Event.UNRECOGNIZED: FailedMultiplexerRound,
+        },
+        FinishedDecisionMakerRound: {},
+        FinishedBetPlacementRound: {},
+        FailedMultiplexerRound: {},
+    }
+    event_to_timeout: Dict[Event, float] = {
+        Event.ROUND_TIMEOUT: 30.0,
+    }
+    final_states: Set[AppState] = {
+        FinishedDecisionMakerRound,
+        FinishedBetPlacementRound,
+        FailedMultiplexerRound,
+    }
+    db_pre_conditions: Dict[AppState, Set[str]] = {
+        PostTxSettlementRound: {get_name(SynchronizedData.tx_submitter)}
+    }
+    db_post_conditions: Dict[AppState, Set[str]] = {
+        FinishedDecisionMakerRound: set(),
+        FinishedBetPlacementRound: set(),
+        FailedMultiplexerRound: set(),
+    }

--- a/packages/valory/skills/tx_settlement_multiplexer_abci/skill.yaml
+++ b/packages/valory/skills/tx_settlement_multiplexer_abci/skill.yaml
@@ -1,0 +1,125 @@
+name: tx_settlement_multiplexer_abci
+author: valory
+version: 0.1.0
+type: skill
+description: This skill implements a multiplexer for the transaction settlement skill.
+license: Apache-2.0
+aea_version: '>=1.0.0, <2.0.0'
+fingerprint:
+  n/a:
+fingerprint_ignore_patterns: []
+connections: []
+contracts: []
+protocols: []
+skills:
+- valory/abstract_round_abci:0.1.0:bafybeiac62ennpw54gns2quk4g3yoaili2mb72nj6c52czobz5dcwj4mwi
+- valory/decision_maker_abci:0.1.0:bafybeigi6bjrgnzk34xpxah46ewovuijjxnqjwnrk6gl7iasxupfluuf5y
+behaviours:
+  main:
+    args: {}
+    class_name: PostTxSettlementFullBehaviour
+handlers:
+  abci:
+    args: {}
+    class_name: TxSettlementMultiplexerHandler
+  contract_api:
+    args: {}
+    class_name: ContractApiHandler
+  http:
+    args: {}
+    class_name: HttpHandler
+  ipfs:
+    args: {}
+    class_name: IpfsHandler
+  ledger_api:
+    args: {}
+    class_name: LedgerApiHandler
+  signing:
+    args: {}
+    class_name: SigningHandler
+  tendermint:
+    args: {}
+    class_name: TendermintHandler
+models:
+  abci_dialogues:
+    args: {}
+    class_name: AbciDialogues
+  benchmark_tool:
+    args:
+      log_dir: /logs
+    class_name: BenchmarkTool
+  contract_api_dialogues:
+    args: {}
+    class_name: ContractApiDialogues
+  http_dialogues:
+    args: {}
+    class_name: HttpDialogues
+  ipfs_dialogues:
+    args: {}
+    class_name: IpfsDialogues
+  ledger_api_dialogues:
+    args: {}
+    class_name: LedgerApiDialogues
+  params:
+    args:
+      cleanup_history_depth: 1
+      cleanup_history_depth_current: null
+      drand_public_key: 868f005eb8e6e4ca0a47c8a77ceaa5309a47978a7c71bc5cce96366b5d7a569937c529eeda66c7293784a9402801af31
+      genesis_config:
+        genesis_time: '2022-05-20T16:00:21.735122717Z'
+        chain_id: chain-c4daS1
+        consensus_params:
+          block:
+            max_bytes: '22020096'
+            max_gas: '-1'
+            time_iota_ms: '1000'
+          evidence:
+            max_age_num_blocks: '100000'
+            max_age_duration: '172800000000000'
+            max_bytes: '1048576'
+          validator:
+            pub_key_types:
+            - ed25519
+          version: {}
+        voting_power: '10'
+      keeper_timeout: 30.0
+      max_attempts: 10
+      max_healthcheck: 120
+      multisend_address: '0x0000000000000000000000000000000000000000'
+      on_chain_service_id: null
+      request_retry_delay: 1.0
+      request_timeout: 10.0
+      reset_pause_duration: 10
+      reset_tendermint_after: 2
+      retry_attempts: 400
+      retry_timeout: 3
+      round_timeout_seconds: 350.0
+      service_id: tx_settlement_multiplexer
+      service_registry_address: null
+      setup:
+        all_participants:
+        - '0x0000000000000000000000000000000000000000'
+        safe_contract_address: '0x0000000000000000000000000000000000000000'
+        consensus_threshold: null
+      share_tm_config_on_startup: false
+      sleep_time: 5
+      tendermint_check_sleep_delay: 3
+      tendermint_com_url: http://localhost:8080
+      tendermint_max_retries: 5
+      tendermint_p2p_url: localhost:26656
+      tendermint_url: http://localhost:26657
+      termination_sleep: 900
+      tx_timeout: 10.0
+      use_termination: false
+    class_name: Params
+  requests:
+    args: {}
+    class_name: Requests
+  signing_dialogues:
+    args: {}
+    class_name: SigningDialogues
+  state:
+    args: {}
+    class_name: SharedState
+dependencies: {}
+is_abstract: true

--- a/packages/valory/skills/tx_settlement_multiplexer_abci/skill.yaml
+++ b/packages/valory/skills/tx_settlement_multiplexer_abci/skill.yaml
@@ -6,14 +6,21 @@ description: This skill implements a multiplexer for the transaction settlement 
 license: Apache-2.0
 aea_version: '>=1.0.0, <2.0.0'
 fingerprint:
-  n/a:
+  README.md: bafybeiegcjg2wjrsqhrmvyulioch3d67rnbzkx5af3ztkaw7kxathjreda
+  __init__.py: bafybeide6k22zk4f3hyzhpapaoddsnxpw5elqcfvrxxj4nfvpzctv6jqhu
+  behaviours.py: bafybeiafrhq7vtj2nrhrcvwi4d4r6w4pn4yoq2ria7lfakn6x4p4dcne4m
+  dialogues.py: bafybeiebofyykseqp3fmif36cqmmyf3k7d2zbocpl6t6wnlpv4szghrxbm
+  fsm_specification.yaml: bafybeierumzymhb7dvhxmqctf3lnrtidp56pmma5ezohbockikajyw5wje
+  handlers.py: bafybeiafbqr7ojfcbwohvee7x4zzswad3ymfrrbjlfz7uuuttmn3qdfs6q
+  models.py: bafybeiahojnn52s762zitwx6k5s4ef5qw7hwjf3orlklqwuz3zi7k2o7bi
+  rounds.py: bafybeichzlh6m6o4cr2o37c4gtnfurgwshdnycqdgco7ultbxejens5bya
 fingerprint_ignore_patterns: []
 connections: []
 contracts: []
 protocols: []
 skills:
 - valory/abstract_round_abci:0.1.0:bafybeiac62ennpw54gns2quk4g3yoaili2mb72nj6c52czobz5dcwj4mwi
-- valory/decision_maker_abci:0.1.0:bafybeigi6bjrgnzk34xpxah46ewovuijjxnqjwnrk6gl7iasxupfluuf5y
+- valory/decision_maker_abci:0.1.0:bafybeib234rmobhfr6es6e6wouthwu7ssdvxjfhgactgjyhwkeq7wufkwu
 behaviours:
   main:
     args: {}

--- a/tox.ini
+++ b/tox.ini
@@ -59,7 +59,7 @@ setenv =
     PYTHONPATH={env:PWD:%CD%}
     PACKAGES_PATHS = packages/valory
     SKILLS_PATHS = {env:PACKAGES_PATHS}/skills
-    SERVICE_SPECIFIC_PACKAGES = {env:SKILLS_PATHS}/market_manager_abci {env:SKILLS_PATHS}/decision_maker_abci {env:SKILLS_PATHS}/trader_abci
+    SERVICE_SPECIFIC_PACKAGES = {env:SKILLS_PATHS}/market_manager_abci {env:SKILLS_PATHS}/decision_maker_abci {env:SKILLS_PATHS}/trader_abci {env:SKILLS_PATHS}/tx_settlement_multiplexer_abci
 
 [testenv:bandit]
 skipsdist = True


### PR DESCRIPTION
Implements a multiplexer for the tx settlement skill to overcome a framework's limitation.

The limitation arises from the necessity to refactor the process of making a request to the mech. This refactoring will bypass the need for the Ethereum private key's path by replacing the mech client. Consequently, to accommodate this change, we will employ a safe transaction via the tx settlement skill.

As a result, we will utilize the tx settlement to perform a safe transaction for two purposes: a) making requests to the mech, and b) placing bets.