### PR TITLE
Fix `NONE` events' emission in `SamplingRound`

### DIFF
--- a/packages/packages.json
+++ b/packages/packages.json
@@ -1,13 +1,13 @@
 {
     "dev": {
         "skill/valory/market_manager_abci/0.1.0": "bafybeifdf6uoscrgvlgqceqcph2pgoygobznw6hbodpav7lubbqsyh4kby",
-        "skill/valory/decision_maker_abci/0.1.0": "bafybeibqsaei2puprlwdwtvt3bf6golmvpdozblcw22qurx5bdymmvwvzy",
-        "skill/valory/trader_abci/0.1.0": "bafybeih4bqbsyup3cvlzzbykffg3nhkjhriyyyvwdldrinzuffppagdmam",
+        "skill/valory/decision_maker_abci/0.1.0": "bafybeiaan3hccyiocw6a2hecrcfx47sjxkuerbcoxjwjgr32zuqujs3qsu",
+        "skill/valory/trader_abci/0.1.0": "bafybeieb3pleydyefkxd7hcern2ghrlxcyasw2hq76l7lucogtgfjimchy",
         "contract/valory/market_maker/0.1.0": "bafybeiain372i5t6eteem36vzhwh6ppka6hc4oyrxjtyzuar6rd6bjocem",
-        "agent/valory/trader/0.1.0": "bafybeifew4rlur76tzunbsslp2u2idsugyiv4tqcdg5idg64mmjfyks7wa",
-        "service/valory/trader/0.1.0": "bafybeiaf4wppnrf6cddthat5xvle4267kfygttl75lofygtksvkmigau5a",
+        "agent/valory/trader/0.1.0": "bafybeieib2wgae3hgxshw2n6kmii5m76awafe6f46mrkif7wtc5mncvdlm",
+        "service/valory/trader/0.1.0": "bafybeicommzb25fe2df6w5x4w5jqxjybgth3nagssvdn4xf2vqq6gf5t2e",
         "contract/valory/erc20/0.1.0": "bafybeiad6qbyhr3sgvclqne7tvyvqt32pcj5aq47hhkd2vmawaflhy5vna",
-        "skill/valory/tx_settlement_multiplexer_abci/0.1.0": "bafybeifrh2pczxim4gvhookg7fvka266pqef3knifp35fvzvf6bljkhi74",
+        "skill/valory/tx_settlement_multiplexer_abci/0.1.0": "bafybeigvuuvfy7dcdp2kofaorjrqhfxiqdcjsojb4xlcim5x35dmmtzyae",
         "contract/valory/mech/0.1.0": "bafybeiauxqogu726oeethvzux6r77zgn7sw5j2l4uigqb47zlqawblkv6e",
         "contract/valory/realitio/0.1.0": "bafybeic5ie4oodetj4krdogydvbfxg4qggc3matpiflocah626tpevpreq",
         "contract/valory/realitio_proxy/0.1.0": "bafybeidx37xzjjmapwacedgzhum6grfzhp5vhouz4zu3pvpgdy5pgb2fr4",

--- a/packages/valory/agents/trader/aea-config.yaml
+++ b/packages/valory/agents/trader/aea-config.yaml
@@ -43,10 +43,10 @@ skills:
 - valory/reset_pause_abci:0.1.0:bafybeibnwjcjx4lluf4cwb6es5peelu3gm7vrzlieygrzpbjlubxpvbvzy
 - valory/termination_abci:0.1.0:bafybeifdtxgldw33kwvsavcituzewwbr6iqfcsgk5qouqfhpwdrivyyyom
 - valory/transaction_settlement_abci:0.1.0:bafybeifpnkwgwpzz6uwrvfgurm26allr6shjfbp7bfbrxwy64sw3nf3fsa
-- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeifrh2pczxim4gvhookg7fvka266pqef3knifp35fvzvf6bljkhi74
+- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeigvuuvfy7dcdp2kofaorjrqhfxiqdcjsojb4xlcim5x35dmmtzyae
 - valory/market_manager_abci:0.1.0:bafybeifdf6uoscrgvlgqceqcph2pgoygobznw6hbodpav7lubbqsyh4kby
-- valory/decision_maker_abci:0.1.0:bafybeibqsaei2puprlwdwtvt3bf6golmvpdozblcw22qurx5bdymmvwvzy
-- valory/trader_abci:0.1.0:bafybeih4bqbsyup3cvlzzbykffg3nhkjhriyyyvwdldrinzuffppagdmam
+- valory/decision_maker_abci:0.1.0:bafybeiaan3hccyiocw6a2hecrcfx47sjxkuerbcoxjwjgr32zuqujs3qsu
+- valory/trader_abci:0.1.0:bafybeieb3pleydyefkxd7hcern2ghrlxcyasw2hq76l7lucogtgfjimchy
 - valory/staking_abci:0.1.0:bafybeigwpp474gw7yb3w3xm4ejz4nxm7n2l4d27po6pj3yh7w3idctge5i
 default_ledger: ethereum
 required_ledgers:

--- a/packages/valory/services/trader/service.yaml
+++ b/packages/valory/services/trader/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeigtuothskwyvrhfosps2bu6suauycolj67dpuxqvnicdrdu7yhtvq
 fingerprint_ignore_patterns: []
-agent: valory/trader:0.1.0:bafybeifew4rlur76tzunbsslp2u2idsugyiv4tqcdg5idg64mmjfyks7wa
+agent: valory/trader:0.1.0:bafybeieib2wgae3hgxshw2n6kmii5m76awafe6f46mrkif7wtc5mncvdlm
 number_of_agents: 4
 deployment: {}
 ---

--- a/packages/valory/skills/decision_maker_abci/behaviours/sampling.py
+++ b/packages/valory/skills/decision_maker_abci/behaviours/sampling.py
@@ -96,7 +96,10 @@ class SamplingBehaviour(DecisionMakerBaseBehaviour):
             self.read_bets()
             idx = self._sample()
             self.store_bets()
-            bets_hash = self.hash_stored_bets()
+            if idx is None:
+                bets_hash = None
+            else:
+                bets_hash = self.hash_stored_bets()
             payload = SamplingPayload(self.context.agent_address, bets_hash, idx)
 
         yield from self.finish_behaviour(payload)

--- a/packages/valory/skills/decision_maker_abci/skill.yaml
+++ b/packages/valory/skills/decision_maker_abci/skill.yaml
@@ -21,7 +21,7 @@ fingerprint:
   behaviours/randomness.py: bafybeidmr33teizrs4uxlo5tdz766ds6os4pe5lttstm7jpmhgmjz5ti3q
   behaviours/reedem.py: bafybeibenzbek5qdtk3gobjxfmsm6tg6i3d4yltozymy23izpgbcpal5ye
   behaviours/round_behaviour.py: bafybeibymtirxbazjalmvfstnohaeqhmk4tggwwqhu62gm7mxdv6eabe3y
-  behaviours/sampling.py: bafybeibxcth4gsn7ov5liz5ma5tcflt7nvi64ku4gxlngno5vn3qr7km4u
+  behaviours/sampling.py: bafybeibtkli72qsvotkrsepkgpiumtr5sershtkpb427oygnszs3dpgxry
   behaviours/tool_selection.py: bafybeicxw4je76uc7znx4u2hq2b2aaxcf7blwfla7lhdhkqnf3kkupsczq
   dialogues.py: bafybeigpwuzku3we7axmxeamg7vn656maww6emuztau5pg3ebsoquyfdqm
   fsm_specification.yaml: bafybeigub5ekfxfj4xaitern7lbjtlpdgjqzgwmuijrea5b6dpu2npau7m

--- a/packages/valory/skills/trader_abci/skill.yaml
+++ b/packages/valory/skills/trader_abci/skill.yaml
@@ -25,8 +25,8 @@ skills:
 - valory/transaction_settlement_abci:0.1.0:bafybeifpnkwgwpzz6uwrvfgurm26allr6shjfbp7bfbrxwy64sw3nf3fsa
 - valory/termination_abci:0.1.0:bafybeifdtxgldw33kwvsavcituzewwbr6iqfcsgk5qouqfhpwdrivyyyom
 - valory/market_manager_abci:0.1.0:bafybeifdf6uoscrgvlgqceqcph2pgoygobznw6hbodpav7lubbqsyh4kby
-- valory/decision_maker_abci:0.1.0:bafybeibqsaei2puprlwdwtvt3bf6golmvpdozblcw22qurx5bdymmvwvzy
-- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeifrh2pczxim4gvhookg7fvka266pqef3knifp35fvzvf6bljkhi74
+- valory/decision_maker_abci:0.1.0:bafybeiaan3hccyiocw6a2hecrcfx47sjxkuerbcoxjwjgr32zuqujs3qsu
+- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeigvuuvfy7dcdp2kofaorjrqhfxiqdcjsojb4xlcim5x35dmmtzyae
 - valory/staking_abci:0.1.0:bafybeigwpp474gw7yb3w3xm4ejz4nxm7n2l4d27po6pj3yh7w3idctge5i
 behaviours:
   main:

--- a/packages/valory/skills/tx_settlement_multiplexer_abci/skill.yaml
+++ b/packages/valory/skills/tx_settlement_multiplexer_abci/skill.yaml
@@ -21,7 +21,7 @@ protocols:
 - valory/ledger_api:1.0.0:bafybeige5agrztgzfevyglf7mb4o7pzfttmq4f6zi765y4g2zvftbyowru
 skills:
 - valory/abstract_round_abci:0.1.0:bafybeicrzndcdbue34yxwwb4hmmdhgzw4owcdcdag3ifj6thpx5wie3dp4
-- valory/decision_maker_abci:0.1.0:bafybeibqsaei2puprlwdwtvt3bf6golmvpdozblcw22qurx5bdymmvwvzy
+- valory/decision_maker_abci:0.1.0:bafybeiaan3hccyiocw6a2hecrcfx47sjxkuerbcoxjwjgr32zuqujs3qsu
 - valory/staking_abci:0.1.0:bafybeigwpp474gw7yb3w3xm4ejz4nxm7n2l4d27po6pj3yh7w3idctge5i
 behaviours:
   main:


### PR DESCRIPTION
Emit a `NONE` event from `SamplingRound` if no bet was sampled.

Fixes #204.