### PR TITLE
Make some fields optional

### DIFF
--- a/packages/packages.json
+++ b/packages/packages.json
@@ -1,13 +1,13 @@
 {
     "dev": {
-        "skill/valory/market_manager_abci/0.1.0": "bafybeids5us4cnfu2zboxfjjkyihxk2i4qmctwzbnrsk2uizzjl2gbjj4m",
-        "skill/valory/decision_maker_abci/0.1.0": "bafybeifxzzqxi4stwn7k6v2iotrf7rijv5bybhwyrstmozwd7zcjfkvwki",
-        "skill/valory/trader_abci/0.1.0": "bafybeihb25sw6gegl53dddltqa2p6pkpnexbttellqgbncq7c76pnzm6tq",
+        "skill/valory/market_manager_abci/0.1.0": "bafybeid2sx5aorbyozxivzk7wfcfsydkil3nxsadb26zt2cri6v2l324ue",
+        "skill/valory/decision_maker_abci/0.1.0": "bafybeihs4k26uk57evqvefqqql627q7vuyrireupam5baqafzxcwtsnvf4",
+        "skill/valory/trader_abci/0.1.0": "bafybeieft6qr7rtl7yvv72uyfl6slyiazcxv6nvczdyulfnza5cxfir5fu",
         "contract/valory/market_maker/0.1.0": "bafybeig3b2wfngntdypnixi2gphuqz3o6w7zba2rq6n6kepwdmth2mx3ni",
-        "agent/valory/trader/0.1.0": "bafybeigepq6yg6atkfkjlqrztmcekqx5r5ydq5m7se264hg2wdbyl4mfr4",
-        "service/valory/trader/0.1.0": "bafybeihgcnioxjhmgv2i2iyht4cru7oqqgkwkxxp3in4bxlaae7owi7ari",
+        "agent/valory/trader/0.1.0": "bafybeig3ar7o6xplpfljxtl356sebmuk2hyjhqh5lgdyhhb7e4iif4kndq",
+        "service/valory/trader/0.1.0": "bafybeidpwt4phbjwu353hv6uqhmx57yajiwrw3oepadyvoak3c5nygozqu",
         "contract/valory/erc20/0.1.0": "bafybeid4dnlzxpvb7sbgo2bnnffzwk5scelytshworzbfyxce6ibdyk67i",
-        "skill/valory/tx_settlement_multiplexer_abci/0.1.0": "bafybeianobsmjh2qjwtdzyvaxpefgz4ywpyxzk7iznmsygved7wxbtl23e",
+        "skill/valory/tx_settlement_multiplexer_abci/0.1.0": "bafybeiavkmrdwdif5i5fs4vz43i43ecashbzzz6r7c5xojtyuhpm35vz2u",
         "contract/valory/mech/0.1.0": "bafybeib3syh35usqjtqapqjjvobnkcxllkpjbxcb67g3vp3f566qsbhqgq"
     },
     "third_party": {

--- a/packages/valory/agents/trader/aea-config.yaml
+++ b/packages/valory/agents/trader/aea-config.yaml
@@ -38,10 +38,10 @@ skills:
 - valory/reset_pause_abci:0.1.0:bafybeialcwck7fahrr23jckv5qjwg3cdq4ai2ihyjsofnbj44jzyl4cjmm
 - valory/termination_abci:0.1.0:bafybeifqsogqiar4yook5bu3j6z66dbdcizey7dr3e5oxeocdjijvfbaja
 - valory/transaction_settlement_abci:0.1.0:bafybeiacwr7p4nhhufoey7uz2jqkegrlykdrmc7mm3rzkvh2mslu66gyle
-- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeianobsmjh2qjwtdzyvaxpefgz4ywpyxzk7iznmsygved7wxbtl23e
-- valory/market_manager_abci:0.1.0:bafybeids5us4cnfu2zboxfjjkyihxk2i4qmctwzbnrsk2uizzjl2gbjj4m
-- valory/decision_maker_abci:0.1.0:bafybeifxzzqxi4stwn7k6v2iotrf7rijv5bybhwyrstmozwd7zcjfkvwki
-- valory/trader_abci:0.1.0:bafybeihb25sw6gegl53dddltqa2p6pkpnexbttellqgbncq7c76pnzm6tq
+- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeiavkmrdwdif5i5fs4vz43i43ecashbzzz6r7c5xojtyuhpm35vz2u
+- valory/market_manager_abci:0.1.0:bafybeid2sx5aorbyozxivzk7wfcfsydkil3nxsadb26zt2cri6v2l324ue
+- valory/decision_maker_abci:0.1.0:bafybeihs4k26uk57evqvefqqql627q7vuyrireupam5baqafzxcwtsnvf4
+- valory/trader_abci:0.1.0:bafybeieft6qr7rtl7yvv72uyfl6slyiazcxv6nvczdyulfnza5cxfir5fu
 default_ledger: ethereum
 required_ledgers:
 - ethereum

--- a/packages/valory/services/trader/service.yaml
+++ b/packages/valory/services/trader/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeigtuothskwyvrhfosps2bu6suauycolj67dpuxqvnicdrdu7yhtvq
 fingerprint_ignore_patterns: []
-agent: valory/trader:0.1.0:bafybeigepq6yg6atkfkjlqrztmcekqx5r5ydq5m7se264hg2wdbyl4mfr4
+agent: valory/trader:0.1.0:bafybeig3ar7o6xplpfljxtl356sebmuk2hyjhqh5lgdyhhb7e4iif4kndq
 number_of_agents: 4
 deployment: {}
 ---

--- a/packages/valory/skills/decision_maker_abci/behaviours/sampling.py
+++ b/packages/valory/skills/decision_maker_abci/behaviours/sampling.py
@@ -72,6 +72,12 @@ class SamplingBehaviour(DecisionMakerBaseBehaviour):
             return None, None
 
         idx = self._sampled_bet_idx(available_bets)
+
+        if self.synchronized_data.bets[idx].usdLiquidityMeasure == 0:
+            msg = "There were no unprocessed bets with non-zero liquidity!"
+            self.context.logger.warning(msg)
+            return None, None
+
         bets = self._set_processed(idx)
         msg = f"Sampled bet: {self.synchronized_data.bets[idx]}"
         self.context.logger.info(msg)

--- a/packages/valory/skills/decision_maker_abci/skill.yaml
+++ b/packages/valory/skills/decision_maker_abci/skill.yaml
@@ -15,7 +15,7 @@ fingerprint:
   behaviours/decision_receive.py: bafybeigjct7st66x7n3go5vdp62wtdxgmgw233hyyvd3a63ly4x3ptdqbq
   behaviours/decision_request.py: bafybeidsvohdt2fxonh5qmctftjj5wfaa5z3ommr2yie6e7bhcml6xueuu
   behaviours/round_behaviour.py: bafybeiahjypqkswz5ufusagxpxmjhngipin2feis56lasqin75jwqcwpaa
-  behaviours/sampling.py: bafybeig3mdp3slye3qsstj5k6heo5ud3zr4ym7us2tvx3yqkywyoggohvm
+  behaviours/sampling.py: bafybeiesza5cols7opbpp3g3ozyqmskl5g6cqdjow4vsq4r7tet2xkyruq
   dialogues.py: bafybeigpwuzku3we7axmxeamg7vn656maww6emuztau5pg3ebsoquyfdqm
   fsm_specification.yaml: bafybeickhbppg4kttuouhwagza2b3ngw3syrmceinkylcw2nruyclkb5di
   handlers.py: bafybeihj33szgrcxnpd73s4nvluyxwwsvhjum2cuq3ilhhe6vfola3k7vy
@@ -42,7 +42,7 @@ protocols:
 - valory/contract_api:1.0.0:bafybeiasywsvax45qmugus5kxogejj66c5taen27h4voriodz7rgushtqa
 skills:
 - valory/abstract_round_abci:0.1.0:bafybeiaseziuvbzh3trjggl5hx2tv3fduqrpiwiyksudaf6nvuxmwrg74i
-- valory/market_manager_abci:0.1.0:bafybeids5us4cnfu2zboxfjjkyihxk2i4qmctwzbnrsk2uizzjl2gbjj4m
+- valory/market_manager_abci:0.1.0:bafybeid2sx5aorbyozxivzk7wfcfsydkil3nxsadb26zt2cri6v2l324ue
 - valory/transaction_settlement_abci:0.1.0:bafybeiacwr7p4nhhufoey7uz2jqkegrlykdrmc7mm3rzkvh2mslu66gyle
 behaviours:
   main:

--- a/packages/valory/skills/market_manager_abci/behaviours.py
+++ b/packages/valory/skills/market_manager_abci/behaviours.py
@@ -88,7 +88,7 @@ class UpdateBetsBehaviour(QueryingBehaviour):
                 bets_updates = (
                     Bet(**bet, market=self._current_market)
                     for bet in bets_market_chunk
-                    if bet["id"] not in existing_ids and bet["outcomes"] is not None
+                    if bet.get("id", "") not in existing_ids
                 )
                 self.bets.extend(bets_updates)
 

--- a/packages/valory/skills/market_manager_abci/bets.py
+++ b/packages/valory/skills/market_manager_abci/bets.py
@@ -62,6 +62,7 @@ class Bet:
         """Post initialization to adjust the values."""
         self._validate()
         self._cast()
+        self._check_usefulness()
 
     def __lt__(self, other: "Bet") -> bool:
         """Implements less than operator."""
@@ -120,6 +121,11 @@ class Bet:
                     setattr(self, field, hinted_type(uncasted))
                 if f"{str(List)}[{type_name}]" == str(hinted_type):
                     setattr(self, field, list(type_to_cast(val) for val in uncasted))
+
+    def _check_usefulness(self) -> None:
+        """If the bet is deemed unhelpful, then blacklist it."""
+        if self.usdLiquidityMeasure == 0:
+            self._blacklist_forever()
 
     def get_outcome(self, index: int) -> str:
         """Get an outcome given its index."""

--- a/packages/valory/skills/market_manager_abci/bets.py
+++ b/packages/valory/skills/market_manager_abci/bets.py
@@ -23,6 +23,7 @@
 import builtins
 import dataclasses
 import json
+import sys
 from enum import Enum, auto
 from typing import Any, Dict, List, Optional, Union
 
@@ -67,7 +68,7 @@ class Bet:
             != len(self.outcomeTokenMarginalPrices)
             != self.outcomeSlotCount
         ):
-            self.outcomes = None
+            self._blacklist_forever()
 
         if isinstance(self.status, int):
             self.status = BetStatus(self.status)
@@ -85,6 +86,12 @@ class Bet:
     def __lt__(self, other: "Bet") -> bool:
         """Implements less than operator."""
         return self.usdLiquidityMeasure < other.usdLiquidityMeasure
+
+    def _blacklist_forever(self) -> None:
+        """Blacklist a bet forever. Should only be used in cases where it is impossible to bet."""
+        self.outcomes = None
+        self.status = BetStatus.BLACKLISTED
+        self.blacklist_expiration = sys.maxsize
 
     def get_outcome(self, index: int) -> str:
         """Get an outcome given its index."""

--- a/packages/valory/skills/market_manager_abci/bets.py
+++ b/packages/valory/skills/market_manager_abci/bets.py
@@ -77,6 +77,9 @@ class Bet:
         str_to_type = {getattr(builtins, type_): type_ for type_ in types_to_cast}
         for field, hinted_type in self.__annotations__.items():
             uncasted = getattr(self, field)
+            if uncasted is None:
+                continue
+
             for type_to_cast, type_name in str_to_type.items():
                 if hinted_type == type_to_cast:
                     setattr(self, field, hinted_type(uncasted))

--- a/packages/valory/skills/market_manager_abci/skill.yaml
+++ b/packages/valory/skills/market_manager_abci/skill.yaml
@@ -8,8 +8,8 @@ aea_version: '>=1.0.0, <2.0.0'
 fingerprint:
   README.md: bafybeie6miwn67uin3bphukmf7qgiifh4xtm42i5v3nuyqxzxtehxsqvcq
   __init__.py: bafybeigrtedqzlq5mtql2ssjsdriw76ml3666m4e2c3fay6vmyzofl6v6e
-  behaviours.py: bafybeig4wbudfwtjcxm3n4qnbjf2czr5jffaiuvnx7vbotsv5vdm3zkhom
-  bets.py: bafybeibkmrktcj3ld5kypdjulf6gwzj6ft6qeh2iokm4yqjzzyv3ry6ga4
+  behaviours.py: bafybeigexg3adtgodlzybgxcqw3qihuhownzxrmfnhlouilt75q7hmp7bu
+  bets.py: bafybeidt7njf6fqzxqzmqe6p3k7pxwjhvsd7ynofb76x3ao32izbswilie
   dialogues.py: bafybeiebofyykseqp3fmif36cqmmyf3k7d2zbocpl6t6wnlpv4szghrxbm
   fsm_specification.yaml: bafybeic5cvwfbiu5pywyp3h5s2elvu7jqdrcwayay7o3v3ow47vu2jw53q
   graph_tooling/__init__.py: bafybeigzo7nhbzafyq3fuhrlewksjvmzttiuk4vonrggtjtph4rw4ncpk4

--- a/packages/valory/skills/trader_abci/skill.yaml
+++ b/packages/valory/skills/trader_abci/skill.yaml
@@ -24,9 +24,9 @@ skills:
 - valory/reset_pause_abci:0.1.0:bafybeialcwck7fahrr23jckv5qjwg3cdq4ai2ihyjsofnbj44jzyl4cjmm
 - valory/transaction_settlement_abci:0.1.0:bafybeiacwr7p4nhhufoey7uz2jqkegrlykdrmc7mm3rzkvh2mslu66gyle
 - valory/termination_abci:0.1.0:bafybeifqsogqiar4yook5bu3j6z66dbdcizey7dr3e5oxeocdjijvfbaja
-- valory/market_manager_abci:0.1.0:bafybeids5us4cnfu2zboxfjjkyihxk2i4qmctwzbnrsk2uizzjl2gbjj4m
-- valory/decision_maker_abci:0.1.0:bafybeifxzzqxi4stwn7k6v2iotrf7rijv5bybhwyrstmozwd7zcjfkvwki
-- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeianobsmjh2qjwtdzyvaxpefgz4ywpyxzk7iznmsygved7wxbtl23e
+- valory/market_manager_abci:0.1.0:bafybeid2sx5aorbyozxivzk7wfcfsydkil3nxsadb26zt2cri6v2l324ue
+- valory/decision_maker_abci:0.1.0:bafybeihs4k26uk57evqvefqqql627q7vuyrireupam5baqafzxcwtsnvf4
+- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeiavkmrdwdif5i5fs4vz43i43ecashbzzz6r7c5xojtyuhpm35vz2u
 behaviours:
   main:
     args: {}

--- a/packages/valory/skills/tx_settlement_multiplexer_abci/skill.yaml
+++ b/packages/valory/skills/tx_settlement_multiplexer_abci/skill.yaml
@@ -20,7 +20,7 @@ contracts: []
 protocols: []
 skills:
 - valory/abstract_round_abci:0.1.0:bafybeiaseziuvbzh3trjggl5hx2tv3fduqrpiwiyksudaf6nvuxmwrg74i
-- valory/decision_maker_abci:0.1.0:bafybeifxzzqxi4stwn7k6v2iotrf7rijv5bybhwyrstmozwd7zcjfkvwki
+- valory/decision_maker_abci:0.1.0:bafybeihs4k26uk57evqvefqqql627q7vuyrireupam5baqafzxcwtsnvf4
 behaviours:
   main:
     args: {}


### PR DESCRIPTION
Fixes a failure that was caused by some optional field being `None`. The service now continues without setting the field instead of failing.

Moreover, blacklists a bet forever if there is no liquidity or there are no outcomes.