### PR TITLE
chore: break up the `check_redeemed` into chunks

### DIFF
--- a/packages/packages.json
+++ b/packages/packages.json
@@ -1,17 +1,17 @@
 {
     "dev": {
         "skill/valory/market_manager_abci/0.1.0": "bafybeidnqerwkljbjgog73qaa5duu5ymsfjs6jsszeupseshx7go3n6afq",
-        "skill/valory/decision_maker_abci/0.1.0": "bafybeihu4vrh2qyujh3rfguwrvekc76en4lo4rn3u6jsgnmxjbmxngzy2y",
-        "skill/valory/trader_abci/0.1.0": "bafybeiglomtffddoqdwerxdlujeakrdpcaawqt7v26kl4vpb5on7uskl7u",
+        "skill/valory/decision_maker_abci/0.1.0": "bafybeig4cuozgv2mimaaxi3nnwz5xkcmgqjcdx4h5zonte6ekgwwmrdbci",
+        "skill/valory/trader_abci/0.1.0": "bafybeidy6veal2qwolydhvu7hbcpv5j7znetssfyzbjuzivznqn2srvfhe",
         "contract/valory/market_maker/0.1.0": "bafybeidaz4dol7qsrwitw5jwasjtvd2vtlxhxizwkzen5kurblwacz4biu",
-        "agent/valory/trader/0.1.0": "bafybeiczas2owldbgyavccypfdue725wthmejw3syofellnfiuf7i37oxq",
-        "service/valory/trader/0.1.0": "bafybeihuhbcocor32ssgne7qxe7zrstuho54oh6gv33mwypcer2q5uktgm",
+        "agent/valory/trader/0.1.0": "bafybeicfbza7idwflcv4tzwdvj5fmojbr65xzmok4q6lepqmz5vm2c3d4u",
+        "service/valory/trader/0.1.0": "bafybeie56ret3dtsnra4466pqf7mq5jd4bj7d6etqbzgjtvftgnypwkgpa",
         "contract/valory/erc20/0.1.0": "bafybeid6p64a6tnovatbwybc6ocdd4u7bqkxsb4ks52rvf7ozcxxl6iaf4",
-        "skill/valory/tx_settlement_multiplexer_abci/0.1.0": "bafybeigqaswq3uvitzthww3zdulwbaefaxrn5vrmxwutxco7hq5fztk6ay",
+        "skill/valory/tx_settlement_multiplexer_abci/0.1.0": "bafybeifa6a2o26pt5h4vletqdzehkvme4jrjdca3sdsqrw3g5v47tr6jd4",
         "contract/valory/mech/0.1.0": "bafybeiddc6pgurpyja2k64wzsb3jgcvl254s7rplgt5iooftsyfalqlbfq",
         "contract/valory/realitio/0.1.0": "bafybeicdgm2a7evjw6szcpo3uaam5mzd6axtevtzwvejr6uaeymbg437da",
         "contract/valory/realitio_proxy/0.1.0": "bafybeibvndq6756qck7forgeavhdbn6ykgqs2ufyg7n5g6qdfpveatxuwy",
-        "contract/valory/conditional_tokens/0.1.0": "bafybeifb5qvzhzuiqmfb7vowynxyia4jyuov7gjyqgdhyw7yvebu6utsvy",
+        "contract/valory/conditional_tokens/0.1.0": "bafybeig26ktayat3m32to3riescg7plsahdylmpf3ubsguiosqixdwjm6m",
         "contract/valory/agent_registry/0.1.0": "bafybeigpd6wvnbb7fbf6yd77rugepv5hrbb6l3qfodstwgemagtcgne3bm"
     },
     "third_party": {

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -1,13 +1,13 @@
 {
     "dev": {
         "skill/valory/market_manager_abci/0.1.0": "bafybeidnqerwkljbjgog73qaa5duu5ymsfjs6jsszeupseshx7go3n6afq",
-        "skill/valory/decision_maker_abci/0.1.0": "bafybeig4cuozgv2mimaaxi3nnwz5xkcmgqjcdx4h5zonte6ekgwwmrdbci",
-        "skill/valory/trader_abci/0.1.0": "bafybeidy6veal2qwolydhvu7hbcpv5j7znetssfyzbjuzivznqn2srvfhe",
+        "skill/valory/decision_maker_abci/0.1.0": "bafybeiersmwlzih3yhv5nhy7ay6lqe377wn757pugsl457ypoik57aotom",
+        "skill/valory/trader_abci/0.1.0": "bafybeiajxg7a47vubwyhqj7brrqheoq3ohwqlq3t4uck75r5p45klt43be",
         "contract/valory/market_maker/0.1.0": "bafybeidaz4dol7qsrwitw5jwasjtvd2vtlxhxizwkzen5kurblwacz4biu",
-        "agent/valory/trader/0.1.0": "bafybeicfbza7idwflcv4tzwdvj5fmojbr65xzmok4q6lepqmz5vm2c3d4u",
-        "service/valory/trader/0.1.0": "bafybeie56ret3dtsnra4466pqf7mq5jd4bj7d6etqbzgjtvftgnypwkgpa",
+        "agent/valory/trader/0.1.0": "bafybeihyksse4ohe3x4tshyrlsral6dgptvb6uqvoteu7prlsdggqjk7tm",
+        "service/valory/trader/0.1.0": "bafybeiemvxyaai7lcfjx5zujfixxfew6vw2xfdpdqzwyyiwnsg6jxu55ny",
         "contract/valory/erc20/0.1.0": "bafybeid6p64a6tnovatbwybc6ocdd4u7bqkxsb4ks52rvf7ozcxxl6iaf4",
-        "skill/valory/tx_settlement_multiplexer_abci/0.1.0": "bafybeifa6a2o26pt5h4vletqdzehkvme4jrjdca3sdsqrw3g5v47tr6jd4",
+        "skill/valory/tx_settlement_multiplexer_abci/0.1.0": "bafybeicwz2jiwwkcufavqc3ttxkaowjcguq7cuaczzlsvonbv2fk373ezu",
         "contract/valory/mech/0.1.0": "bafybeiddc6pgurpyja2k64wzsb3jgcvl254s7rplgt5iooftsyfalqlbfq",
         "contract/valory/realitio/0.1.0": "bafybeicdgm2a7evjw6szcpo3uaam5mzd6axtevtzwvejr6uaeymbg437da",
         "contract/valory/realitio_proxy/0.1.0": "bafybeibvndq6756qck7forgeavhdbn6ykgqs2ufyg7n5g6qdfpveatxuwy",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -1,17 +1,17 @@
 {
     "dev": {
         "skill/valory/market_manager_abci/0.1.0": "bafybeidnqerwkljbjgog73qaa5duu5ymsfjs6jsszeupseshx7go3n6afq",
-        "skill/valory/decision_maker_abci/0.1.0": "bafybeieryuvqcg5ko3mnkpw3j34scedrqgomo2xm42bhweszwgwgtjhi6u",
-        "skill/valory/trader_abci/0.1.0": "bafybeihxfq6vtr7krfwbmkh4j2ozlzdccl4ladxwwhkqmkaa74koivanu4",
+        "skill/valory/decision_maker_abci/0.1.0": "bafybeihu4vrh2qyujh3rfguwrvekc76en4lo4rn3u6jsgnmxjbmxngzy2y",
+        "skill/valory/trader_abci/0.1.0": "bafybeiglomtffddoqdwerxdlujeakrdpcaawqt7v26kl4vpb5on7uskl7u",
         "contract/valory/market_maker/0.1.0": "bafybeidaz4dol7qsrwitw5jwasjtvd2vtlxhxizwkzen5kurblwacz4biu",
-        "agent/valory/trader/0.1.0": "bafybeiehv2cjbusia35yjxqim25jvq4d6tni5kcfckemgkvixzx327p7ui",
-        "service/valory/trader/0.1.0": "bafybeia5rzebe7z3nfgpfngp44rloro3do3y4wxxuroajftqbuiqojnjly",
+        "agent/valory/trader/0.1.0": "bafybeiczas2owldbgyavccypfdue725wthmejw3syofellnfiuf7i37oxq",
+        "service/valory/trader/0.1.0": "bafybeihuhbcocor32ssgne7qxe7zrstuho54oh6gv33mwypcer2q5uktgm",
         "contract/valory/erc20/0.1.0": "bafybeid6p64a6tnovatbwybc6ocdd4u7bqkxsb4ks52rvf7ozcxxl6iaf4",
-        "skill/valory/tx_settlement_multiplexer_abci/0.1.0": "bafybeibkj47cuymq57ccbje6hjtidvpycs6rg2cpshoehi7filrsgokdfi",
+        "skill/valory/tx_settlement_multiplexer_abci/0.1.0": "bafybeigqaswq3uvitzthww3zdulwbaefaxrn5vrmxwutxco7hq5fztk6ay",
         "contract/valory/mech/0.1.0": "bafybeiddc6pgurpyja2k64wzsb3jgcvl254s7rplgt5iooftsyfalqlbfq",
         "contract/valory/realitio/0.1.0": "bafybeicdgm2a7evjw6szcpo3uaam5mzd6axtevtzwvejr6uaeymbg437da",
         "contract/valory/realitio_proxy/0.1.0": "bafybeibvndq6756qck7forgeavhdbn6ykgqs2ufyg7n5g6qdfpveatxuwy",
-        "contract/valory/conditional_tokens/0.1.0": "bafybeicxwjdbmjajgr5rsmadtkxxwmcm42r2htef3tvng73uzib4hmb6qa",
+        "contract/valory/conditional_tokens/0.1.0": "bafybeifb5qvzhzuiqmfb7vowynxyia4jyuov7gjyqgdhyw7yvebu6utsvy",
         "contract/valory/agent_registry/0.1.0": "bafybeigpd6wvnbb7fbf6yd77rugepv5hrbb6l3qfodstwgemagtcgne3bm"
     },
     "third_party": {

--- a/packages/valory/agents/trader/aea-config.yaml
+++ b/packages/valory/agents/trader/aea-config.yaml
@@ -41,10 +41,10 @@ skills:
 - valory/reset_pause_abci:0.1.0:bafybeigeoc363gv3wp2rrmk6p2fdxney33nxd3owtpfugzapgruwe4klyu
 - valory/termination_abci:0.1.0:bafybeigqpij2sgrpnilqjljfciixop4fldq5qceixc7534q6af4potdmdm
 - valory/transaction_settlement_abci:0.1.0:bafybeia7rzsbea3ch4gcafyp3z6uvqh4npws2xpdwbkkdbrqqpjops7nui
-- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeifa6a2o26pt5h4vletqdzehkvme4jrjdca3sdsqrw3g5v47tr6jd4
+- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeicwz2jiwwkcufavqc3ttxkaowjcguq7cuaczzlsvonbv2fk373ezu
 - valory/market_manager_abci:0.1.0:bafybeidnqerwkljbjgog73qaa5duu5ymsfjs6jsszeupseshx7go3n6afq
-- valory/decision_maker_abci:0.1.0:bafybeig4cuozgv2mimaaxi3nnwz5xkcmgqjcdx4h5zonte6ekgwwmrdbci
-- valory/trader_abci:0.1.0:bafybeidy6veal2qwolydhvu7hbcpv5j7znetssfyzbjuzivznqn2srvfhe
+- valory/decision_maker_abci:0.1.0:bafybeiersmwlzih3yhv5nhy7ay6lqe377wn757pugsl457ypoik57aotom
+- valory/trader_abci:0.1.0:bafybeiajxg7a47vubwyhqj7brrqheoq3ohwqlq3t4uck75r5p45klt43be
 default_ledger: ethereum
 required_ledgers:
 - ethereum

--- a/packages/valory/agents/trader/aea-config.yaml
+++ b/packages/valory/agents/trader/aea-config.yaml
@@ -22,7 +22,7 @@ contracts:
 - valory/erc20:0.1.0:bafybeid6p64a6tnovatbwybc6ocdd4u7bqkxsb4ks52rvf7ozcxxl6iaf4
 - valory/multisend:0.1.0:bafybeieg4tywd5lww2vygvpkilg3hcepa4rmhehjuamyvdf6vazt554v6u
 - valory/mech:0.1.0:bafybeiddc6pgurpyja2k64wzsb3jgcvl254s7rplgt5iooftsyfalqlbfq
-- valory/conditional_tokens:0.1.0:bafybeifb5qvzhzuiqmfb7vowynxyia4jyuov7gjyqgdhyw7yvebu6utsvy
+- valory/conditional_tokens:0.1.0:bafybeig26ktayat3m32to3riescg7plsahdylmpf3ubsguiosqixdwjm6m
 - valory/realitio:0.1.0:bafybeicdgm2a7evjw6szcpo3uaam5mzd6axtevtzwvejr6uaeymbg437da
 - valory/realitio_proxy:0.1.0:bafybeibvndq6756qck7forgeavhdbn6ykgqs2ufyg7n5g6qdfpveatxuwy
 protocols:
@@ -41,10 +41,10 @@ skills:
 - valory/reset_pause_abci:0.1.0:bafybeigeoc363gv3wp2rrmk6p2fdxney33nxd3owtpfugzapgruwe4klyu
 - valory/termination_abci:0.1.0:bafybeigqpij2sgrpnilqjljfciixop4fldq5qceixc7534q6af4potdmdm
 - valory/transaction_settlement_abci:0.1.0:bafybeia7rzsbea3ch4gcafyp3z6uvqh4npws2xpdwbkkdbrqqpjops7nui
-- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeigqaswq3uvitzthww3zdulwbaefaxrn5vrmxwutxco7hq5fztk6ay
+- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeifa6a2o26pt5h4vletqdzehkvme4jrjdca3sdsqrw3g5v47tr6jd4
 - valory/market_manager_abci:0.1.0:bafybeidnqerwkljbjgog73qaa5duu5ymsfjs6jsszeupseshx7go3n6afq
-- valory/decision_maker_abci:0.1.0:bafybeihu4vrh2qyujh3rfguwrvekc76en4lo4rn3u6jsgnmxjbmxngzy2y
-- valory/trader_abci:0.1.0:bafybeiglomtffddoqdwerxdlujeakrdpcaawqt7v26kl4vpb5on7uskl7u
+- valory/decision_maker_abci:0.1.0:bafybeig4cuozgv2mimaaxi3nnwz5xkcmgqjcdx4h5zonte6ekgwwmrdbci
+- valory/trader_abci:0.1.0:bafybeidy6veal2qwolydhvu7hbcpv5j7znetssfyzbjuzivznqn2srvfhe
 default_ledger: ethereum
 required_ledgers:
 - ethereum

--- a/packages/valory/agents/trader/aea-config.yaml
+++ b/packages/valory/agents/trader/aea-config.yaml
@@ -22,7 +22,7 @@ contracts:
 - valory/erc20:0.1.0:bafybeid6p64a6tnovatbwybc6ocdd4u7bqkxsb4ks52rvf7ozcxxl6iaf4
 - valory/multisend:0.1.0:bafybeieg4tywd5lww2vygvpkilg3hcepa4rmhehjuamyvdf6vazt554v6u
 - valory/mech:0.1.0:bafybeiddc6pgurpyja2k64wzsb3jgcvl254s7rplgt5iooftsyfalqlbfq
-- valory/conditional_tokens:0.1.0:bafybeicxwjdbmjajgr5rsmadtkxxwmcm42r2htef3tvng73uzib4hmb6qa
+- valory/conditional_tokens:0.1.0:bafybeifb5qvzhzuiqmfb7vowynxyia4jyuov7gjyqgdhyw7yvebu6utsvy
 - valory/realitio:0.1.0:bafybeicdgm2a7evjw6szcpo3uaam5mzd6axtevtzwvejr6uaeymbg437da
 - valory/realitio_proxy:0.1.0:bafybeibvndq6756qck7forgeavhdbn6ykgqs2ufyg7n5g6qdfpveatxuwy
 protocols:
@@ -41,10 +41,10 @@ skills:
 - valory/reset_pause_abci:0.1.0:bafybeigeoc363gv3wp2rrmk6p2fdxney33nxd3owtpfugzapgruwe4klyu
 - valory/termination_abci:0.1.0:bafybeigqpij2sgrpnilqjljfciixop4fldq5qceixc7534q6af4potdmdm
 - valory/transaction_settlement_abci:0.1.0:bafybeia7rzsbea3ch4gcafyp3z6uvqh4npws2xpdwbkkdbrqqpjops7nui
-- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeibkj47cuymq57ccbje6hjtidvpycs6rg2cpshoehi7filrsgokdfi
+- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeigqaswq3uvitzthww3zdulwbaefaxrn5vrmxwutxco7hq5fztk6ay
 - valory/market_manager_abci:0.1.0:bafybeidnqerwkljbjgog73qaa5duu5ymsfjs6jsszeupseshx7go3n6afq
-- valory/decision_maker_abci:0.1.0:bafybeieryuvqcg5ko3mnkpw3j34scedrqgomo2xm42bhweszwgwgtjhi6u
-- valory/trader_abci:0.1.0:bafybeihxfq6vtr7krfwbmkh4j2ozlzdccl4ladxwwhkqmkaa74koivanu4
+- valory/decision_maker_abci:0.1.0:bafybeihu4vrh2qyujh3rfguwrvekc76en4lo4rn3u6jsgnmxjbmxngzy2y
+- valory/trader_abci:0.1.0:bafybeiglomtffddoqdwerxdlujeakrdpcaawqt7v26kl4vpb5on7uskl7u
 default_ledger: ethereum
 required_ledgers:
 - ethereum

--- a/packages/valory/contracts/conditional_tokens/contract.py
+++ b/packages/valory/contracts/conditional_tokens/contract.py
@@ -73,18 +73,16 @@ class ConditionalTokensContract(Contract):
             to_checksum(token) for token in collateral_tokens
         ]
         latest_block = ledger_api.api.eth.block_number
-
-        payout_filter = contract_instance.events.PayoutRedemption.build_filter()
-        payout_filter.args.redeemer.match_single(redeemer_checksummed)
-        payout_filter.args.collateralToken.match_any(*collateral_tokens_checksummed)
-        payout_filter.args.parentCollectionId.match_any(*parent_collection_ids)
-        payout_filter.args.conditionId.match_any(*condition_ids)
-        payout_filter.args.indexSets.match_any(*index_sets)
-
         try:
             redeemed = []
             for from_block in range(earliest_block, latest_block, chunk_size):
                 to_block = min(from_block + chunk_size, latest_block)
+                payout_filter = contract_instance.events.PayoutRedemption.build_filter()
+                payout_filter.args.redeemer.match_single(redeemer_checksummed)
+                payout_filter.args.collateralToken.match_any(*collateral_tokens_checksummed)
+                payout_filter.args.parentCollectionId.match_any(*parent_collection_ids)
+                payout_filter.args.conditionId.match_any(*condition_ids)
+                payout_filter.args.indexSets.match_any(*index_sets)
                 payout_filter.fromBlock = from_block
                 payout_filter.toBlock = to_block
                 redeemed_chunk = list(payout_filter.deploy(ledger_api.api).get_all_entries())

--- a/packages/valory/contracts/conditional_tokens/contract.py
+++ b/packages/valory/contracts/conditional_tokens/contract.py
@@ -51,6 +51,7 @@ class ConditionalTokensContract(Contract):
         condition_ids: List[HexBytes],
         index_sets: List[List[int]],
         from_block_numbers: Dict[HexBytes, BlockIdentifier],
+        chunk_size: int = 50_000,
     ) -> JSONLike:
         """Filter to find out whether a position has already been redeemed."""
         earliest_block = DEFAULT_FROM_BLOCK
@@ -71,10 +72,9 @@ class ConditionalTokensContract(Contract):
         collateral_tokens_checksummed = [
             to_checksum(token) for token in collateral_tokens
         ]
+        latest_block = ledger_api.api.eth.block_number
 
         payout_filter = contract_instance.events.PayoutRedemption.build_filter()
-        payout_filter.fromBlock = earliest_block
-        payout_filter.toBlock = DEFAULT_TO_BLOCK
         payout_filter.args.redeemer.match_single(redeemer_checksummed)
         payout_filter.args.collateralToken.match_any(*collateral_tokens_checksummed)
         payout_filter.args.parentCollectionId.match_any(*parent_collection_ids)
@@ -82,7 +82,13 @@ class ConditionalTokensContract(Contract):
         payout_filter.args.indexSets.match_any(*index_sets)
 
         try:
-            redeemed = list(payout_filter.deploy(ledger_api.api).get_all_entries())
+            redeemed = []
+            for from_block in range(earliest_block, latest_block, chunk_size):
+                to_block = min(from_block + chunk_size, latest_block)
+                payout_filter.fromBlock = from_block
+                payout_filter.toBlock = to_block
+                redeemed_chunk = list(payout_filter.deploy(ledger_api.api).get_all_entries())
+                redeemed.extend(redeemed_chunk)
         except (Urllib3ReadTimeoutError, RequestsReadTimeoutError):
             msg = (
                 "The RPC timed out! This usually happens if the filtering is too wide. "

--- a/packages/valory/contracts/conditional_tokens/contract.yaml
+++ b/packages/valory/contracts/conditional_tokens/contract.yaml
@@ -8,7 +8,7 @@ aea_version: '>=1.0.0, <2.0.0'
 fingerprint:
   __init__.py: bafybeidhdxio3oq5gqdnxmngumvt3fcd6zyiyrpk5f2k4dwhflbg4e5iky
   build/ConditionalTokens.json: bafybeia2ahis7zx2yhhf23kpkcxu56hto6fwg6ptjg5ld46lp4dgz7cz3e
-  contract.py: bafybeifgwflxpbnuwhkaez6mkbwvnryzjyxozaemuz4g4bstfrcfcwdqey
+  contract.py: bafybeibex3xrphf7ssmblx3bo6cy3qzv2wk3nxmnv3k6w56yr6cwnkejlq
 fingerprint_ignore_patterns: []
 class_name: ConditionalTokensContract
 contract_interface_paths:

--- a/packages/valory/contracts/conditional_tokens/contract.yaml
+++ b/packages/valory/contracts/conditional_tokens/contract.yaml
@@ -8,7 +8,7 @@ aea_version: '>=1.0.0, <2.0.0'
 fingerprint:
   __init__.py: bafybeidhdxio3oq5gqdnxmngumvt3fcd6zyiyrpk5f2k4dwhflbg4e5iky
   build/ConditionalTokens.json: bafybeia2ahis7zx2yhhf23kpkcxu56hto6fwg6ptjg5ld46lp4dgz7cz3e
-  contract.py: bafybeigzs6lox5rebabne5knyxxpz4erdlgveogcebsqa4lxasyis3ichu
+  contract.py: bafybeifgwflxpbnuwhkaez6mkbwvnryzjyxozaemuz4g4bstfrcfcwdqey
 fingerprint_ignore_patterns: []
 class_name: ConditionalTokensContract
 contract_interface_paths:

--- a/packages/valory/services/trader/service.yaml
+++ b/packages/valory/services/trader/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeigtuothskwyvrhfosps2bu6suauycolj67dpuxqvnicdrdu7yhtvq
 fingerprint_ignore_patterns: []
-agent: valory/trader:0.1.0:bafybeiehv2cjbusia35yjxqim25jvq4d6tni5kcfckemgkvixzx327p7ui
+agent: valory/trader:0.1.0:bafybeiczas2owldbgyavccypfdue725wthmejw3syofellnfiuf7i37oxq
 number_of_agents: 4
 deployment: {}
 ---

--- a/packages/valory/services/trader/service.yaml
+++ b/packages/valory/services/trader/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeigtuothskwyvrhfosps2bu6suauycolj67dpuxqvnicdrdu7yhtvq
 fingerprint_ignore_patterns: []
-agent: valory/trader:0.1.0:bafybeicfbza7idwflcv4tzwdvj5fmojbr65xzmok4q6lepqmz5vm2c3d4u
+agent: valory/trader:0.1.0:bafybeihyksse4ohe3x4tshyrlsral6dgptvb6uqvoteu7prlsdggqjk7tm
 number_of_agents: 4
 deployment: {}
 ---

--- a/packages/valory/services/trader/service.yaml
+++ b/packages/valory/services/trader/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeigtuothskwyvrhfosps2bu6suauycolj67dpuxqvnicdrdu7yhtvq
 fingerprint_ignore_patterns: []
-agent: valory/trader:0.1.0:bafybeiczas2owldbgyavccypfdue725wthmejw3syofellnfiuf7i37oxq
+agent: valory/trader:0.1.0:bafybeicfbza7idwflcv4tzwdvj5fmojbr65xzmok4q6lepqmz5vm2c3d4u
 number_of_agents: 4
 deployment: {}
 ---

--- a/packages/valory/skills/decision_maker_abci/behaviours/reedem.py
+++ b/packages/valory/skills/decision_maker_abci/behaviours/reedem.py
@@ -350,6 +350,9 @@ class RedeemBehaviour(RedeemInfoBehaviour):
         )
         return result
 
+    def _get_redeemed_positions(self) -> Generator:
+        """Get the redeemed positions."""
+
     def _clean_redeem_info(self) -> Generator:
         """Clean the redeeming information based on whether any positions have already been redeemed."""
         yield from self.wait_for_condition_with_sleep(self._check_already_redeemed)

--- a/packages/valory/skills/decision_maker_abci/behaviours/reedem.py
+++ b/packages/valory/skills/decision_maker_abci/behaviours/reedem.py
@@ -350,9 +350,6 @@ class RedeemBehaviour(RedeemInfoBehaviour):
         )
         return result
 
-    def _get_redeemed_positions(self) -> Generator:
-        """Get the redeemed positions."""
-
     def _clean_redeem_info(self) -> Generator:
         """Clean the redeeming information based on whether any positions have already been redeemed."""
         yield from self.wait_for_condition_with_sleep(self._check_already_redeemed)

--- a/packages/valory/skills/decision_maker_abci/skill.yaml
+++ b/packages/valory/skills/decision_maker_abci/skill.yaml
@@ -18,7 +18,7 @@ fingerprint:
   behaviours/decision_receive.py: bafybeid54jwjs4lulcl2n2w7taxne3wqgsey6ppaidwr2up6bztyf35ghm
   behaviours/decision_request.py: bafybeidlyl2ojmpfs2zkewoacraya2cbampo4ynqbqaocsoq7v2nif3ahi
   behaviours/handle_failed_tx.py: bafybeidxpc6u575ymct5tdwutvzov6zqfdoio5irgldn3fw7q3lg36mmxm
-  behaviours/reedem.py: bafybeifpqinwxep47tpdzlwyrdxknkuzlzahi7t6572ynlkhpf5tf77wku
+  behaviours/reedem.py: bafybeigzsx4wyov3ehfvdjmo2d7yimss4p7mbkopkqyr4gryxpa5rpv6ku
   behaviours/round_behaviour.py: bafybeig4tdktyu6hapoqymnxh2bgpds547st6a44heue657wkctwe4gjvm
   behaviours/sampling.py: bafybeiadikynvkaofbko72jc45xthhmmjfmlkpgramormhxwk5u47rnwdu
   behaviours/tool_selection.py: bafybeidd7jmauc6edgt7caxylanfdz3ucb2qzsndszlxv7an4lohe2waja

--- a/packages/valory/skills/decision_maker_abci/skill.yaml
+++ b/packages/valory/skills/decision_maker_abci/skill.yaml
@@ -18,7 +18,7 @@ fingerprint:
   behaviours/decision_receive.py: bafybeid54jwjs4lulcl2n2w7taxne3wqgsey6ppaidwr2up6bztyf35ghm
   behaviours/decision_request.py: bafybeidlyl2ojmpfs2zkewoacraya2cbampo4ynqbqaocsoq7v2nif3ahi
   behaviours/handle_failed_tx.py: bafybeidxpc6u575ymct5tdwutvzov6zqfdoio5irgldn3fw7q3lg36mmxm
-  behaviours/reedem.py: bafybeigzsx4wyov3ehfvdjmo2d7yimss4p7mbkopkqyr4gryxpa5rpv6ku
+  behaviours/reedem.py: bafybeifpqinwxep47tpdzlwyrdxknkuzlzahi7t6572ynlkhpf5tf77wku
   behaviours/round_behaviour.py: bafybeig4tdktyu6hapoqymnxh2bgpds547st6a44heue657wkctwe4gjvm
   behaviours/sampling.py: bafybeiadikynvkaofbko72jc45xthhmmjfmlkpgramormhxwk5u47rnwdu
   behaviours/tool_selection.py: bafybeidd7jmauc6edgt7caxylanfdz3ucb2qzsndszlxv7an4lohe2waja
@@ -49,7 +49,7 @@ contracts:
 - valory/erc20:0.1.0:bafybeid6p64a6tnovatbwybc6ocdd4u7bqkxsb4ks52rvf7ozcxxl6iaf4
 - valory/multisend:0.1.0:bafybeieg4tywd5lww2vygvpkilg3hcepa4rmhehjuamyvdf6vazt554v6u
 - valory/mech:0.1.0:bafybeiddc6pgurpyja2k64wzsb3jgcvl254s7rplgt5iooftsyfalqlbfq
-- valory/conditional_tokens:0.1.0:bafybeicxwjdbmjajgr5rsmadtkxxwmcm42r2htef3tvng73uzib4hmb6qa
+- valory/conditional_tokens:0.1.0:bafybeifb5qvzhzuiqmfb7vowynxyia4jyuov7gjyqgdhyw7yvebu6utsvy
 - valory/realitio:0.1.0:bafybeicdgm2a7evjw6szcpo3uaam5mzd6axtevtzwvejr6uaeymbg437da
 - valory/realitio_proxy:0.1.0:bafybeibvndq6756qck7forgeavhdbn6ykgqs2ufyg7n5g6qdfpveatxuwy
 - valory/agent_registry:0.1.0:bafybeigpd6wvnbb7fbf6yd77rugepv5hrbb6l3qfodstwgemagtcgne3bm

--- a/packages/valory/skills/decision_maker_abci/skill.yaml
+++ b/packages/valory/skills/decision_maker_abci/skill.yaml
@@ -49,7 +49,7 @@ contracts:
 - valory/erc20:0.1.0:bafybeid6p64a6tnovatbwybc6ocdd4u7bqkxsb4ks52rvf7ozcxxl6iaf4
 - valory/multisend:0.1.0:bafybeieg4tywd5lww2vygvpkilg3hcepa4rmhehjuamyvdf6vazt554v6u
 - valory/mech:0.1.0:bafybeiddc6pgurpyja2k64wzsb3jgcvl254s7rplgt5iooftsyfalqlbfq
-- valory/conditional_tokens:0.1.0:bafybeifb5qvzhzuiqmfb7vowynxyia4jyuov7gjyqgdhyw7yvebu6utsvy
+- valory/conditional_tokens:0.1.0:bafybeig26ktayat3m32to3riescg7plsahdylmpf3ubsguiosqixdwjm6m
 - valory/realitio:0.1.0:bafybeicdgm2a7evjw6szcpo3uaam5mzd6axtevtzwvejr6uaeymbg437da
 - valory/realitio_proxy:0.1.0:bafybeibvndq6756qck7forgeavhdbn6ykgqs2ufyg7n5g6qdfpveatxuwy
 - valory/agent_registry:0.1.0:bafybeigpd6wvnbb7fbf6yd77rugepv5hrbb6l3qfodstwgemagtcgne3bm

--- a/packages/valory/skills/trader_abci/skill.yaml
+++ b/packages/valory/skills/trader_abci/skill.yaml
@@ -25,8 +25,8 @@ skills:
 - valory/transaction_settlement_abci:0.1.0:bafybeia7rzsbea3ch4gcafyp3z6uvqh4npws2xpdwbkkdbrqqpjops7nui
 - valory/termination_abci:0.1.0:bafybeigqpij2sgrpnilqjljfciixop4fldq5qceixc7534q6af4potdmdm
 - valory/market_manager_abci:0.1.0:bafybeidnqerwkljbjgog73qaa5duu5ymsfjs6jsszeupseshx7go3n6afq
-- valory/decision_maker_abci:0.1.0:bafybeieryuvqcg5ko3mnkpw3j34scedrqgomo2xm42bhweszwgwgtjhi6u
-- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeibkj47cuymq57ccbje6hjtidvpycs6rg2cpshoehi7filrsgokdfi
+- valory/decision_maker_abci:0.1.0:bafybeihu4vrh2qyujh3rfguwrvekc76en4lo4rn3u6jsgnmxjbmxngzy2y
+- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeigqaswq3uvitzthww3zdulwbaefaxrn5vrmxwutxco7hq5fztk6ay
 behaviours:
   main:
     args: {}

--- a/packages/valory/skills/trader_abci/skill.yaml
+++ b/packages/valory/skills/trader_abci/skill.yaml
@@ -25,8 +25,8 @@ skills:
 - valory/transaction_settlement_abci:0.1.0:bafybeia7rzsbea3ch4gcafyp3z6uvqh4npws2xpdwbkkdbrqqpjops7nui
 - valory/termination_abci:0.1.0:bafybeigqpij2sgrpnilqjljfciixop4fldq5qceixc7534q6af4potdmdm
 - valory/market_manager_abci:0.1.0:bafybeidnqerwkljbjgog73qaa5duu5ymsfjs6jsszeupseshx7go3n6afq
-- valory/decision_maker_abci:0.1.0:bafybeihu4vrh2qyujh3rfguwrvekc76en4lo4rn3u6jsgnmxjbmxngzy2y
-- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeigqaswq3uvitzthww3zdulwbaefaxrn5vrmxwutxco7hq5fztk6ay
+- valory/decision_maker_abci:0.1.0:bafybeig4cuozgv2mimaaxi3nnwz5xkcmgqjcdx4h5zonte6ekgwwmrdbci
+- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeifa6a2o26pt5h4vletqdzehkvme4jrjdca3sdsqrw3g5v47tr6jd4
 behaviours:
   main:
     args: {}

--- a/packages/valory/skills/trader_abci/skill.yaml
+++ b/packages/valory/skills/trader_abci/skill.yaml
@@ -25,8 +25,8 @@ skills:
 - valory/transaction_settlement_abci:0.1.0:bafybeia7rzsbea3ch4gcafyp3z6uvqh4npws2xpdwbkkdbrqqpjops7nui
 - valory/termination_abci:0.1.0:bafybeigqpij2sgrpnilqjljfciixop4fldq5qceixc7534q6af4potdmdm
 - valory/market_manager_abci:0.1.0:bafybeidnqerwkljbjgog73qaa5duu5ymsfjs6jsszeupseshx7go3n6afq
-- valory/decision_maker_abci:0.1.0:bafybeig4cuozgv2mimaaxi3nnwz5xkcmgqjcdx4h5zonte6ekgwwmrdbci
-- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeifa6a2o26pt5h4vletqdzehkvme4jrjdca3sdsqrw3g5v47tr6jd4
+- valory/decision_maker_abci:0.1.0:bafybeiersmwlzih3yhv5nhy7ay6lqe377wn757pugsl457ypoik57aotom
+- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeicwz2jiwwkcufavqc3ttxkaowjcguq7cuaczzlsvonbv2fk373ezu
 behaviours:
   main:
     args: {}

--- a/packages/valory/skills/tx_settlement_multiplexer_abci/skill.yaml
+++ b/packages/valory/skills/tx_settlement_multiplexer_abci/skill.yaml
@@ -20,7 +20,7 @@ contracts: []
 protocols: []
 skills:
 - valory/abstract_round_abci:0.1.0:bafybeih2fyfb6kkf7r45pvdk7pyyebr5xloia4xiqxtb3qsrasnstqmepq
-- valory/decision_maker_abci:0.1.0:bafybeieryuvqcg5ko3mnkpw3j34scedrqgomo2xm42bhweszwgwgtjhi6u
+- valory/decision_maker_abci:0.1.0:bafybeihu4vrh2qyujh3rfguwrvekc76en4lo4rn3u6jsgnmxjbmxngzy2y
 behaviours:
   main:
     args: {}

--- a/packages/valory/skills/tx_settlement_multiplexer_abci/skill.yaml
+++ b/packages/valory/skills/tx_settlement_multiplexer_abci/skill.yaml
@@ -20,7 +20,7 @@ contracts: []
 protocols: []
 skills:
 - valory/abstract_round_abci:0.1.0:bafybeih2fyfb6kkf7r45pvdk7pyyebr5xloia4xiqxtb3qsrasnstqmepq
-- valory/decision_maker_abci:0.1.0:bafybeig4cuozgv2mimaaxi3nnwz5xkcmgqjcdx4h5zonte6ekgwwmrdbci
+- valory/decision_maker_abci:0.1.0:bafybeiersmwlzih3yhv5nhy7ay6lqe377wn757pugsl457ypoik57aotom
 behaviours:
   main:
     args: {}

--- a/packages/valory/skills/tx_settlement_multiplexer_abci/skill.yaml
+++ b/packages/valory/skills/tx_settlement_multiplexer_abci/skill.yaml
@@ -20,7 +20,7 @@ contracts: []
 protocols: []
 skills:
 - valory/abstract_round_abci:0.1.0:bafybeih2fyfb6kkf7r45pvdk7pyyebr5xloia4xiqxtb3qsrasnstqmepq
-- valory/decision_maker_abci:0.1.0:bafybeihu4vrh2qyujh3rfguwrvekc76en4lo4rn3u6jsgnmxjbmxngzy2y
+- valory/decision_maker_abci:0.1.0:bafybeig4cuozgv2mimaaxi3nnwz5xkcmgqjcdx4h5zonte6ekgwwmrdbci
 behaviours:
   main:
     args: {}


### PR DESCRIPTION
This PR adds support for breaking up the `check_redeemed` into chunks of 50K blocks.