### PR TITLE
Fix contract error reporting

### DIFF
--- a/packages/packages.json
+++ b/packages/packages.json
@@ -1,13 +1,13 @@
 {
     "dev": {
         "skill/valory/market_manager_abci/0.1.0": "bafybeibwcm2wqoucpbep6pav4fb5mofhjahxiqszul4wcv4xr52dei6pe4",
-        "skill/valory/decision_maker_abci/0.1.0": "bafybeicl4aoamtxmixvd6azigrq3hdqqkrdlr2fqajlfykxfgqc3c6faty",
-        "skill/valory/trader_abci/0.1.0": "bafybeihe5mmaerpksv4zthkwi5zxaolz43r3ae4ww65xe5u4g6o3wmnm54",
+        "skill/valory/decision_maker_abci/0.1.0": "bafybeiejy2zxj5wzriay2vwecgvxxprwvs6rt32627jtjfn7gtsy46eimy",
+        "skill/valory/trader_abci/0.1.0": "bafybeiexo6pdhhdipnceixtls47jonhflcqsxnbv2c333zmgfxmoygfwgu",
         "contract/valory/market_maker/0.1.0": "bafybeiftimqgvrbval2lxp7au6y72amioo4gtcdth2dflrbwa47i6opyb4",
-        "agent/valory/trader/0.1.0": "bafybeigfykczyaiyqqnm6qrepfvwdvhrmisul7caefiktbnxsd7uer34mm",
-        "service/valory/trader/0.1.0": "bafybeib6oxd3tg4yu34mpbojckewbnz7cwkejcbwqsg65sfx4eki5yzume",
+        "agent/valory/trader/0.1.0": "bafybeidclpkg6uwii2d5gk74b4l6pv3vfgrg5tt3njumhk2ab3uidcogky",
+        "service/valory/trader/0.1.0": "bafybeidug5h7tac43yp5t6mfyl3qdmfwzh63otz63l547iiguosyyygmnq",
         "contract/valory/erc20/0.1.0": "bafybeifjwr6rwklgg2uk2zkfysn55qqy7dfi4jx7sek6lzdup37fynhpxe",
-        "skill/valory/tx_settlement_multiplexer_abci/0.1.0": "bafybeicwioojvq56vbhwwqewamf6wulxd52rnx2gpchocicmf5orl67lim",
+        "skill/valory/tx_settlement_multiplexer_abci/0.1.0": "bafybeiffvwkifzq4eiqr4syfbbsfjcrsea5wj55ttismoxozt6trithu7u",
         "contract/valory/mech/0.1.0": "bafybeie753wdqks6k4x5fqlpo7tgll2avutjcaodpwlptqvzefsi5xbvai",
         "contract/valory/realitio/0.1.0": "bafybeid5cdncqui3egi57eh6ptz2yqxsjpnmwzdc2siewuown3gktdwm6m",
         "contract/valory/realitio_proxy/0.1.0": "bafybeibvndq6756qck7forgeavhdbn6ykgqs2ufyg7n5g6qdfpveatxuwy",

--- a/packages/valory/agents/trader/aea-config.yaml
+++ b/packages/valory/agents/trader/aea-config.yaml
@@ -41,10 +41,10 @@ skills:
 - valory/reset_pause_abci:0.1.0:bafybeifoihgilpfr76hc5skzspm6qehkwivx7ld2cy3veipcsi4gr2c7na
 - valory/termination_abci:0.1.0:bafybeigcsls72uosoui2y5ppmnvsljjhnxakkeh3fdohklcg66aqq4g7xu
 - valory/transaction_settlement_abci:0.1.0:bafybeiglsnh2hvfau5gab7requh34k4sbqwbjvrhhqjpes4hakcwq46cpi
-- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeicwioojvq56vbhwwqewamf6wulxd52rnx2gpchocicmf5orl67lim
+- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeiffvwkifzq4eiqr4syfbbsfjcrsea5wj55ttismoxozt6trithu7u
 - valory/market_manager_abci:0.1.0:bafybeibwcm2wqoucpbep6pav4fb5mofhjahxiqszul4wcv4xr52dei6pe4
-- valory/decision_maker_abci:0.1.0:bafybeicl4aoamtxmixvd6azigrq3hdqqkrdlr2fqajlfykxfgqc3c6faty
-- valory/trader_abci:0.1.0:bafybeihe5mmaerpksv4zthkwi5zxaolz43r3ae4ww65xe5u4g6o3wmnm54
+- valory/decision_maker_abci:0.1.0:bafybeiejy2zxj5wzriay2vwecgvxxprwvs6rt32627jtjfn7gtsy46eimy
+- valory/trader_abci:0.1.0:bafybeiexo6pdhhdipnceixtls47jonhflcqsxnbv2c333zmgfxmoygfwgu
 default_ledger: ethereum
 required_ledgers:
 - ethereum

--- a/packages/valory/services/trader/service.yaml
+++ b/packages/valory/services/trader/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeigtuothskwyvrhfosps2bu6suauycolj67dpuxqvnicdrdu7yhtvq
 fingerprint_ignore_patterns: []
-agent: valory/trader:0.1.0:bafybeigfykczyaiyqqnm6qrepfvwdvhrmisul7caefiktbnxsd7uer34mm
+agent: valory/trader:0.1.0:bafybeidclpkg6uwii2d5gk74b4l6pv3vfgrg5tt3njumhk2ab3uidcogky
 number_of_agents: 4
 deployment: {}
 ---

--- a/packages/valory/skills/decision_maker_abci/behaviours/base.py
+++ b/packages/valory/skills/decision_maker_abci/behaviours/base.py
@@ -126,6 +126,15 @@ class DecisionMakerBaseBehaviour(BaseBehaviour, ABC):
         """Convert WEI to native token."""
         return wei / 10**18
 
+    def default_error(
+        self, contract_id: str, contract_callable: str, response_msg: ContractApiMessage
+    ) -> None:
+        """Return a default contract interaction error message."""
+        self.context.logger.error(
+            f"Could not successfully interact with the {contract_id} contract "
+            f"using {contract_callable!r}: {response_msg}"
+        )
+
     def contract_interaction_error(
         self, contract_id: str, contract_callable: str, response_msg: ContractApiMessage
     ) -> None:
@@ -138,11 +147,7 @@ class DecisionMakerBaseBehaviour(BaseBehaviour, ABC):
                 logger(msg)
                 return
 
-            if level == "error":
-                logger(
-                    f"Could not successfully interact with the {contract_id} contract "
-                    f"using {contract_callable!r}: {response_msg}"
-                )
+        self.default_error(contract_id, contract_callable, response_msg)
 
     def contract_interact(
         self,
@@ -164,9 +169,7 @@ class DecisionMakerBaseBehaviour(BaseBehaviour, ABC):
             **kwargs,
         )
         if response_msg.performative != ContractApiMessage.Performative.RAW_TRANSACTION:
-            self.contract_interaction_error(
-                contract_id, contract_callable, response_msg
-            )
+            self.default_error(contract_id, contract_callable, response_msg)
             return False
 
         data = response_msg.raw_transaction.body.get(data_key, None)

--- a/packages/valory/skills/decision_maker_abci/skill.yaml
+++ b/packages/valory/skills/decision_maker_abci/skill.yaml
@@ -12,7 +12,7 @@ fingerprint:
   README.md: bafybeia367zzdwndvlhw27rvnwodytjo3ms7gbc3q7mhrrjqjgfasnk47i
   __init__.py: bafybeih563ujnigeci2ldzh7hakbau6a222vsed7leg3b7lq32vcn3nm4a
   behaviours/__init__.py: bafybeih6ddz2ocvm6x6ytvlbcz6oi4snb5ee5xh5h65nq4w2qf7fd7zfky
-  behaviours/base.py: bafybeiam2idnum2kzvnvndrgzx4mz2pom4zawi44yzw3aoyhrgraqyoube
+  behaviours/base.py: bafybeibrqxw7jdslsew226tss3p3s7fhj6rkwz6fig46zgnp54ijyspgly
   behaviours/bet_placement.py: bafybeicdmayxmxvydechibri7z45wrx7n354eny4s5aval5mk2pqdszh64
   behaviours/blacklisting.py: bafybeicvespraci44y2dtddy4wi7cdhjuyk6crjs7ztnssm2rcrovha3hm
   behaviours/decision_receive.py: bafybeigjct7st66x7n3go5vdp62wtdxgmgw233hyyvd3a63ly4x3ptdqbq

--- a/packages/valory/skills/trader_abci/skill.yaml
+++ b/packages/valory/skills/trader_abci/skill.yaml
@@ -25,8 +25,8 @@ skills:
 - valory/transaction_settlement_abci:0.1.0:bafybeiglsnh2hvfau5gab7requh34k4sbqwbjvrhhqjpes4hakcwq46cpi
 - valory/termination_abci:0.1.0:bafybeigcsls72uosoui2y5ppmnvsljjhnxakkeh3fdohklcg66aqq4g7xu
 - valory/market_manager_abci:0.1.0:bafybeibwcm2wqoucpbep6pav4fb5mofhjahxiqszul4wcv4xr52dei6pe4
-- valory/decision_maker_abci:0.1.0:bafybeicl4aoamtxmixvd6azigrq3hdqqkrdlr2fqajlfykxfgqc3c6faty
-- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeicwioojvq56vbhwwqewamf6wulxd52rnx2gpchocicmf5orl67lim
+- valory/decision_maker_abci:0.1.0:bafybeiejy2zxj5wzriay2vwecgvxxprwvs6rt32627jtjfn7gtsy46eimy
+- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeiffvwkifzq4eiqr4syfbbsfjcrsea5wj55ttismoxozt6trithu7u
 behaviours:
   main:
     args: {}

--- a/packages/valory/skills/tx_settlement_multiplexer_abci/skill.yaml
+++ b/packages/valory/skills/tx_settlement_multiplexer_abci/skill.yaml
@@ -20,7 +20,7 @@ contracts: []
 protocols: []
 skills:
 - valory/abstract_round_abci:0.1.0:bafybeif3cqkks5qx3lqi6nwwhebcirhazt2vidw3sueeqsyxvjeszjt3om
-- valory/decision_maker_abci:0.1.0:bafybeicl4aoamtxmixvd6azigrq3hdqqkrdlr2fqajlfykxfgqc3c6faty
+- valory/decision_maker_abci:0.1.0:bafybeiejy2zxj5wzriay2vwecgvxxprwvs6rt32627jtjfn7gtsy46eimy
 behaviours:
   main:
     args: {}


### PR DESCRIPTION
The error handling was utilizing the `raw_transaction` attribute. However, this wouldn't be set if the performative was not the expected one (e.g., `ERROR`), and as a result, an exception would be raised.