### PR TITLE
Fix payout

### DIFF
--- a/packages/packages.json
+++ b/packages/packages.json
@@ -14,12 +14,12 @@
         "contract/valory/service_staking_token/0.1.0": "bafybeifutwafhejdpyhskq5lzwvvrber2inzaq5hcooehdazooojnffmmq",
         "contract/valory/transfer_nft_condition/0.1.0": "bafybeigm4xtymjkq5piqwthecqoc5htu2u2lu23qzoh6j4elqabsrs6uwu",
         "skill/valory/market_manager_abci/0.1.0": "bafybeibi6f5v77mhcj6cdujuf2vdgrdjnhvgt2fp6nwszqrhv6de6zg3ne",
-        "skill/valory/decision_maker_abci/0.1.0": "bafybeih2ar2x6pqtj7hltapc7jouu5ylrrckpb6d3rzk3vo3ecxxeozwly",
-        "skill/valory/trader_abci/0.1.0": "bafybeialljddzyqmx5g6jvkx7xvinnpy6ccemrqt6ylr5l7vuhwhsbrmyq",
-        "skill/valory/tx_settlement_multiplexer_abci/0.1.0": "bafybeifpzm5zaeeptxrig4qxgsfpopzlvw7j3s6abbudki4ckdyultwlmm",
+        "skill/valory/decision_maker_abci/0.1.0": "bafybeidicnzsh4xaxllpvb5t2watofzu4phr7d67v45jqrtiuhofueb75m",
+        "skill/valory/trader_abci/0.1.0": "bafybeieukljshhssi4d6v5khmgzxj5ghg22u7nvbxp57vgoie6urx444mq",
+        "skill/valory/tx_settlement_multiplexer_abci/0.1.0": "bafybeidpgig4dzg3ev45i3j5xf7ctq3uuvum7k2o5czbuic3p57hc44nmq",
         "skill/valory/staking_abci/0.1.0": "bafybeic4jjovyh4rwwyjw3pcaqtzywuy5wqlywu6bofrd7tsjgix4bzsoi",
-        "agent/valory/trader/0.1.0": "bafybeifyfrhctc26gaxfqmkvmkol3monadaqv6kx2mhz4zbvdzsm37kxcy",
-        "service/valory/trader/0.1.0": "bafybeibp2weso4kbf4mhijhocbsvnu7azqdfum56tjh24lm2brz5zn36da"
+        "agent/valory/trader/0.1.0": "bafybeicczyfill4rb47tgjsra5xqoc5yi4htzacpqtdlkcdpmumvf4eryq",
+        "service/valory/trader/0.1.0": "bafybeicku3z24744pcfrjxjzq6r4ux3bvbkwhwhypifa7o4yly24yqtsne"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeihv62fim3wl2bayavfcg3u5e5cxu3b7brtu4cn5xoxd6lqwachasi",

--- a/packages/valory/agents/trader/aea-config.yaml
+++ b/packages/valory/agents/trader/aea-config.yaml
@@ -44,10 +44,10 @@ skills:
 - valory/reset_pause_abci:0.1.0:bafybeicm7onl72rfnn33pbvzwjpkl5gafeieyobfcnyresxz7kunjwmqea
 - valory/termination_abci:0.1.0:bafybeie6h7j4hyhgj2wte64n3xyudxq4pgqcqjmslxi5tff4mb6vce2tay
 - valory/transaction_settlement_abci:0.1.0:bafybeid57tozt5f3kgzmu22nbr3c3oy4p7bi2bu66rqsgnlylq6xgh2ixe
-- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeifpzm5zaeeptxrig4qxgsfpopzlvw7j3s6abbudki4ckdyultwlmm
+- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeidpgig4dzg3ev45i3j5xf7ctq3uuvum7k2o5czbuic3p57hc44nmq
 - valory/market_manager_abci:0.1.0:bafybeibi6f5v77mhcj6cdujuf2vdgrdjnhvgt2fp6nwszqrhv6de6zg3ne
