### PR TITLE
Fix typo

### DIFF
--- a/packages/packages.json
+++ b/packages/packages.json
@@ -2,10 +2,10 @@
     "dev": {
         "skill/valory/market_manager_abci/0.1.0": "bafybeibwcm2wqoucpbep6pav4fb5mofhjahxiqszul4wcv4xr52dei6pe4",
         "skill/valory/decision_maker_abci/0.1.0": "bafybeicl4aoamtxmixvd6azigrq3hdqqkrdlr2fqajlfykxfgqc3c6faty",
-        "skill/valory/trader_abci/0.1.0": "bafybeicpvh7xwn4dex5drp2riacapylfd5wodvjicdi7ut35ni5e5r4mp4",
+        "skill/valory/trader_abci/0.1.0": "bafybeihe5mmaerpksv4zthkwi5zxaolz43r3ae4ww65xe5u4g6o3wmnm54",
         "contract/valory/market_maker/0.1.0": "bafybeiftimqgvrbval2lxp7au6y72amioo4gtcdth2dflrbwa47i6opyb4",
-        "agent/valory/trader/0.1.0": "bafybeig6bgb7hqpgatovjgecygelsdoqzry4rc267qg727krmk6vj5zpxq",
-        "service/valory/trader/0.1.0": "bafybeidnihr2k2ywxawioazyxbmiynhc43mtk2ga5l22hza3ff2nyvm65e",
+        "agent/valory/trader/0.1.0": "bafybeigfykczyaiyqqnm6qrepfvwdvhrmisul7caefiktbnxsd7uer34mm",
+        "service/valory/trader/0.1.0": "bafybeib6oxd3tg4yu34mpbojckewbnz7cwkejcbwqsg65sfx4eki5yzume",
         "contract/valory/erc20/0.1.0": "bafybeifjwr6rwklgg2uk2zkfysn55qqy7dfi4jx7sek6lzdup37fynhpxe",
         "skill/valory/tx_settlement_multiplexer_abci/0.1.0": "bafybeicwioojvq56vbhwwqewamf6wulxd52rnx2gpchocicmf5orl67lim",
         "contract/valory/mech/0.1.0": "bafybeie753wdqks6k4x5fqlpo7tgll2avutjcaodpwlptqvzefsi5xbvai",

--- a/packages/valory/agents/trader/aea-config.yaml
+++ b/packages/valory/agents/trader/aea-config.yaml
@@ -44,7 +44,7 @@ skills:
 - valory/tx_settlement_multiplexer_abci:0.1.0:bafybeicwioojvq56vbhwwqewamf6wulxd52rnx2gpchocicmf5orl67lim
 - valory/market_manager_abci:0.1.0:bafybeibwcm2wqoucpbep6pav4fb5mofhjahxiqszul4wcv4xr52dei6pe4
 - valory/decision_maker_abci:0.1.0:bafybeicl4aoamtxmixvd6azigrq3hdqqkrdlr2fqajlfykxfgqc3c6faty
-- valory/trader_abci:0.1.0:bafybeicpvh7xwn4dex5drp2riacapylfd5wodvjicdi7ut35ni5e5r4mp4
+- valory/trader_abci:0.1.0:bafybeihe5mmaerpksv4zthkwi5zxaolz43r3ae4ww65xe5u4g6o3wmnm54
 default_ledger: ethereum
 required_ledgers:
 - ethereum

--- a/packages/valory/services/trader/service.yaml
+++ b/packages/valory/services/trader/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeigtuothskwyvrhfosps2bu6suauycolj67dpuxqvnicdrdu7yhtvq
 fingerprint_ignore_patterns: []
-agent: valory/trader:0.1.0:bafybeig6bgb7hqpgatovjgecygelsdoqzry4rc267qg727krmk6vj5zpxq
+agent: valory/trader:0.1.0:bafybeigfykczyaiyqqnm6qrepfvwdvhrmisul7caefiktbnxsd7uer34mm
 number_of_agents: 4
 deployment: {}
 ---

--- a/packages/valory/skills/trader_abci/behaviours.py
+++ b/packages/valory/skills/trader_abci/behaviours.py
@@ -66,4 +66,4 @@ class TraderConsensusBehaviour(AbstractRoundBehaviour):
         *TransactionSettlementRoundBehaviour.behaviours,
         *PostTxSettlementFullBehaviour.behaviours,
     }
-    background_behaviour_cls = {BackgroundBehaviour}
+    background_behaviours_cls = {BackgroundBehaviour}  # type: ignore

--- a/packages/valory/skills/trader_abci/skill.yaml
+++ b/packages/valory/skills/trader_abci/skill.yaml
@@ -8,7 +8,7 @@ aea_version: '>=1.0.0, <2.0.0'
 fingerprint:
   README.md: bafybeiab4xgadptz4mhvno4p6xvkh7p4peg7iuhotabydriu74dmj6ljga
   __init__.py: bafybeido7wa33h4dtleap57vzgyb4fsofk4vindsqcekyfo5i56i2rll2a
-  behaviours.py: bafybeifhfrpbciajcxd5wwfo4shugug4hx6q2elbhrqrekrbtda66ptdpy
+  behaviours.py: bafybeigwadq27e4cnklboorhitwzzve4xkcgjdu2upplbbweuqyl52fj3q
   composition.py: bafybeie45dgneoggyavgdtswcygvz5o3klmtqf57zoxqnxrtneruutqevi
   dialogues.py: bafybeiebofyykseqp3fmif36cqmmyf3k7d2zbocpl6t6wnlpv4szghrxbm
   fsm_specification.yaml: bafybeiasu522aq3xthvuyvajpvzxy33nu6l4esuyl2xmkslckldcomwfzu


### PR DESCRIPTION
The following error was being raised from the core:
```
_check_matching_round_consistency
    round_to_behaviour[b.matching_round].append(b)

KeyError: <class 'packages.valory.skills.termination_abci.rounds.BackgroundRound'>
```

This indicates that the `BackgroundRound` did not have a matching behaviour specified. The reason was the typo on 1b1130ec9aaeb5a796c9fda7320cfc75a85f0515. As a result, the `background_behaviours_cls` attribute was never overridden to set the corresponding background behaviour.

:information_source: Opened https://github.com/valory-xyz/open-autonomy/issues/2042 to handle and show a more helpful error message on the core.