### PR TITLE
Fix indefinite loop

### DIFF
--- a/packages/packages.json
+++ b/packages/packages.json
@@ -1,13 +1,13 @@
 {
     "dev": {
         "skill/valory/market_manager_abci/0.1.0": "bafybeibulxdh2fiar3gmqmxu3772s3bxps6jpl77r2weuh3py56mtmiptu",
-        "skill/valory/decision_maker_abci/0.1.0": "bafybeihkwk6yzys5lkqgccvl5wkp2r22v7i6rsttyuh4zmfe37idybzrme",
-        "skill/valory/trader_abci/0.1.0": "bafybeidrjwbdagvzhws2xtjg6gu2hc32lzyut6psv63dgavglhcisgcjpe",
+        "skill/valory/decision_maker_abci/0.1.0": "bafybeigircx36tx3nw3r6dgym357e3wyzabb7y7zhahhttwbkgnxinsgre",
+        "skill/valory/trader_abci/0.1.0": "bafybeieql7tbo4hqgwjmitho2t2ih4luek7p5swdxgkm4ivdxds4byrale",
         "contract/valory/market_maker/0.1.0": "bafybeighn4o263yxjxc46n5rckfnonwtyyhvjmegmkrqraixvswuyhcsp4",
-        "agent/valory/trader/0.1.0": "bafybeiclkbc4ewf7rvooibm465qmfljdvbhl3cytdvq3bn4drmipuqrd6y",
-        "service/valory/trader/0.1.0": "bafybeid25qzthxgeeq3h2znwbih6wzsctvdytcyi2nwcozigzfwm4vhl7q",
+        "agent/valory/trader/0.1.0": "bafybeidtnoig36drx73jgln7ihdi6tx5dj3hi6fqfi2d4u5naidd2jtvty",
+        "service/valory/trader/0.1.0": "bafybeia76255utpjtvovvcksfle3lytvgkf2zcfw3ikmelmjt2wk3srb54",
         "contract/valory/erc20/0.1.0": "bafybeigukunw5qnrbpwb3arqdbt2anducy7grpc5lcbbbagxzcixdmvwyy",
-        "skill/valory/tx_settlement_multiplexer_abci/0.1.0": "bafybeicets4augpv4btd2aktqavrz3qhmjysi3mqhgyvr6rexz3244iiru",
+        "skill/valory/tx_settlement_multiplexer_abci/0.1.0": "bafybeibupdpthklpcrm3bbmmwqbglamjwn3ek7dmxl5rpod4ys6oarbw5y",
         "contract/valory/mech/0.1.0": "bafybeid62uorgjwj7bzeptykawh2jr2bxloaalk65tm3kchth4gnfq2q2u"
     },
     "third_party": {

--- a/packages/valory/agents/trader/aea-config.yaml
+++ b/packages/valory/agents/trader/aea-config.yaml
@@ -38,10 +38,10 @@ skills:
 - valory/reset_pause_abci:0.1.0:bafybeid445uy6wwvugf3byzl7r73c7teu6xr5ezxb4h7cxbenghg3copvy
 - valory/termination_abci:0.1.0:bafybeiguy7pkrcptg6c754ioig4mlkr7truccym3fpv6jwpjx2tmpdbzhi
 - valory/transaction_settlement_abci:0.1.0:bafybeidpsnguxizkpihtkqzojr3em7yy7c6qc7gxpbh5vglmwws5wke7bi
-- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeicets4augpv4btd2aktqavrz3qhmjysi3mqhgyvr6rexz3244iiru
+- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeibupdpthklpcrm3bbmmwqbglamjwn3ek7dmxl5rpod4ys6oarbw5y
 - valory/market_manager_abci:0.1.0:bafybeibulxdh2fiar3gmqmxu3772s3bxps6jpl77r2weuh3py56mtmiptu
-- valory/decision_maker_abci:0.1.0:bafybeihkwk6yzys5lkqgccvl5wkp2r22v7i6rsttyuh4zmfe37idybzrme
-- valory/trader_abci:0.1.0:bafybeidrjwbdagvzhws2xtjg6gu2hc32lzyut6psv63dgavglhcisgcjpe
+- valory/decision_maker_abci:0.1.0:bafybeigircx36tx3nw3r6dgym357e3wyzabb7y7zhahhttwbkgnxinsgre
+- valory/trader_abci:0.1.0:bafybeieql7tbo4hqgwjmitho2t2ih4luek7p5swdxgkm4ivdxds4byrale
 default_ledger: ethereum
 required_ledgers:
 - ethereum

--- a/packages/valory/services/trader/service.yaml
+++ b/packages/valory/services/trader/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeigtuothskwyvrhfosps2bu6suauycolj67dpuxqvnicdrdu7yhtvq
 fingerprint_ignore_patterns: []
-agent: valory/trader:0.1.0:bafybeiclkbc4ewf7rvooibm465qmfljdvbhl3cytdvq3bn4drmipuqrd6y
+agent: valory/trader:0.1.0:bafybeidtnoig36drx73jgln7ihdi6tx5dj3hi6fqfi2d4u5naidd2jtvty
 number_of_agents: 4
 deployment: {}
 ---

--- a/packages/valory/skills/decision_maker_abci/fsm_specification.yaml
+++ b/packages/valory/skills/decision_maker_abci/fsm_specification.yaml
@@ -42,7 +42,7 @@ transition_func:
     (BlacklistingRound, NO_MAJORITY): BlacklistingRound
     (BlacklistingRound, ROUND_TIMEOUT): BlacklistingRound
     (DecisionReceiveRound, DONE): BetPlacementRound
-    (DecisionReceiveRound, MECH_RESPONSE_ERROR): DecisionReceiveRound
+    (DecisionReceiveRound, MECH_RESPONSE_ERROR): BlacklistingRound
     (DecisionReceiveRound, NO_MAJORITY): DecisionReceiveRound
     (DecisionReceiveRound, ROUND_TIMEOUT): DecisionReceiveRound
     (DecisionReceiveRound, TIE): BlacklistingRound

--- a/packages/valory/skills/decision_maker_abci/rounds.py
+++ b/packages/valory/skills/decision_maker_abci/rounds.py
@@ -127,7 +127,7 @@ class DecisionMakerAbciApp(AbciApp[Event]):
         },
         DecisionReceiveRound: {
             Event.DONE: BetPlacementRound,
-            Event.MECH_RESPONSE_ERROR: DecisionReceiveRound,  # loop on the same state until Mech deliver is received
+            Event.MECH_RESPONSE_ERROR: BlacklistingRound,
             Event.NO_MAJORITY: DecisionReceiveRound,
             Event.TIE: BlacklistingRound,
             Event.UNPROFITABLE: BlacklistingRound,

--- a/packages/valory/skills/decision_maker_abci/rounds.py
+++ b/packages/valory/skills/decision_maker_abci/rounds.py
@@ -76,7 +76,7 @@ class DecisionMakerAbciApp(AbciApp[Event]):
             - none: 8.
         2. DecisionReceiveRound
             - done: 4.
-            - mech response error: 2.
+            - mech response error: 3.
             - no majority: 2.
             - tie: 3.
             - unprofitable: 3.

--- a/packages/valory/skills/decision_maker_abci/skill.yaml
+++ b/packages/valory/skills/decision_maker_abci/skill.yaml
@@ -17,11 +17,11 @@ fingerprint:
   behaviours/round_behaviour.py: bafybeiahjypqkswz5ufusagxpxmjhngipin2feis56lasqin75jwqcwpaa
   behaviours/sampling.py: bafybeiesza5cols7opbpp3g3ozyqmskl5g6cqdjow4vsq4r7tet2xkyruq
   dialogues.py: bafybeigpwuzku3we7axmxeamg7vn656maww6emuztau5pg3ebsoquyfdqm
-  fsm_specification.yaml: bafybeifx2pct7dt4ttnf5bmmum5sejx5eavbznlsjzyd7kkkddwop5gzce
+  fsm_specification.yaml: bafybeigdfhb6h3okjytsnh7np7m25e2jh6tg7664zfv3mqkictje77z5zm
   handlers.py: bafybeihj33szgrcxnpd73s4nvluyxwwsvhjum2cuq3ilhhe6vfola3k7vy
   models.py: bafybeietew6d4nva64afznxropoko2is56f33dfww5es4cmdwuqpdh56m4
   payloads.py: bafybeifvklik2j2jsevy2e5oermoo3mml6hiy6gyuppsd7cgupsylosl6a
-  rounds.py: bafybeicpyo4y5rabtnxqwyojwvdaqj4ep7fa5asoj7lfu2n7fdv7whgifa
+  rounds.py: bafybeihcjqhodtyutwdjcdpdmuw3ra7qhf56brh5g2k4ctcn3t5lvdvwhy
   states/__init__.py: bafybeid23llnyp6j257dluxmrnztugo5llsrog7kua53hllyktz4dqhqoy
   states/base.py: bafybeib7wpuo2suhgb6xkvxvjiij22bvm5e2tpzpoccelv57c2stql4o7y
   states/bet_placement.py: bafybeibalhxhp2c4oljmiwqi6ds3g36fgtabmf42mb5sgq6z22znrcbhda

--- a/packages/valory/skills/trader_abci/fsm_specification.yaml
+++ b/packages/valory/skills/trader_abci/fsm_specification.yaml
@@ -83,7 +83,7 @@ transition_func:
     (CollectSignatureRound, NO_MAJORITY): ResetRound
     (CollectSignatureRound, ROUND_TIMEOUT): CollectSignatureRound
     (DecisionReceiveRound, DONE): BetPlacementRound
-    (DecisionReceiveRound, MECH_RESPONSE_ERROR): DecisionReceiveRound
+    (DecisionReceiveRound, MECH_RESPONSE_ERROR): BlacklistingRound
     (DecisionReceiveRound, NO_MAJORITY): DecisionReceiveRound
     (DecisionReceiveRound, ROUND_TIMEOUT): DecisionReceiveRound
     (DecisionReceiveRound, TIE): BlacklistingRound

--- a/packages/valory/skills/trader_abci/skill.yaml
+++ b/packages/valory/skills/trader_abci/skill.yaml
@@ -11,7 +11,7 @@ fingerprint:
   behaviours.py: bafybeiaqm5cdrhdiavrcuop35dndttz2cgmt2emcs274l6swobfla2a3li
   composition.py: bafybeihfwptqgt74i3c7ojaeztchyk765xzyualdtedtvsdczuswwwzu5e
   dialogues.py: bafybeiebofyykseqp3fmif36cqmmyf3k7d2zbocpl6t6wnlpv4szghrxbm
-  fsm_specification.yaml: bafybeifyadlv4gdqhzo2jerex5xtj3hcg4m64n6pal6e774dehl3tvkp2q
+  fsm_specification.yaml: bafybeiavnhxwmh27v5iol4grbbuv3vn2xcpuha3mzwx43aj5yqrx4xbfte
   handlers.py: bafybeicamc6vmozij5dwvkxmbxjazsgf3sacojhstbjtq7vfggszxugvey
   models.py: bafybeid4lhamqwhe2mxizjftdz3wspinrdzb5sor3iwo7pltixmojwrx6y
 fingerprint_ignore_patterns: []
@@ -25,8 +25,8 @@ skills:
 - valory/transaction_settlement_abci:0.1.0:bafybeidpsnguxizkpihtkqzojr3em7yy7c6qc7gxpbh5vglmwws5wke7bi
 - valory/termination_abci:0.1.0:bafybeiguy7pkrcptg6c754ioig4mlkr7truccym3fpv6jwpjx2tmpdbzhi
 - valory/market_manager_abci:0.1.0:bafybeibulxdh2fiar3gmqmxu3772s3bxps6jpl77r2weuh3py56mtmiptu
-- valory/decision_maker_abci:0.1.0:bafybeihkwk6yzys5lkqgccvl5wkp2r22v7i6rsttyuh4zmfe37idybzrme
-- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeicets4augpv4btd2aktqavrz3qhmjysi3mqhgyvr6rexz3244iiru
+- valory/decision_maker_abci:0.1.0:bafybeigircx36tx3nw3r6dgym357e3wyzabb7y7zhahhttwbkgnxinsgre
+- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeibupdpthklpcrm3bbmmwqbglamjwn3ek7dmxl5rpod4ys6oarbw5y
 behaviours:
   main:
     args: {}

--- a/packages/valory/skills/tx_settlement_multiplexer_abci/skill.yaml
+++ b/packages/valory/skills/tx_settlement_multiplexer_abci/skill.yaml
@@ -20,7 +20,7 @@ contracts: []
 protocols: []
 skills:
 - valory/abstract_round_abci:0.1.0:bafybeigxjcci53vwytymzlhr37436yvenh7jup4astrn7dgyixo24aq2pq
-- valory/decision_maker_abci:0.1.0:bafybeihkwk6yzys5lkqgccvl5wkp2r22v7i6rsttyuh4zmfe37idybzrme
+- valory/decision_maker_abci:0.1.0:bafybeigircx36tx3nw3r6dgym357e3wyzabb7y7zhahhttwbkgnxinsgre
 behaviours:
   main:
     args: {}


### PR DESCRIPTION
Fixes bug introduced on #55.

We should not loop when the mech responds with an error, because we may end up in an infinite loop. For example:

```
.
.
.
2023-08-24 10:30:57	[2023-08-24 07:30:54,544] [INFO] [agent] Entered in the 'decision_receive_behaviour' behaviour
2023-08-24 10:30:57	[2023-08-24 07:30:54,958] [INFO] [agent] Filtering the mech's events from block 29603038 for a response to our request with id 95742878796854394748598648414290800360463793057586612482979887355606567890053.
2023-08-24 10:30:57	[2023-08-24 07:30:55,345] [INFO] [agent] Retrieved the mech's response: {'requestId': 95742878796854394748598648414290800360463793057586612482979887355606567890053, 'result': 'invalid request'}.
2023-08-24 10:30:57	[2023-08-24 07:30:55,345] [INFO] [agent] Decision has been received:
2023-08-24 10:30:57	MechInteractionResponse(requestId=0, result=None, error="The response's format was unexpected: {'requestId': 95742878796854394748598648414290800360463793057586612482979887355606567890053, 'result': 'invalid request'}")
2023-08-24 10:30:57	[2023-08-24 07:30:55,345] [ERROR] [agent] There was an error on the mech's response: The response's format was unexpected: {'requestId': 95742878796854394748598648414290800360463793057586612482979887355606567890053, 'result': 'invalid request'}
2023-08-24 10:30:57	[2023-08-24 07:30:55,546] [INFO] [agent] 'decision_receive_round' round is done with event: Event.MECH_RESPONSE_ERROR
2023-08-24 10:30:57	[2023-08-24 07:30:55,546] [INFO] [agent] Entered in the 'decision_receive_round' round for period 8
.
.
.
```