-- valory/decision_maker_abci:0.1.0:bafybeih2ar2x6pqtj7hltapc7jouu5ylrrckpb6d3rzk3vo3ecxxeozwly
-- valory/trader_abci:0.1.0:bafybeialljddzyqmx5g6jvkx7xvinnpy6ccemrqt6ylr5l7vuhwhsbrmyq
+- valory/decision_maker_abci:0.1.0:bafybeidicnzsh4xaxllpvb5t2watofzu4phr7d67v45jqrtiuhofueb75m
+- valory/trader_abci:0.1.0:bafybeieukljshhssi4d6v5khmgzxj5ghg22u7nvbxp57vgoie6urx444mq
 - valory/staking_abci:0.1.0:bafybeic4jjovyh4rwwyjw3pcaqtzywuy5wqlywu6bofrd7tsjgix4bzsoi
 default_ledger: ethereum
 required_ledgers:

--- a/packages/valory/services/trader/service.yaml
+++ b/packages/valory/services/trader/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeigtuothskwyvrhfosps2bu6suauycolj67dpuxqvnicdrdu7yhtvq
 fingerprint_ignore_patterns: []
-agent: valory/trader:0.1.0:bafybeifyfrhctc26gaxfqmkvmkol3monadaqv6kx2mhz4zbvdzsm37kxcy
+agent: valory/trader:0.1.0:bafybeicczyfill4rb47tgjsra5xqoc5yi4htzacpqtdlkcdpmumvf4eryq
 number_of_agents: 4
 deployment: {}
 ---

--- a/packages/valory/skills/decision_maker_abci/behaviours/reedem.py
+++ b/packages/valory/skills/decision_maker_abci/behaviours/reedem.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # ------------------------------------------------------------------------------
 #
-#   Copyright 2023 Valory AG
+#   Copyright 2023-2024 Valory AG
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.

--- a/packages/valory/skills/decision_maker_abci/behaviours/reedem.py
+++ b/packages/valory/skills/decision_maker_abci/behaviours/reedem.py
@@ -202,9 +202,9 @@ class RedeemBehaviour(RedeemInfoBehaviour):
         return self.shared_state.redeeming_progress
 
     @redeeming_progress.setter
-    def redeeming_progress(self, payouts: RedeemingProgress) -> None:
+    def redeeming_progress(self, progress: RedeemingProgress) -> None:
         """Set the redeeming check progress in the shared state."""
-        self.shared_state.redeeming_progress = payouts
+        self.shared_state.redeeming_progress = progress
 
     @property
     def latest_block_number(self) -> int:

--- a/packages/valory/skills/decision_maker_abci/behaviours/reedem.py
+++ b/packages/valory/skills/decision_maker_abci/behaviours/reedem.py
@@ -487,7 +487,7 @@ class RedeemBehaviour(RedeemInfoBehaviour):
     def _check_already_redeemed_via_subgraph(self) -> WaitableConditionType:
         """Check whether the condition ids have already been redeemed via subgraph."""
         safe_address = self.synchronized_data.safe_contract_address.lower()
