### PR TITLE
Fix RPC timeouts

### DIFF
--- a/packages/packages.json
+++ b/packages/packages.json
@@ -1,17 +1,17 @@
 {
     "dev": {
-        "skill/valory/market_manager_abci/0.1.0": "bafybeih6tmi4blhdqkjgtvqkwbtbky5kzhl57h6ze4rtr3r2rh43pkhvyi",
-        "skill/valory/decision_maker_abci/0.1.0": "bafybeibadjiuw4icm64rm5mrooht6he2xw6ery6yxu5qnwhqkpwlfhen2m",
-        "skill/valory/trader_abci/0.1.0": "bafybeif7zbal6iqiui3dwqfswnev6tcjsszixhrpv3m6kufgxfvh7veadi",
+        "skill/valory/market_manager_abci/0.1.0": "bafybeia3d2eri2fll6cu2ksg5riyhgn2i3ofn767sdj5xhwnfyidnaolpu",
+        "skill/valory/decision_maker_abci/0.1.0": "bafybeihyuoyu4dowmwf3ajkxgll5ysjvzfr6p27cxqqfdq7fvp2kwsq56y",
+        "skill/valory/trader_abci/0.1.0": "bafybeiaumqislfwbsswcpoid2pdq6psq5e77aihjhnmrn6ygx2k6dk2ehq",
         "contract/valory/market_maker/0.1.0": "bafybeiftimqgvrbval2lxp7au6y72amioo4gtcdth2dflrbwa47i6opyb4",
-        "agent/valory/trader/0.1.0": "bafybeietnokftb3klhladvtrrrwhizq7nj64s4tqxbw3xwylxpgulr4g5u",
-        "service/valory/trader/0.1.0": "bafybeiczvwvd7s2q7yc5lh4qxzolpga4f2xstme4rzq6sot7oefnz7dqim",
+        "agent/valory/trader/0.1.0": "bafybeiefd67r3etu5xhgwxwjxsu2g6nfophralgvqldjbstlcwboy32gdi",
+        "service/valory/trader/0.1.0": "bafybeia66mugb3foqfh5gjrgjovgnyc4uvjiowkqrbikdekhs2veiszidi",
         "contract/valory/erc20/0.1.0": "bafybeifjwr6rwklgg2uk2zkfysn55qqy7dfi4jx7sek6lzdup37fynhpxe",
-        "skill/valory/tx_settlement_multiplexer_abci/0.1.0": "bafybeiez2gopga42empgxlgprmw34joobw3rx2h5ybnk2u35vdmpkjtjfq",
+        "skill/valory/tx_settlement_multiplexer_abci/0.1.0": "bafybeicd7gho5rxde57tsjsu7puooxcogomrfd4fgfuoveos2l5lqtnnuu",
         "contract/valory/mech/0.1.0": "bafybeie753wdqks6k4x5fqlpo7tgll2avutjcaodpwlptqvzefsi5xbvai",
         "contract/valory/realitio/0.1.0": "bafybeigb722aznqhc5lsbt3dn4bpyaqe5hnl5onmnestqmzliwtvl3eaom",
         "contract/valory/realitio_proxy/0.1.0": "bafybeibvndq6756qck7forgeavhdbn6ykgqs2ufyg7n5g6qdfpveatxuwy",
-        "contract/valory/conditional_tokens/0.1.0": "bafybeiaqcyzbuhv4ey2h7hn2dq5zibf3pmkotx2t7fihdawf5h4u4uu65e"
+        "contract/valory/conditional_tokens/0.1.0": "bafybeicxwjdbmjajgr5rsmadtkxxwmcm42r2htef3tvng73uzib4hmb6qa"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifuxs7gdg2okbn7uofymenjlmnih2wxwkym44lsgwmklgwuckxm2m",

--- a/packages/valory/agents/trader/aea-config.yaml
+++ b/packages/valory/agents/trader/aea-config.yaml
@@ -22,7 +22,7 @@ contracts:
 - valory/erc20:0.1.0:bafybeifjwr6rwklgg2uk2zkfysn55qqy7dfi4jx7sek6lzdup37fynhpxe
 - valory/multisend:0.1.0:bafybeie7m7pjbnw7cccpbvmbgkut24dtlt4cgvug3tbac7gej37xvwbv3a
 - valory/mech:0.1.0:bafybeie753wdqks6k4x5fqlpo7tgll2avutjcaodpwlptqvzefsi5xbvai
-- valory/conditional_tokens:0.1.0:bafybeiaqcyzbuhv4ey2h7hn2dq5zibf3pmkotx2t7fihdawf5h4u4uu65e
+- valory/conditional_tokens:0.1.0:bafybeicxwjdbmjajgr5rsmadtkxxwmcm42r2htef3tvng73uzib4hmb6qa
 - valory/realitio:0.1.0:bafybeigb722aznqhc5lsbt3dn4bpyaqe5hnl5onmnestqmzliwtvl3eaom
 - valory/realitio_proxy:0.1.0:bafybeibvndq6756qck7forgeavhdbn6ykgqs2ufyg7n5g6qdfpveatxuwy
 protocols:
@@ -41,10 +41,10 @@ skills:
 - valory/reset_pause_abci:0.1.0:bafybeifoihgilpfr76hc5skzspm6qehkwivx7ld2cy3veipcsi4gr2c7na
 - valory/termination_abci:0.1.0:bafybeigcsls72uosoui2y5ppmnvsljjhnxakkeh3fdohklcg66aqq4g7xu
 - valory/transaction_settlement_abci:0.1.0:bafybeiglsnh2hvfau5gab7requh34k4sbqwbjvrhhqjpes4hakcwq46cpi
-- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeiez2gopga42empgxlgprmw34joobw3rx2h5ybnk2u35vdmpkjtjfq
-- valory/market_manager_abci:0.1.0:bafybeih6tmi4blhdqkjgtvqkwbtbky5kzhl57h6ze4rtr3r2rh43pkhvyi
-- valory/decision_maker_abci:0.1.0:bafybeibadjiuw4icm64rm5mrooht6he2xw6ery6yxu5qnwhqkpwlfhen2m
-- valory/trader_abci:0.1.0:bafybeif7zbal6iqiui3dwqfswnev6tcjsszixhrpv3m6kufgxfvh7veadi
+- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeicd7gho5rxde57tsjsu7puooxcogomrfd4fgfuoveos2l5lqtnnuu
+- valory/market_manager_abci:0.1.0:bafybeia3d2eri2fll6cu2ksg5riyhgn2i3ofn767sdj5xhwnfyidnaolpu
+- valory/decision_maker_abci:0.1.0:bafybeihyuoyu4dowmwf3ajkxgll5ysjvzfr6p27cxqqfdq7fvp2kwsq56y
+- valory/trader_abci:0.1.0:bafybeiaumqislfwbsswcpoid2pdq6psq5e77aihjhnmrn6ygx2k6dk2ehq
 default_ledger: ethereum
 required_ledgers:
 - ethereum

--- a/packages/valory/agents/trader/aea-config.yaml
+++ b/packages/valory/agents/trader/aea-config.yaml
@@ -186,6 +186,7 @@ models:
       realitio_address: ${str:0x79e32aE03fb27B07C89c0c568F80287C01ca2E57}
       redeeming_batch_size: ${int:5}
       slippage: ${float:0.01}
+      redeem_margin_days: ${int:15}
 ---
 public_id: valory/p2p_libp2p_client:0.1.0
 type: connection

--- a/packages/valory/contracts/conditional_tokens/contract.py
+++ b/packages/valory/contracts/conditional_tokens/contract.py
@@ -91,6 +91,8 @@ class ConditionalTokensContract(Contract):
                 f"Did the creation happen too long in the past?\n"
                 f"The market with condition id {earliest_condition_id!r} "
                 f"is the oldest one and the block filtering was set based on it."
+                "If the issue persists, try to decrease the value of `redeem_margin_days` "
+                f"in the agent's configuration, based on the date corresponding to the block number {earliest_block}."
             )
             return dict(error=msg)
 

--- a/packages/valory/contracts/conditional_tokens/contract.yaml
+++ b/packages/valory/contracts/conditional_tokens/contract.yaml
@@ -8,7 +8,7 @@ aea_version: '>=1.0.0, <2.0.0'
 fingerprint:
   __init__.py: bafybeidhdxio3oq5gqdnxmngumvt3fcd6zyiyrpk5f2k4dwhflbg4e5iky
   build/ConditionalTokens.json: bafybeia2ahis7zx2yhhf23kpkcxu56hto6fwg6ptjg5ld46lp4dgz7cz3e
-  contract.py: bafybeiamr2y22rcwlf2h75uryweqx4qjztjrmhzb2flivkcfqvifedvdpi
+  contract.py: bafybeigzs6lox5rebabne5knyxxpz4erdlgveogcebsqa4lxasyis3ichu
 fingerprint_ignore_patterns: []
 class_name: ConditionalTokensContract
 contract_interface_paths:

--- a/packages/valory/services/trader/service.yaml
+++ b/packages/valory/services/trader/service.yaml
@@ -103,6 +103,7 @@ type: skill
         realitio_address: ${REALITIO_ADDRESS:str:0x79e32aE03fb27B07C89c0c568F80287C01ca2E57}
         redeeming_batch_size: ${REDEEMING_BATCH_SIZE:int:5}
         slippage: ${SLIPPAGE:float:0.01}
+        redeem_margin_days: ${REDEEM_MARGIN_DAYS:int:15}
     benchmark_tool: &id005
       args:
         log_dir: ${LOG_DIR:str:/benchmarks}
@@ -166,6 +167,7 @@ type: skill
         realitio_address: ${REALITIO_ADDRESS:str:0x79e32aE03fb27B07C89c0c568F80287C01ca2E57}
         redeeming_batch_size: ${REDEEMING_BATCH_SIZE:int:5}
         slippage: ${SLIPPAGE:float:0.01}
+        redeem_margin_days: ${REDEEM_MARGIN_DAYS:int:15}
     benchmark_tool: *id005
 2:
   models:
@@ -227,6 +229,7 @@ type: skill
         realitio_address: ${REALITIO_ADDRESS:str:0x79e32aE03fb27B07C89c0c568F80287C01ca2E57}
         redeeming_batch_size: ${REDEEMING_BATCH_SIZE:int:5}
         slippage: ${SLIPPAGE:float:0.01}
+        redeem_margin_days: ${REDEEM_MARGIN_DAYS:int:15}
     benchmark_tool: *id005
 3:
   models:
@@ -288,6 +291,7 @@ type: skill
         realitio_address: ${REALITIO_ADDRESS:str:0x79e32aE03fb27B07C89c0c568F80287C01ca2E57}
         redeeming_batch_size: ${REDEEMING_BATCH_SIZE:int:5}
         slippage: ${SLIPPAGE:float:0.01}
+        redeem_margin_days: ${REDEEM_MARGIN_DAYS:int:15}
     benchmark_tool: *id005
 ---
 public_id: valory/ledger:0.19.0

--- a/packages/valory/services/trader/service.yaml
+++ b/packages/valory/services/trader/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeigtuothskwyvrhfosps2bu6suauycolj67dpuxqvnicdrdu7yhtvq
 fingerprint_ignore_patterns: []
-agent: valory/trader:0.1.0:bafybeietnokftb3klhladvtrrrwhizq7nj64s4tqxbw3xwylxpgulr4g5u
+agent: valory/trader:0.1.0:bafybeiefd67r3etu5xhgwxwjxsu2g6nfophralgvqldjbstlcwboy32gdi
 number_of_agents: 4
 deployment: {}
 ---

--- a/packages/valory/skills/decision_maker_abci/skill.yaml
+++ b/packages/valory/skills/decision_maker_abci/skill.yaml
@@ -46,14 +46,14 @@ contracts:
 - valory/erc20:0.1.0:bafybeifjwr6rwklgg2uk2zkfysn55qqy7dfi4jx7sek6lzdup37fynhpxe
 - valory/multisend:0.1.0:bafybeie7m7pjbnw7cccpbvmbgkut24dtlt4cgvug3tbac7gej37xvwbv3a
 - valory/mech:0.1.0:bafybeie753wdqks6k4x5fqlpo7tgll2avutjcaodpwlptqvzefsi5xbvai
-- valory/conditional_tokens:0.1.0:bafybeiaqcyzbuhv4ey2h7hn2dq5zibf3pmkotx2t7fihdawf5h4u4uu65e
+- valory/conditional_tokens:0.1.0:bafybeicxwjdbmjajgr5rsmadtkxxwmcm42r2htef3tvng73uzib4hmb6qa
 - valory/realitio:0.1.0:bafybeigb722aznqhc5lsbt3dn4bpyaqe5hnl5onmnestqmzliwtvl3eaom
 - valory/realitio_proxy:0.1.0:bafybeibvndq6756qck7forgeavhdbn6ykgqs2ufyg7n5g6qdfpveatxuwy
 protocols:
 - valory/contract_api:1.0.0:bafybeiasywsvax45qmugus5kxogejj66c5taen27h4voriodz7rgushtqa
 skills:
 - valory/abstract_round_abci:0.1.0:bafybeif3cqkks5qx3lqi6nwwhebcirhazt2vidw3sueeqsyxvjeszjt3om
-- valory/market_manager_abci:0.1.0:bafybeih6tmi4blhdqkjgtvqkwbtbky5kzhl57h6ze4rtr3r2rh43pkhvyi
+- valory/market_manager_abci:0.1.0:bafybeia3d2eri2fll6cu2ksg5riyhgn2i3ofn767sdj5xhwnfyidnaolpu
 - valory/transaction_settlement_abci:0.1.0:bafybeiglsnh2hvfau5gab7requh34k4sbqwbjvrhhqjpes4hakcwq46cpi
 behaviours:
   main:

--- a/packages/valory/skills/market_manager_abci/graph_tooling/queries/omen.py
+++ b/packages/valory/skills/market_manager_abci/graph_tooling/queries/omen.py
@@ -61,6 +61,7 @@ trades = Template(
           creator: "${creator}",
           fpmm_: {
             answerFinalizedTimestamp_not: null,
+            creationTimestamp_gt: "${from_timestamp}",
             isPendingArbitration: false
           }
         }

--- a/packages/valory/skills/market_manager_abci/graph_tooling/requests.py
+++ b/packages/valory/skills/market_manager_abci/graph_tooling/requests.py
@@ -41,6 +41,9 @@ from packages.valory.skills.market_manager_abci.models import (
 from packages.valory.skills.market_manager_abci.rounds import SynchronizedData
 
 
+DAY_UNIX = 24 * 60 * 60
+
+
 def to_content(query: str) -> bytes:
     """Convert the given query string to payload content, i.e., add it under a `queries` key and convert it to bytes."""
     finalized_query = {"query": query}
@@ -184,7 +187,9 @@ class QueryingBehaviour(BaseBehaviour, ABC):
         self._fetch_status = FetchStatus.IN_PROGRESS
 
         safe = self.synchronized_data.safe_contract_address
-        query = trades.substitute(creator=safe.lower())
+        redeem_margin = self.params.redeem_margin_days * DAY_UNIX
+        from_timestamp = self.synced_time - redeem_margin
+        query = trades.substitute(creator=safe.lower(), from_timestamp=from_timestamp)
 
         # workaround because we cannot have multiple response keys for a single `ApiSpec`
         res_key_backup = self.current_subgraph.response_info.response_key

--- a/packages/valory/skills/market_manager_abci/skill.yaml
+++ b/packages/valory/skills/market_manager_abci/skill.yaml
@@ -137,6 +137,7 @@ models:
       - en_US
       average_block_time: 5
       abt_error_mult: 5
+      redeem_margin_days: 15
     class_name: MarketManagerParams
   network_subgraph:
     args:

--- a/packages/valory/skills/market_manager_abci/skill.yaml
+++ b/packages/valory/skills/market_manager_abci/skill.yaml
@@ -15,10 +15,10 @@ fingerprint:
   graph_tooling/__init__.py: bafybeigzo7nhbzafyq3fuhrlewksjvmzttiuk4vonrggtjtph4rw4ncpk4
   graph_tooling/queries/__init__.py: bafybeihbybnl53i7k57ql5ujt5ru5n2eg324jfndh4lcnm4fk52mwbkjda
   graph_tooling/queries/network.py: bafybeigeq72ys2nrjqspj2uacaudrgljrne5a3o5jvzsktldxdq6m2xmeu
-  graph_tooling/queries/omen.py: bafybeie3g27ald6eb35uonu4itfxsj7gvkqdrhj3sn5mfrotodyq5m3nzu
-  graph_tooling/requests.py: bafybeiee27knuanzuvk4boop6ycfn3vlpm22zgclwynkgeiauywjeo2r3e
+  graph_tooling/queries/omen.py: bafybeihfppuyr6pth3vpd7iuqzqt567j37fgyegubttp4v2wo6r2knwuwe
+  graph_tooling/requests.py: bafybeibaghhrjesca7dbjxyjct6jaak6ozpa4ltzd6c5sxbq5nlq22ulkq
   handlers.py: bafybeihot2i2yvfkz2gcowvt66wdu6tkjbmv7hsmc4jzt4reqeaiuphbtu
-  models.py: bafybeifmb4cojxesv2lcw6j3pm3yqjpsiuwyxpuexjbz656fpapdqcj2ba
+  models.py: bafybeiaplszooak63fo3i6agaoyol4tpof4q4tvoj4j6f2cr2corajnl3a
   payloads.py: bafybeiamavgddfbzofpsjthmw6j7g2dyxm7fb6hvdb47kweyrx4w2ihcfi
   rounds.py: bafybeib2jkzzpnmx6eebw3cw6t2hlzxktumbzrerjlowlpv532eink6g7e
 fingerprint_ignore_patterns: []

--- a/packages/valory/skills/trader_abci/skill.yaml
+++ b/packages/valory/skills/trader_abci/skill.yaml
@@ -168,6 +168,7 @@ models:
       realitio_address: '0x79e32aE03fb27B07C89c0c568F80287C01ca2E57'
       redeeming_batch_size: 5
       slippage: 0.01
+      redeem_margin_days: 15
     class_name: TraderParams
   network_subgraph:
     args:

--- a/packages/valory/skills/trader_abci/skill.yaml
+++ b/packages/valory/skills/trader_abci/skill.yaml
@@ -24,9 +24,9 @@ skills:
 - valory/reset_pause_abci:0.1.0:bafybeifoihgilpfr76hc5skzspm6qehkwivx7ld2cy3veipcsi4gr2c7na
 - valory/transaction_settlement_abci:0.1.0:bafybeiglsnh2hvfau5gab7requh34k4sbqwbjvrhhqjpes4hakcwq46cpi
 - valory/termination_abci:0.1.0:bafybeigcsls72uosoui2y5ppmnvsljjhnxakkeh3fdohklcg66aqq4g7xu
-- valory/market_manager_abci:0.1.0:bafybeih6tmi4blhdqkjgtvqkwbtbky5kzhl57h6ze4rtr3r2rh43pkhvyi
-- valory/decision_maker_abci:0.1.0:bafybeibadjiuw4icm64rm5mrooht6he2xw6ery6yxu5qnwhqkpwlfhen2m
-- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeiez2gopga42empgxlgprmw34joobw3rx2h5ybnk2u35vdmpkjtjfq
+- valory/market_manager_abci:0.1.0:bafybeia3d2eri2fll6cu2ksg5riyhgn2i3ofn767sdj5xhwnfyidnaolpu
+- valory/decision_maker_abci:0.1.0:bafybeihyuoyu4dowmwf3ajkxgll5ysjvzfr6p27cxqqfdq7fvp2kwsq56y
+- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeicd7gho5rxde57tsjsu7puooxcogomrfd4fgfuoveos2l5lqtnnuu
 behaviours:
   main:
     args: {}

--- a/packages/valory/skills/tx_settlement_multiplexer_abci/skill.yaml
+++ b/packages/valory/skills/tx_settlement_multiplexer_abci/skill.yaml
@@ -20,7 +20,7 @@ contracts: []
 protocols: []
 skills:
 - valory/abstract_round_abci:0.1.0:bafybeif3cqkks5qx3lqi6nwwhebcirhazt2vidw3sueeqsyxvjeszjt3om
-- valory/decision_maker_abci:0.1.0:bafybeibadjiuw4icm64rm5mrooht6he2xw6ery6yxu5qnwhqkpwlfhen2m
+- valory/decision_maker_abci:0.1.0:bafybeihyuoyu4dowmwf3ajkxgll5ysjvzfr6p27cxqqfdq7fvp2kwsq56y
 behaviours:
   main:
     args: {}


### PR DESCRIPTION
Addresses a known timeout limitation of getblock's Gnosis RPCs.
The service now only searches up to a specific number of days in the past (`redeem_margin_days`) for redeeming positions. Positions for older markets will have to be manually redeemed.