-        from_timestamp, to_timestamp = 0.0, time.time()  # from begging to now
+        from_timestamp, to_timestamp = 0.0, time.time()  # from beginning to now
 
         # get the trades
         trades = yield from self.fetch_trades(
@@ -496,7 +496,7 @@ class RedeemBehaviour(RedeemInfoBehaviour):
         if trades is None:
             return False
 
-        # get the user positions
+        # get the user's positions
         user_positions = yield from self.fetch_user_positions(safe_address)
         if user_positions is None:
             return False

--- a/packages/valory/skills/decision_maker_abci/behaviours/reedem.py
+++ b/packages/valory/skills/decision_maker_abci/behaviours/reedem.py
@@ -535,7 +535,11 @@ class RedeemBehaviour(RedeemInfoBehaviour):
         payouts_amount = sum(payouts.values())
         if payouts_amount > 0:
             self.redeemed_condition_ids |= set(payouts.keys())
-            self.payout_so_far += payouts_amount
+            if self.params.use_subgraph_for_redeeming:
+                self.payout_so_far = payouts_amount
+            else:
+                self.payout_so_far += payouts_amount
+
             # filter the trades again if new payouts have been found
             self._filter_trades()
             wxdai_amount = self.wei_to_native(self.payout_so_far)

--- a/packages/valory/skills/decision_maker_abci/skill.yaml
+++ b/packages/valory/skills/decision_maker_abci/skill.yaml
@@ -21,7 +21,7 @@ fingerprint:
   behaviours/handle_failed_tx.py: bafybeidxpc6u575ymct5tdwutvzov6zqfdoio5irgldn3fw7q3lg36mmxm
   behaviours/order_subscription.py: bafybeifygejified3yoza3gy4g7ina6m4lmz4pp2abtwfuwrmiwznnvrua
   behaviours/randomness.py: bafybeidmr33teizrs4uxlo5tdz766ds6os4pe5lttstm7jpmhgmjz5ti3q
-  behaviours/reedem.py: bafybeibenzbek5qdtk3gobjxfmsm6tg6i3d4yltozymy23izpgbcpal5ye
+  behaviours/reedem.py: bafybeihwe4azke5zbdu4rhhsx3bmjgnkagwkuowyowvkure2do2rg4ainy
   behaviours/round_behaviour.py: bafybeidrks62unrnoyp3jnbz2nozgnittfntyknymuuja7jwcsjuap4fve
   behaviours/sampling.py: bafybeibtkli72qsvotkrsepkgpiumtr5sershtkpb427oygnszs3dpgxry
   behaviours/tool_selection.py: bafybeicxw4je76uc7znx4u2hq2b2aaxcf7blwfla7lhdhkqnf3kkupsczq

--- a/packages/valory/skills/trader_abci/skill.yaml
+++ b/packages/valory/skills/trader_abci/skill.yaml
@@ -25,8 +25,8 @@ skills:
 - valory/transaction_settlement_abci:0.1.0:bafybeid57tozt5f3kgzmu22nbr3c3oy4p7bi2bu66rqsgnlylq6xgh2ixe
 - valory/termination_abci:0.1.0:bafybeie6h7j4hyhgj2wte64n3xyudxq4pgqcqjmslxi5tff4mb6vce2tay
 - valory/market_manager_abci:0.1.0:bafybeibi6f5v77mhcj6cdujuf2vdgrdjnhvgt2fp6nwszqrhv6de6zg3ne
-- valory/decision_maker_abci:0.1.0:bafybeih2ar2x6pqtj7hltapc7jouu5ylrrckpb6d3rzk3vo3ecxxeozwly
-- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeifpzm5zaeeptxrig4qxgsfpopzlvw7j3s6abbudki4ckdyultwlmm
+- valory/decision_maker_abci:0.1.0:bafybeidicnzsh4xaxllpvb5t2watofzu4phr7d67v45jqrtiuhofueb75m
+- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeidpgig4dzg3ev45i3j5xf7ctq3uuvum7k2o5czbuic3p57hc44nmq
 - valory/staking_abci:0.1.0:bafybeic4jjovyh4rwwyjw3pcaqtzywuy5wqlywu6bofrd7tsjgix4bzsoi
 behaviours:
   main:

--- a/packages/valory/skills/tx_settlement_multiplexer_abci/skill.yaml
+++ b/packages/valory/skills/tx_settlement_multiplexer_abci/skill.yaml
@@ -21,7 +21,7 @@ protocols:
 - valory/ledger_api:1.0.0:bafybeihdk6psr4guxmbcrc26jr2cbgzpd5aljkqvpwo64bvaz7tdti2oni
 skills:
 - valory/abstract_round_abci:0.1.0:bafybeigjrepaqpb3m7zunmt4hryos4vto4yyj3u6iyofdb2fotwho3bqvm
-- valory/decision_maker_abci:0.1.0:bafybeih2ar2x6pqtj7hltapc7jouu5ylrrckpb6d3rzk3vo3ecxxeozwly
+- valory/decision_maker_abci:0.1.0:bafybeidicnzsh4xaxllpvb5t2watofzu4phr7d67v45jqrtiuhofueb75m
 - valory/staking_abci:0.1.0:bafybeic4jjovyh4rwwyjw3pcaqtzywuy5wqlywu6bofrd7tsjgix4bzsoi
 behaviours:
   main:


### PR DESCRIPTION
Fixes an issue introduced in #172.

When we get the payout from the events on-chain, `0` is returned for the positions that have already been redeemed. However, this is not the case when we retrieve the payout from the subgraph. The `get_position_lifetime_value()` calculates the lifetime value returned from the conditional tokens' subgraph. In the latter case, all the payout amounts are returned, regardless of whether we have redeemed or not.

Therefore, when we use the on-chain events, we need to sum the current payouts with the payouts so far. However, when we use the subgraph, we need to set the payouts so far with the currently calculated payouts.