### PR TITLE
Feat: stop trading conditions

### DIFF
--- a/.github/workflows/common_checks.yaml
+++ b/.github/workflows/common_checks.yaml
@@ -124,4 +124,4 @@ jobs:
           wget https://github.com/zricethezav/gitleaks/releases/download/v8.10.1/gitleaks_8.10.1_linux_x64.tar.gz && \
           tar -xzf gitleaks_8.10.1_linux_x64.tar.gz && \
           sudo install gitleaks /usr/bin && \
-          gitleaks detect --report-format json --report-path leak_report
+          gitleaks detect --report-format json --report-path leak_report -v

--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ packages/valory/protocols/tendermint
 .env
 .1env
 keys.json
+keys_json/
 leak_report
 
 agent/

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -21,3 +21,5 @@ d004f2345bf31b27c343eb52c1bc5a2698e838d6:packages/valory/skills/market_manager_a
 b2c15c1a44ba680dd747a6fbdda9f2e9aced39eb:packages/valory/contracts/service_staking_token/contract.yaml:generic-api-key:10
 fc7d0697d1543849b07750430843e6b01426cc7a:packages/valory/services/trader_omen_gnosis/service.yaml:generic-api-key:64
 63bb4c2347c3def7bd65d554c8d536b79325afb9:packages/valory/skills/trader_abci/skill.yaml:generic-api-key:154
+809a4d8befaf483c8d5d775f3271e7d8601e2985:packages/valory/skills/decision_maker_abci/skill.yaml:generic-api-key:186
+809a4d8befaf483c8d5d775f3271e7d8601e2985:packages/valory/skills/trader_abci/skill.yaml:generic-api-key:154

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -20,3 +20,4 @@ ed30ffbaaf3c10476dc642d388985c250afaeb8d:packages/valory/skills/market_manager_a
 d004f2345bf31b27c343eb52c1bc5a2698e838d6:packages/valory/skills/market_manager_abci/graph_tooling/requests.py:generic-api-key:221
 b2c15c1a44ba680dd747a6fbdda9f2e9aced39eb:packages/valory/contracts/service_staking_token/contract.yaml:generic-api-key:10
 fc7d0697d1543849b07750430843e6b01426cc7a:packages/valory/services/trader_omen_gnosis/service.yaml:generic-api-key:64
+63bb4c2347c3def7bd65d554c8d536b79325afb9:packages/valory/skills/trader_abci/skill.yaml:generic-api-key:154

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -23,3 +23,6 @@ fc7d0697d1543849b07750430843e6b01426cc7a:packages/valory/services/trader_omen_gn
 63bb4c2347c3def7bd65d554c8d536b79325afb9:packages/valory/skills/trader_abci/skill.yaml:generic-api-key:154
 809a4d8befaf483c8d5d775f3271e7d8601e2985:packages/valory/skills/decision_maker_abci/skill.yaml:generic-api-key:186
 809a4d8befaf483c8d5d775f3271e7d8601e2985:packages/valory/skills/trader_abci/skill.yaml:generic-api-key:154
+ae28aeb8ad56e1873bfb3996c5d5ad8367709cd1:packages/valory/skills/decision_maker_abci/skill.yaml:generic-api-key:186
+ae28aeb8ad56e1873bfb3996c5d5ad8367709cd1:packages/valory/skills/trader_abci/skill.yaml:generic-api-key:154
+

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -13,12 +13,12 @@
         "contract/valory/transfer_nft_condition/0.1.0": "bafybeicgpoag2lymofz3vnen76q7gtig5hzimn32o57php4uerr6t25em4",
         "skill/valory/market_manager_abci/0.1.0": "bafybeidygkw7mwhbk3ry3au5c5265vms5eti375v5jthd4be5dfnnoache",
         "skill/valory/decision_maker_abci/0.1.0": "bafybeihl4fyyjj34kvouh3ujmekqm4vsn5eabpfsww7danwyqmfhxxlequ",
-        "skill/valory/trader_abci/0.1.0": "bafybeia7a6glncfuncgnupyhfldvp2qy5fau3n72pqdqf6zorvhug7kfiq",
+        "skill/valory/trader_abci/0.1.0": "bafybeidmp5fbufsvbo2jyxmh3epazeni6jxauyf7h5vssuxr74i2jlgcdi",
         "skill/valory/tx_settlement_multiplexer_abci/0.1.0": "bafybeifmyrqtgp4duq65ag3pnbid2xlgxemefln3mshccs6dnhdtieg4la",
         "skill/valory/staking_abci/0.1.0": "bafybeicrp3dbvxcb2wa7kdgpkxu7aqji5fwq6icwcfw7anfcpqv26irsr4",
-        "skill/valory/check_stop_trading_abci/0.1.0": "bafybeihs2yjqyqno6h5pmhrwlpgnoqunnho54p2y46ut2hmorsaz36quru",
-        "agent/valory/trader/0.1.0": "bafybeignyb7bcsysmks3v7wzspscocy5t63oc4ucpakcs5vmc2g3eebxm4",
-        "service/valory/trader/0.1.0": "bafybeiewwtagcb6kndddzqapebdmuwrywa67nrcyud6wi32oaw5uunxyyi"
+        "skill/valory/check_stop_trading_abci/0.1.0": "bafybeig7doeus3ezz57nazjmjd6qkkbkuptr3rf4btbbuxsx767jsxcnha",
+        "agent/valory/trader/0.1.0": "bafybeidxsseryfymbqeg67ezacy74p3e2i3sslz6fkiebf4lqmjxrx7zse",
+        "service/valory/trader/0.1.0": "bafybeidupsn5xvnnf7ivcznqzvfmdmh7sdllubbnifwll3obqoidwukawq"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeihv62fim3wl2bayavfcg3u5e5cxu3b7brtu4cn5xoxd6lqwachasi",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -18,7 +18,7 @@
         "skill/valory/staking_abci/0.1.0": "bafybeicrp3dbvxcb2wa7kdgpkxu7aqji5fwq6icwcfw7anfcpqv26irsr4",
         "skill/valory/check_stop_trading_abci/0.1.0": "bafybeihs2yjqyqno6h5pmhrwlpgnoqunnho54p2y46ut2hmorsaz36quru",
         "agent/valory/trader/0.1.0": "bafybeignyb7bcsysmks3v7wzspscocy5t63oc4ucpakcs5vmc2g3eebxm4",
-        "service/valory/trader/0.1.0": "bafybeihv4m7py577dfzp5nefvoqlxm5msxnc6weo53nfi6wjfdzgj6ztsu"
+        "service/valory/trader/0.1.0": "bafybeiewwtagcb6kndddzqapebdmuwrywa67nrcyud6wi32oaw5uunxyyi"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeihv62fim3wl2bayavfcg3u5e5cxu3b7brtu4cn5xoxd6lqwachasi",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -13,12 +13,12 @@
         "contract/valory/transfer_nft_condition/0.1.0": "bafybeicgpoag2lymofz3vnen76q7gtig5hzimn32o57php4uerr6t25em4",
         "skill/valory/market_manager_abci/0.1.0": "bafybeidygkw7mwhbk3ry3au5c5265vms5eti375v5jthd4be5dfnnoache",
         "skill/valory/decision_maker_abci/0.1.0": "bafybeibvq365gs7ibi7bkzoqyiirdcbpros2q7z3zpsqxhbcfy5d77y7je",
-        "skill/valory/trader_abci/0.1.0": "bafybeihzojyuubf3ka32ic55h2456wiptcbbh6fwwmcwo7jmh5znvjbaki",
+        "skill/valory/trader_abci/0.1.0": "bafybeih3lfegxuczo6navbdg2n365dtswjb3ekplpn4bjmk67dskeyqwuu",
         "skill/valory/tx_settlement_multiplexer_abci/0.1.0": "bafybeibcuvrm5fvmh7nuee4tmbof6debprdqzhvhdpzp2dbddtwva4wz3y",
         "skill/valory/staking_abci/0.1.0": "bafybeicrp3dbvxcb2wa7kdgpkxu7aqji5fwq6icwcfw7anfcpqv26irsr4",
-        "skill/valory/check_stop_trading_abci/0.1.0": "bafybeifho6gdnpx3j2czez4iotjhgropakiubzya6ceag556ijjqc5gfay",
-        "agent/valory/trader/0.1.0": "bafybeiexvfnp2wvxcon3plkx5jzpgkz36ricwioffnhpu4iueqtfbvzrpy",
-        "service/valory/trader/0.1.0": "bafybeihik7bbmaqgqxezfgufeiov4mn4nketzsf3cng7qu7ovux3cm6olm"
+        "skill/valory/check_stop_trading_abci/0.1.0": "bafybeiazbeawv7y6edcua6qa7z2kyckcgielwjt2metts6vuv5qecvvn4q",
+        "agent/valory/trader/0.1.0": "bafybeidq5r2wxn5qlo5rc5d4cvulhwv7udm3inforyiezkgvvkr34jmezm",
+        "service/valory/trader/0.1.0": "bafybeic4qhge7pzivmdquwphixrsiniajdqguomlltihods4cyuwdbt4fi"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeihv62fim3wl2bayavfcg3u5e5cxu3b7brtu4cn5xoxd6lqwachasi",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -13,12 +13,12 @@
         "contract/valory/transfer_nft_condition/0.1.0": "bafybeicgpoag2lymofz3vnen76q7gtig5hzimn32o57php4uerr6t25em4",
         "skill/valory/market_manager_abci/0.1.0": "bafybeidygkw7mwhbk3ry3au5c5265vms5eti375v5jthd4be5dfnnoache",
         "skill/valory/decision_maker_abci/0.1.0": "bafybeihl4fyyjj34kvouh3ujmekqm4vsn5eabpfsww7danwyqmfhxxlequ",
-        "skill/valory/trader_abci/0.1.0": "bafybeihxgz7wwzipkuw673fetxzkexp2qzrysuos2od3unk4ycznz7lvai",
+        "skill/valory/trader_abci/0.1.0": "bafybeifheb2uynf2c2li6ldj2dpwsusp2vlctuewug3hzkky67b3rfvt3i",
         "skill/valory/tx_settlement_multiplexer_abci/0.1.0": "bafybeifmyrqtgp4duq65ag3pnbid2xlgxemefln3mshccs6dnhdtieg4la",
         "skill/valory/staking_abci/0.1.0": "bafybeicrp3dbvxcb2wa7kdgpkxu7aqji5fwq6icwcfw7anfcpqv26irsr4",
-        "skill/valory/check_stop_trading_abci/0.1.0": "bafybeigqdtgp44ocop6btftb5zfrq4yrjunsr5ija2dxpvpalxqmlqxzbm",
-        "agent/valory/trader/0.1.0": "bafybeibrtndmvq3sqnd6sznqreukjfe5776q25e4lqqscayznzjdrgfuu4",
-        "service/valory/trader/0.1.0": "bafybeib5a624gd4y7kg7iaunujrjxet3m6rih3kjq4aosd2qkrofnoekja"
+        "skill/valory/check_stop_trading_abci/0.1.0": "bafybeifho6gdnpx3j2czez4iotjhgropakiubzya6ceag556ijjqc5gfay",
+        "agent/valory/trader/0.1.0": "bafybeig2clkaul65rgkttohpj6c5dvry2brux2krjw2aua2mzxidfsjmn4",
+        "service/valory/trader/0.1.0": "bafybeib6fbaqu4k4wtediupg7fw6t53rksrnefekt6wkl3hlvu5j6qdvmq"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeihv62fim3wl2bayavfcg3u5e5cxu3b7brtu4cn5xoxd6lqwachasi",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -13,12 +13,12 @@
         "contract/valory/transfer_nft_condition/0.1.0": "bafybeicgpoag2lymofz3vnen76q7gtig5hzimn32o57php4uerr6t25em4",
         "skill/valory/market_manager_abci/0.1.0": "bafybeidygkw7mwhbk3ry3au5c5265vms5eti375v5jthd4be5dfnnoache",
         "skill/valory/decision_maker_abci/0.1.0": "bafybeibvq365gs7ibi7bkzoqyiirdcbpros2q7z3zpsqxhbcfy5d77y7je",
-        "skill/valory/trader_abci/0.1.0": "bafybeih3lfegxuczo6navbdg2n365dtswjb3ekplpn4bjmk67dskeyqwuu",
+        "skill/valory/trader_abci/0.1.0": "bafybeia25dej4nrhrtahbinvilwj4wywomkuryfjhcomieubw2n4mfarjq",
         "skill/valory/tx_settlement_multiplexer_abci/0.1.0": "bafybeibcuvrm5fvmh7nuee4tmbof6debprdqzhvhdpzp2dbddtwva4wz3y",
         "skill/valory/staking_abci/0.1.0": "bafybeicrp3dbvxcb2wa7kdgpkxu7aqji5fwq6icwcfw7anfcpqv26irsr4",
-        "skill/valory/check_stop_trading_abci/0.1.0": "bafybeiazbeawv7y6edcua6qa7z2kyckcgielwjt2metts6vuv5qecvvn4q",
-        "agent/valory/trader/0.1.0": "bafybeidq5r2wxn5qlo5rc5d4cvulhwv7udm3inforyiezkgvvkr34jmezm",
-        "service/valory/trader/0.1.0": "bafybeic4qhge7pzivmdquwphixrsiniajdqguomlltihods4cyuwdbt4fi"
+        "skill/valory/check_stop_trading_abci/0.1.0": "bafybeiegjhswbs4uxmyxrfppteunfhuzluigvf3b325e56vw2k764rklbu",
+        "agent/valory/trader/0.1.0": "bafybeicnz7hmbxgphadyauhn5h75jchvxyqkguhfyyd7zj54jre76usncq",
+        "service/valory/trader/0.1.0": "bafybeibtiux4p3j7pbfbdoxp6zmwkxhi6hbw3ekmpafxvk74zxse6iksbe"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeihv62fim3wl2bayavfcg3u5e5cxu3b7brtu4cn5xoxd6lqwachasi",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -13,12 +13,12 @@
         "contract/valory/transfer_nft_condition/0.1.0": "bafybeicgpoag2lymofz3vnen76q7gtig5hzimn32o57php4uerr6t25em4",
         "skill/valory/market_manager_abci/0.1.0": "bafybeidygkw7mwhbk3ry3au5c5265vms5eti375v5jthd4be5dfnnoache",
         "skill/valory/decision_maker_abci/0.1.0": "bafybeihl4fyyjj34kvouh3ujmekqm4vsn5eabpfsww7danwyqmfhxxlequ",
-        "skill/valory/trader_abci/0.1.0": "bafybeiduzcdjahjrxgx4twy4mm6l55kq7skf5g33fmsztqjsw37fzpgmui",
+        "skill/valory/trader_abci/0.1.0": "bafybeibaaj3pfykph7uuphh4nb3mty6azexpdhqxtgv47pzpjl6zogx2iu",
         "skill/valory/tx_settlement_multiplexer_abci/0.1.0": "bafybeifmyrqtgp4duq65ag3pnbid2xlgxemefln3mshccs6dnhdtieg4la",
         "skill/valory/staking_abci/0.1.0": "bafybeicrp3dbvxcb2wa7kdgpkxu7aqji5fwq6icwcfw7anfcpqv26irsr4",
-        "skill/valory/check_stop_trading_abci/0.1.0": "bafybeiamwtr56zmm7effymgo7jwgix4nwdbhwjrjix4csrdtlyk3qoky3i",
-        "agent/valory/trader/0.1.0": "bafybeihfsry4qd7gslcavioe4l6gkxjyhqvhmy6ayih2uxi4fgqav2r3ge",
-        "service/valory/trader/0.1.0": "bafybeihwwfqhcusr57mxtlottypx7h5qqn7r6zdhmhgtrla5p4ntkfzi7i"
+        "skill/valory/check_stop_trading_abci/0.1.0": "bafybeihxs5gjblndvzipowu3576v6sq476j52leubezge7dixqexunbh3m",
+        "agent/valory/trader/0.1.0": "bafybeihjuzydhrkyqwxk3hmmmulc5gyemq24qujwbknt6psruiovtknv34",
+        "service/valory/trader/0.1.0": "bafybeiazg6psoawy4wkfqrrlvxisp5ch6jlxo62qdvd36vo5dvedzmpi44"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeihv62fim3wl2bayavfcg3u5e5cxu3b7brtu4cn5xoxd6lqwachasi",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -13,12 +13,12 @@
         "contract/valory/transfer_nft_condition/0.1.0": "bafybeicgpoag2lymofz3vnen76q7gtig5hzimn32o57php4uerr6t25em4",
         "skill/valory/market_manager_abci/0.1.0": "bafybeidygkw7mwhbk3ry3au5c5265vms5eti375v5jthd4be5dfnnoache",
         "skill/valory/decision_maker_abci/0.1.0": "bafybeihl4fyyjj34kvouh3ujmekqm4vsn5eabpfsww7danwyqmfhxxlequ",
-        "skill/valory/trader_abci/0.1.0": "bafybeidmp5fbufsvbo2jyxmh3epazeni6jxauyf7h5vssuxr74i2jlgcdi",
+        "skill/valory/trader_abci/0.1.0": "bafybeihxgz7wwzipkuw673fetxzkexp2qzrysuos2od3unk4ycznz7lvai",
         "skill/valory/tx_settlement_multiplexer_abci/0.1.0": "bafybeifmyrqtgp4duq65ag3pnbid2xlgxemefln3mshccs6dnhdtieg4la",
         "skill/valory/staking_abci/0.1.0": "bafybeicrp3dbvxcb2wa7kdgpkxu7aqji5fwq6icwcfw7anfcpqv26irsr4",
-        "skill/valory/check_stop_trading_abci/0.1.0": "bafybeig7doeus3ezz57nazjmjd6qkkbkuptr3rf4btbbuxsx767jsxcnha",
-        "agent/valory/trader/0.1.0": "bafybeidxsseryfymbqeg67ezacy74p3e2i3sslz6fkiebf4lqmjxrx7zse",
-        "service/valory/trader/0.1.0": "bafybeidupsn5xvnnf7ivcznqzvfmdmh7sdllubbnifwll3obqoidwukawq"
+        "skill/valory/check_stop_trading_abci/0.1.0": "bafybeigqdtgp44ocop6btftb5zfrq4yrjunsr5ija2dxpvpalxqmlqxzbm",
+        "agent/valory/trader/0.1.0": "bafybeibrtndmvq3sqnd6sznqreukjfe5776q25e4lqqscayznzjdrgfuu4",
+        "service/valory/trader/0.1.0": "bafybeib5a624gd4y7kg7iaunujrjxet3m6rih3kjq4aosd2qkrofnoekja"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeihv62fim3wl2bayavfcg3u5e5cxu3b7brtu4cn5xoxd6lqwachasi",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -12,13 +12,13 @@
         "contract/valory/service_staking_token/0.1.0": "bafybeid44l7qekvkwkvmfl4kcqchnaktttacp7lbx464mzqqs5cnefj35e",
         "contract/valory/transfer_nft_condition/0.1.0": "bafybeicgpoag2lymofz3vnen76q7gtig5hzimn32o57php4uerr6t25em4",
         "skill/valory/market_manager_abci/0.1.0": "bafybeidygkw7mwhbk3ry3au5c5265vms5eti375v5jthd4be5dfnnoache",
-        "skill/valory/decision_maker_abci/0.1.0": "bafybeif64m3zztadm2jjonorlwc2lpppqmqktig4jvfvycz3w5qv6sfrpa",
-        "skill/valory/trader_abci/0.1.0": "bafybeia3pfyuea4wxwbtizq57vcx2tg4z6dk4i5twhhqqjwzoi5l37gkl4",
-        "skill/valory/tx_settlement_multiplexer_abci/0.1.0": "bafybeigwosmf2ltoh2wkwppgftqzucktzq2b7eiakhtclnfybpsusregde",
+        "skill/valory/decision_maker_abci/0.1.0": "bafybeibvq365gs7ibi7bkzoqyiirdcbpros2q7z3zpsqxhbcfy5d77y7je",
+        "skill/valory/trader_abci/0.1.0": "bafybeihzojyuubf3ka32ic55h2456wiptcbbh6fwwmcwo7jmh5znvjbaki",
+        "skill/valory/tx_settlement_multiplexer_abci/0.1.0": "bafybeibcuvrm5fvmh7nuee4tmbof6debprdqzhvhdpzp2dbddtwva4wz3y",
         "skill/valory/staking_abci/0.1.0": "bafybeicrp3dbvxcb2wa7kdgpkxu7aqji5fwq6icwcfw7anfcpqv26irsr4",
         "skill/valory/check_stop_trading_abci/0.1.0": "bafybeifho6gdnpx3j2czez4iotjhgropakiubzya6ceag556ijjqc5gfay",
-        "agent/valory/trader/0.1.0": "bafybeihlc6vtlokdt4wxxt7jqto6rokydpn2xhlqpmny3cs4s76flaeeoq",
-        "service/valory/trader/0.1.0": "bafybeig5nbohr7bgf2nn6ghdw3q2ij7sms7patvvwgoqzo2nhz5q74x4oa"
+        "agent/valory/trader/0.1.0": "bafybeiexvfnp2wvxcon3plkx5jzpgkz36ricwioffnhpu4iueqtfbvzrpy",
+        "service/valory/trader/0.1.0": "bafybeihik7bbmaqgqxezfgufeiov4mn4nketzsf3cng7qu7ovux3cm6olm"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeihv62fim3wl2bayavfcg3u5e5cxu3b7brtu4cn5xoxd6lqwachasi",
@@ -46,6 +46,6 @@
         "skill/valory/abstract_round_abci/0.1.0": "bafybeih3enhagoql7kzpeyzzu2scpkif6y3ubakpralfnwxcvxexdyvy5i",
         "skill/valory/transaction_settlement_abci/0.1.0": "bafybeigtzlk4uakmd54rxnznorcrstsr52kta474lgrnvx5ovr546vj7sq",
         "skill/valory/termination_abci/0.1.0": "bafybeihq6qtbwt6i53ayqym63vhjexkcppy26gguzhhjqywfmiuqghvv44",
-        "skill/valory/mech_interact_abci/0.1.0": "bafybeihvjtdg47pchoutcuh5l7jwiclpowriymtj7nyud22cetjjxggeiy"
+        "skill/valory/mech_interact_abci/0.1.0": "bafybeib3aytq2a5hk6vjsak3eznuilndx4p53utdylbyhcmt6ty7kk6euq"
     }
 }

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -13,11 +13,12 @@
         "contract/valory/transfer_nft_condition/0.1.0": "bafybeicgpoag2lymofz3vnen76q7gtig5hzimn32o57php4uerr6t25em4",
         "skill/valory/market_manager_abci/0.1.0": "bafybeidygkw7mwhbk3ry3au5c5265vms5eti375v5jthd4be5dfnnoache",
         "skill/valory/decision_maker_abci/0.1.0": "bafybeigyrxb6ycg243crte5mmmut2znfhlnc43rqn3mnp3sylvf563teki",
-        "skill/valory/trader_abci/0.1.0": "bafybeifupwnewnhskanrklryt2vxalc5jkqedr2ywt3ux6fpaugc6kuu6q",
+        "skill/valory/trader_abci/0.1.0": "bafybeie3wjbqbcgeeuxw3irtcgofwhlhsq25tz4mpgywef52m3wmtrlpwa",
         "skill/valory/tx_settlement_multiplexer_abci/0.1.0": "bafybeibl6b5negw35fumbvl6dvcu7dammqmac5x3htapu3p7yf7lkqr73a",
         "skill/valory/staking_abci/0.1.0": "bafybeibf565rftitlrlovlvchoe45ng72ctec74fsvrmegp3o4uepu4q2e",
-        "agent/valory/trader/0.1.0": "bafybeicxc3v3ungi6qindlyayahmngk23xf6carthxilva3jmd3jdkn3mu",
-        "service/valory/trader/0.1.0": "bafybeibtstpn3x3shp5nujacgbwidmc5nwxdcz55p2qptwufkucnkhgr54"
+        "skill/valory/check_stop_trading_abci/0.1.0": "bafybeihd2awwfnwboe4tnb6gmrhtheg5py4m37sdqtxxn7z3wnhxxntku4",
+        "agent/valory/trader/0.1.0": "bafybeihibluqupq6si5ecm7zrbnxlrnlsnmnfsivc2jjbwguxcmptzxrxi",
+        "service/valory/trader/0.1.0": "bafybeibzjpvneeolms54grz2r5wmnomx3n5r7todil7r2u6gwtjumogxea"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeihv62fim3wl2bayavfcg3u5e5cxu3b7brtu4cn5xoxd6lqwachasi",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -12,13 +12,13 @@
         "contract/valory/service_staking_token/0.1.0": "bafybeid44l7qekvkwkvmfl4kcqchnaktttacp7lbx464mzqqs5cnefj35e",
         "contract/valory/transfer_nft_condition/0.1.0": "bafybeicgpoag2lymofz3vnen76q7gtig5hzimn32o57php4uerr6t25em4",
         "skill/valory/market_manager_abci/0.1.0": "bafybeidygkw7mwhbk3ry3au5c5265vms5eti375v5jthd4be5dfnnoache",
-        "skill/valory/decision_maker_abci/0.1.0": "bafybeihl4fyyjj34kvouh3ujmekqm4vsn5eabpfsww7danwyqmfhxxlequ",
-        "skill/valory/trader_abci/0.1.0": "bafybeifheb2uynf2c2li6ldj2dpwsusp2vlctuewug3hzkky67b3rfvt3i",
-        "skill/valory/tx_settlement_multiplexer_abci/0.1.0": "bafybeifmyrqtgp4duq65ag3pnbid2xlgxemefln3mshccs6dnhdtieg4la",
+        "skill/valory/decision_maker_abci/0.1.0": "bafybeif64m3zztadm2jjonorlwc2lpppqmqktig4jvfvycz3w5qv6sfrpa",
+        "skill/valory/trader_abci/0.1.0": "bafybeia3pfyuea4wxwbtizq57vcx2tg4z6dk4i5twhhqqjwzoi5l37gkl4",
+        "skill/valory/tx_settlement_multiplexer_abci/0.1.0": "bafybeigwosmf2ltoh2wkwppgftqzucktzq2b7eiakhtclnfybpsusregde",
         "skill/valory/staking_abci/0.1.0": "bafybeicrp3dbvxcb2wa7kdgpkxu7aqji5fwq6icwcfw7anfcpqv26irsr4",
         "skill/valory/check_stop_trading_abci/0.1.0": "bafybeifho6gdnpx3j2czez4iotjhgropakiubzya6ceag556ijjqc5gfay",
-        "agent/valory/trader/0.1.0": "bafybeig2clkaul65rgkttohpj6c5dvry2brux2krjw2aua2mzxidfsjmn4",
-        "service/valory/trader/0.1.0": "bafybeib6fbaqu4k4wtediupg7fw6t53rksrnefekt6wkl3hlvu5j6qdvmq"
+        "agent/valory/trader/0.1.0": "bafybeihlc6vtlokdt4wxxt7jqto6rokydpn2xhlqpmny3cs4s76flaeeoq",
+        "service/valory/trader/0.1.0": "bafybeig5nbohr7bgf2nn6ghdw3q2ij7sms7patvvwgoqzo2nhz5q74x4oa"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeihv62fim3wl2bayavfcg3u5e5cxu3b7brtu4cn5xoxd6lqwachasi",
@@ -46,6 +46,6 @@
         "skill/valory/abstract_round_abci/0.1.0": "bafybeih3enhagoql7kzpeyzzu2scpkif6y3ubakpralfnwxcvxexdyvy5i",
         "skill/valory/transaction_settlement_abci/0.1.0": "bafybeigtzlk4uakmd54rxnznorcrstsr52kta474lgrnvx5ovr546vj7sq",
         "skill/valory/termination_abci/0.1.0": "bafybeihq6qtbwt6i53ayqym63vhjexkcppy26gguzhhjqywfmiuqghvv44",
-        "skill/valory/mech_interact_abci/0.1.0": "bafybeihovtfa2oocrx32pdq2af6ey37om7q7b2gy3kkd3azv6mjrclohsy"
+        "skill/valory/mech_interact_abci/0.1.0": "bafybeihvjtdg47pchoutcuh5l7jwiclpowriymtj7nyud22cetjjxggeiy"
     }
 }

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -13,12 +13,12 @@
         "contract/valory/transfer_nft_condition/0.1.0": "bafybeicgpoag2lymofz3vnen76q7gtig5hzimn32o57php4uerr6t25em4",
         "skill/valory/market_manager_abci/0.1.0": "bafybeidygkw7mwhbk3ry3au5c5265vms5eti375v5jthd4be5dfnnoache",
         "skill/valory/decision_maker_abci/0.1.0": "bafybeibvq365gs7ibi7bkzoqyiirdcbpros2q7z3zpsqxhbcfy5d77y7je",
-        "skill/valory/trader_abci/0.1.0": "bafybeia25dej4nrhrtahbinvilwj4wywomkuryfjhcomieubw2n4mfarjq",
+        "skill/valory/trader_abci/0.1.0": "bafybeibss6panq224ec5eecn2jh5lqzyvptahnlrtxcfz6gvej5mdtdqei",
         "skill/valory/tx_settlement_multiplexer_abci/0.1.0": "bafybeibcuvrm5fvmh7nuee4tmbof6debprdqzhvhdpzp2dbddtwva4wz3y",
         "skill/valory/staking_abci/0.1.0": "bafybeicrp3dbvxcb2wa7kdgpkxu7aqji5fwq6icwcfw7anfcpqv26irsr4",
-        "skill/valory/check_stop_trading_abci/0.1.0": "bafybeiegjhswbs4uxmyxrfppteunfhuzluigvf3b325e56vw2k764rklbu",
-        "agent/valory/trader/0.1.0": "bafybeicnz7hmbxgphadyauhn5h75jchvxyqkguhfyyd7zj54jre76usncq",
-        "service/valory/trader/0.1.0": "bafybeibtiux4p3j7pbfbdoxp6zmwkxhi6hbw3ekmpafxvk74zxse6iksbe"
+        "skill/valory/check_stop_trading_abci/0.1.0": "bafybeiedpw6gudh7ddrcfpggnbxmbfaqn57a5geg645c2ymuzwy3rtckii",
+        "agent/valory/trader/0.1.0": "bafybeieqcfsz3bgh5kkw5fg3zb7laznfv57riclspqfe4eooi4wkq5ds2e",
+        "service/valory/trader/0.1.0": "bafybeieqm5hdfk22mnqtw4onc3oyqccu6yydop7hdrmuqsucja7vvv55bq"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeihv62fim3wl2bayavfcg3u5e5cxu3b7brtu4cn5xoxd6lqwachasi",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -13,12 +13,12 @@
         "contract/valory/transfer_nft_condition/0.1.0": "bafybeicgpoag2lymofz3vnen76q7gtig5hzimn32o57php4uerr6t25em4",
         "skill/valory/market_manager_abci/0.1.0": "bafybeidygkw7mwhbk3ry3au5c5265vms5eti375v5jthd4be5dfnnoache",
         "skill/valory/decision_maker_abci/0.1.0": "bafybeigyrxb6ycg243crte5mmmut2znfhlnc43rqn3mnp3sylvf563teki",
-        "skill/valory/trader_abci/0.1.0": "bafybeie3wjbqbcgeeuxw3irtcgofwhlhsq25tz4mpgywef52m3wmtrlpwa",
+        "skill/valory/trader_abci/0.1.0": "bafybeigbex4w7e6jmuts7mmzwc466urybbkakd6walqubufocpnhqjxape",
         "skill/valory/tx_settlement_multiplexer_abci/0.1.0": "bafybeibl6b5negw35fumbvl6dvcu7dammqmac5x3htapu3p7yf7lkqr73a",
         "skill/valory/staking_abci/0.1.0": "bafybeibf565rftitlrlovlvchoe45ng72ctec74fsvrmegp3o4uepu4q2e",
-        "skill/valory/check_stop_trading_abci/0.1.0": "bafybeihd2awwfnwboe4tnb6gmrhtheg5py4m37sdqtxxn7z3wnhxxntku4",
-        "agent/valory/trader/0.1.0": "bafybeihibluqupq6si5ecm7zrbnxlrnlsnmnfsivc2jjbwguxcmptzxrxi",
-        "service/valory/trader/0.1.0": "bafybeibzjpvneeolms54grz2r5wmnomx3n5r7todil7r2u6gwtjumogxea"
+        "skill/valory/check_stop_trading_abci/0.1.0": "bafybeidqgwx3747hk3icoadjcly7ug2lp6nbg6p4afe2ziga3ph26j4e5u",
+        "agent/valory/trader/0.1.0": "bafybeifyhkayzznnniw2huazh5zuuwox3g3woj3ulgv5zt4nm6zny2ctd4",
+        "service/valory/trader/0.1.0": "bafybeiama4jq3t5tucs4uw6cokxn6ogs5cyg2obvue3mlgmpfvgxw5aaoy"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeihv62fim3wl2bayavfcg3u5e5cxu3b7brtu4cn5xoxd6lqwachasi",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -9,16 +9,16 @@
         "contract/valory/realitio_proxy/0.1.0": "bafybeidx37xzjjmapwacedgzhum6grfzhp5vhouz4zu3pvpgdy5pgb2fr4",
         "contract/valory/conditional_tokens/0.1.0": "bafybeigucumqbsk74nj4rpm4p2cpiky4dj6uws7nfmgpimuviaxcamwqnu",
         "contract/valory/agent_registry/0.1.0": "bafybeibedc7ehebk3ikr4cowjbvgpxqpu65nforgqmraxqxiq5jv6rboqe",
-        "contract/valory/service_staking_token/0.1.0": "bafybeibpe24zfvpipaut77tsutmednncjviqeoekxltsndovdz3ugek7bu",
+        "contract/valory/service_staking_token/0.1.0": "bafybeid44l7qekvkwkvmfl4kcqchnaktttacp7lbx464mzqqs5cnefj35e",
         "contract/valory/transfer_nft_condition/0.1.0": "bafybeicgpoag2lymofz3vnen76q7gtig5hzimn32o57php4uerr6t25em4",
         "skill/valory/market_manager_abci/0.1.0": "bafybeidygkw7mwhbk3ry3au5c5265vms5eti375v5jthd4be5dfnnoache",
-        "skill/valory/decision_maker_abci/0.1.0": "bafybeigyrxb6ycg243crte5mmmut2znfhlnc43rqn3mnp3sylvf563teki",
-        "skill/valory/trader_abci/0.1.0": "bafybeigbex4w7e6jmuts7mmzwc466urybbkakd6walqubufocpnhqjxape",
-        "skill/valory/tx_settlement_multiplexer_abci/0.1.0": "bafybeibl6b5negw35fumbvl6dvcu7dammqmac5x3htapu3p7yf7lkqr73a",
-        "skill/valory/staking_abci/0.1.0": "bafybeibf565rftitlrlovlvchoe45ng72ctec74fsvrmegp3o4uepu4q2e",
-        "skill/valory/check_stop_trading_abci/0.1.0": "bafybeidqgwx3747hk3icoadjcly7ug2lp6nbg6p4afe2ziga3ph26j4e5u",
-        "agent/valory/trader/0.1.0": "bafybeifyhkayzznnniw2huazh5zuuwox3g3woj3ulgv5zt4nm6zny2ctd4",
-        "service/valory/trader/0.1.0": "bafybeiama4jq3t5tucs4uw6cokxn6ogs5cyg2obvue3mlgmpfvgxw5aaoy"
+        "skill/valory/decision_maker_abci/0.1.0": "bafybeihl4fyyjj34kvouh3ujmekqm4vsn5eabpfsww7danwyqmfhxxlequ",
+        "skill/valory/trader_abci/0.1.0": "bafybeicwhwk7iax77ol5lpvuvftuah2yue5kbwskvw3pkb4dn3kbnxj2w4",
+        "skill/valory/tx_settlement_multiplexer_abci/0.1.0": "bafybeifmyrqtgp4duq65ag3pnbid2xlgxemefln3mshccs6dnhdtieg4la",
+        "skill/valory/staking_abci/0.1.0": "bafybeicrp3dbvxcb2wa7kdgpkxu7aqji5fwq6icwcfw7anfcpqv26irsr4",
+        "skill/valory/check_stop_trading_abci/0.1.0": "bafybeievqacjszo4u5ohfeajwzowoazdthqmdkoefookjjmvmkhbuj3yem",
+        "agent/valory/trader/0.1.0": "bafybeib7l33g4py7b5aupvdcyk2qaa7ail2zunq5vwupeb3vifrer6v2cu",
+        "service/valory/trader/0.1.0": "bafybeieujqemifkzel75ws7yz6cjr6spbpimvsuqbqi5zjbzbzh4dreiky"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeihv62fim3wl2bayavfcg3u5e5cxu3b7brtu4cn5xoxd6lqwachasi",
@@ -31,7 +31,7 @@
         "protocol/valory/ipfs/0.1.0": "bafybeiftxi2qhreewgsc5wevogi7yc5g6hbcbo4uiuaibauhv3nhfcdtvm",
         "contract/valory/gnosis_safe_proxy_factory/0.1.0": "bafybeib6podeifufgmawvicm3xyz3uaplbcrsptjzz4unpseh7qtcpar74",
         "contract/valory/gnosis_safe/0.1.0": "bafybeibq77mgzhyb23blf2eqmia3kc6io5karedfzhntvpcebeqdzrgyqa",
-        "contract/valory/mech/0.1.0": "bafybeiejdn3rqqa7smbeiypajy63um7okteimvj6bsud3gezneycmdc6te",
+        "contract/valory/mech/0.1.0": "bafybeiejkna5d7hllaxm6avsnffxfs6n4nx2lncmjz6iodkt2xhcy3mbva",
         "contract/valory/service_registry/0.1.0": "bafybeicbxmbzt757lbmyh6762lrkcrp3oeum6dk3z7pvosixasifsk6xlm",
         "contract/valory/multisend/0.1.0": "bafybeig5byt5urg2d2bsecufxe5ql7f4mezg3mekfleeh32nmuusx66p4y",
         "contract/valory/erc20/0.1.0": "bafybeigvftdxjgnlsoemst5d57cor36idywk7bwcfj2bjqijxdxo3xpurq",
@@ -46,6 +46,6 @@
         "skill/valory/abstract_round_abci/0.1.0": "bafybeih3enhagoql7kzpeyzzu2scpkif6y3ubakpralfnwxcvxexdyvy5i",
         "skill/valory/transaction_settlement_abci/0.1.0": "bafybeigtzlk4uakmd54rxnznorcrstsr52kta474lgrnvx5ovr546vj7sq",
         "skill/valory/termination_abci/0.1.0": "bafybeihq6qtbwt6i53ayqym63vhjexkcppy26gguzhhjqywfmiuqghvv44",
-        "skill/valory/mech_interact_abci/0.1.0": "bafybeig2kvyn52kskydyono5wmjsfwtzeq5pcsrtn7p72rfesjatzwgrnq"
+        "skill/valory/mech_interact_abci/0.1.0": "bafybeihovtfa2oocrx32pdq2af6ey37om7q7b2gy3kkd3azv6mjrclohsy"
     }
 }

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -13,12 +13,12 @@
         "contract/valory/transfer_nft_condition/0.1.0": "bafybeicgpoag2lymofz3vnen76q7gtig5hzimn32o57php4uerr6t25em4",
         "skill/valory/market_manager_abci/0.1.0": "bafybeidygkw7mwhbk3ry3au5c5265vms5eti375v5jthd4be5dfnnoache",
         "skill/valory/decision_maker_abci/0.1.0": "bafybeihl4fyyjj34kvouh3ujmekqm4vsn5eabpfsww7danwyqmfhxxlequ",
-        "skill/valory/trader_abci/0.1.0": "bafybeihsj6o4oxc2nwmpeim35eifuasdiqilhwzdyyixcgmd3f2myvcmp4",
+        "skill/valory/trader_abci/0.1.0": "bafybeia7a6glncfuncgnupyhfldvp2qy5fau3n72pqdqf6zorvhug7kfiq",
         "skill/valory/tx_settlement_multiplexer_abci/0.1.0": "bafybeifmyrqtgp4duq65ag3pnbid2xlgxemefln3mshccs6dnhdtieg4la",
         "skill/valory/staking_abci/0.1.0": "bafybeicrp3dbvxcb2wa7kdgpkxu7aqji5fwq6icwcfw7anfcpqv26irsr4",
-        "skill/valory/check_stop_trading_abci/0.1.0": "bafybeiexye4ibyldvivlivngz4fdlghegapvz6bjm3k6zrszmi7mv34hpy",
-        "agent/valory/trader/0.1.0": "bafybeific5t6nud2pwvvsubve65injzil3gsftb5j7kxhgefwl5w2bbczq",
-        "service/valory/trader/0.1.0": "bafybeie5i3f2jx5bpevrj6vcx7xtoz7izfpiwgyeszc3zxp4f26tia6oce"
+        "skill/valory/check_stop_trading_abci/0.1.0": "bafybeihs2yjqyqno6h5pmhrwlpgnoqunnho54p2y46ut2hmorsaz36quru",
+        "agent/valory/trader/0.1.0": "bafybeignyb7bcsysmks3v7wzspscocy5t63oc4ucpakcs5vmc2g3eebxm4",
+        "service/valory/trader/0.1.0": "bafybeihv4m7py577dfzp5nefvoqlxm5msxnc6weo53nfi6wjfdzgj6ztsu"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeihv62fim3wl2bayavfcg3u5e5cxu3b7brtu4cn5xoxd6lqwachasi",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -13,12 +13,12 @@
         "contract/valory/transfer_nft_condition/0.1.0": "bafybeicgpoag2lymofz3vnen76q7gtig5hzimn32o57php4uerr6t25em4",
         "skill/valory/market_manager_abci/0.1.0": "bafybeidygkw7mwhbk3ry3au5c5265vms5eti375v5jthd4be5dfnnoache",
         "skill/valory/decision_maker_abci/0.1.0": "bafybeihl4fyyjj34kvouh3ujmekqm4vsn5eabpfsww7danwyqmfhxxlequ",
-        "skill/valory/trader_abci/0.1.0": "bafybeibaaj3pfykph7uuphh4nb3mty6azexpdhqxtgv47pzpjl6zogx2iu",
+        "skill/valory/trader_abci/0.1.0": "bafybeihsj6o4oxc2nwmpeim35eifuasdiqilhwzdyyixcgmd3f2myvcmp4",
         "skill/valory/tx_settlement_multiplexer_abci/0.1.0": "bafybeifmyrqtgp4duq65ag3pnbid2xlgxemefln3mshccs6dnhdtieg4la",
         "skill/valory/staking_abci/0.1.0": "bafybeicrp3dbvxcb2wa7kdgpkxu7aqji5fwq6icwcfw7anfcpqv26irsr4",
-        "skill/valory/check_stop_trading_abci/0.1.0": "bafybeihxs5gjblndvzipowu3576v6sq476j52leubezge7dixqexunbh3m",
-        "agent/valory/trader/0.1.0": "bafybeihjuzydhrkyqwxk3hmmmulc5gyemq24qujwbknt6psruiovtknv34",
-        "service/valory/trader/0.1.0": "bafybeiazg6psoawy4wkfqrrlvxisp5ch6jlxo62qdvd36vo5dvedzmpi44"
+        "skill/valory/check_stop_trading_abci/0.1.0": "bafybeiexye4ibyldvivlivngz4fdlghegapvz6bjm3k6zrszmi7mv34hpy",
+        "agent/valory/trader/0.1.0": "bafybeific5t6nud2pwvvsubve65injzil3gsftb5j7kxhgefwl5w2bbczq",
+        "service/valory/trader/0.1.0": "bafybeie5i3f2jx5bpevrj6vcx7xtoz7izfpiwgyeszc3zxp4f26tia6oce"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeihv62fim3wl2bayavfcg3u5e5cxu3b7brtu4cn5xoxd6lqwachasi",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -13,12 +13,12 @@
         "contract/valory/transfer_nft_condition/0.1.0": "bafybeicgpoag2lymofz3vnen76q7gtig5hzimn32o57php4uerr6t25em4",
         "skill/valory/market_manager_abci/0.1.0": "bafybeidygkw7mwhbk3ry3au5c5265vms5eti375v5jthd4be5dfnnoache",
         "skill/valory/decision_maker_abci/0.1.0": "bafybeihl4fyyjj34kvouh3ujmekqm4vsn5eabpfsww7danwyqmfhxxlequ",
-        "skill/valory/trader_abci/0.1.0": "bafybeicwhwk7iax77ol5lpvuvftuah2yue5kbwskvw3pkb4dn3kbnxj2w4",
+        "skill/valory/trader_abci/0.1.0": "bafybeiduzcdjahjrxgx4twy4mm6l55kq7skf5g33fmsztqjsw37fzpgmui",
         "skill/valory/tx_settlement_multiplexer_abci/0.1.0": "bafybeifmyrqtgp4duq65ag3pnbid2xlgxemefln3mshccs6dnhdtieg4la",
         "skill/valory/staking_abci/0.1.0": "bafybeicrp3dbvxcb2wa7kdgpkxu7aqji5fwq6icwcfw7anfcpqv26irsr4",
-        "skill/valory/check_stop_trading_abci/0.1.0": "bafybeievqacjszo4u5ohfeajwzowoazdthqmdkoefookjjmvmkhbuj3yem",
-        "agent/valory/trader/0.1.0": "bafybeib7l33g4py7b5aupvdcyk2qaa7ail2zunq5vwupeb3vifrer6v2cu",
-        "service/valory/trader/0.1.0": "bafybeieujqemifkzel75ws7yz6cjr6spbpimvsuqbqi5zjbzbzh4dreiky"
+        "skill/valory/check_stop_trading_abci/0.1.0": "bafybeiamwtr56zmm7effymgo7jwgix4nwdbhwjrjix4csrdtlyk3qoky3i",
+        "agent/valory/trader/0.1.0": "bafybeihfsry4qd7gslcavioe4l6gkxjyhqvhmy6ayih2uxi4fgqav2r3ge",
+        "service/valory/trader/0.1.0": "bafybeihwwfqhcusr57mxtlottypx7h5qqn7r6zdhmhgtrla5p4ntkfzi7i"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeihv62fim3wl2bayavfcg3u5e5cxu3b7brtu4cn5xoxd6lqwachasi",

--- a/packages/valory/agents/trader/aea-config.yaml
+++ b/packages/valory/agents/trader/aea-config.yaml
@@ -46,9 +46,9 @@ skills:
 - valory/tx_settlement_multiplexer_abci:0.1.0:bafybeifmyrqtgp4duq65ag3pnbid2xlgxemefln3mshccs6dnhdtieg4la
 - valory/market_manager_abci:0.1.0:bafybeidygkw7mwhbk3ry3au5c5265vms5eti375v5jthd4be5dfnnoache
 - valory/decision_maker_abci:0.1.0:bafybeihl4fyyjj34kvouh3ujmekqm4vsn5eabpfsww7danwyqmfhxxlequ
-- valory/trader_abci:0.1.0:bafybeia7a6glncfuncgnupyhfldvp2qy5fau3n72pqdqf6zorvhug7kfiq
+- valory/trader_abci:0.1.0:bafybeidmp5fbufsvbo2jyxmh3epazeni6jxauyf7h5vssuxr74i2jlgcdi
 - valory/staking_abci:0.1.0:bafybeicrp3dbvxcb2wa7kdgpkxu7aqji5fwq6icwcfw7anfcpqv26irsr4
-- valory/check_stop_trading_abci:0.1.0:bafybeihs2yjqyqno6h5pmhrwlpgnoqunnho54p2y46ut2hmorsaz36quru
+- valory/check_stop_trading_abci:0.1.0:bafybeig7doeus3ezz57nazjmjd6qkkbkuptr3rf4btbbuxsx767jsxcnha
 - valory/mech_interact_abci:0.1.0:bafybeihovtfa2oocrx32pdq2af6ey37om7q7b2gy3kkd3azv6mjrclohsy
 customs:
 - valory/mike_strat:0.1.0:bafybeihjiol7f4ch4piwfikurdtfwzsh6qydkbsztpbwbwb2yrqdqf726m

--- a/packages/valory/agents/trader/aea-config.yaml
+++ b/packages/valory/agents/trader/aea-config.yaml
@@ -19,14 +19,13 @@ contracts:
 - valory/gnosis_safe_proxy_factory:0.1.0:bafybeib6podeifufgmawvicm3xyz3uaplbcrsptjzz4unpseh7qtcpar74
 - valory/service_registry:0.1.0:bafybeicbxmbzt757lbmyh6762lrkcrp3oeum6dk3z7pvosixasifsk6xlm
 - valory/market_maker:0.1.0:bafybeihyi42hkmu2knrunfdbunjh6j3ibfrnwj7rmqw7mm7pmerzcwzfiq
-- valory/erc20:0.1.0:bafybeigvftdxjgnlsoemst5d57cor36idywk7bwcfj2bjqijxdxo3xpurq
 - valory/multisend:0.1.0:bafybeig5byt5urg2d2bsecufxe5ql7f4mezg3mekfleeh32nmuusx66p4y
-- valory/mech:0.1.0:bafybeiejdn3rqqa7smbeiypajy63um7okteimvj6bsud3gezneycmdc6te
+- valory/mech:0.1.0:bafybeiejkna5d7hllaxm6avsnffxfs6n4nx2lncmjz6iodkt2xhcy3mbva
 - valory/conditional_tokens:0.1.0:bafybeigucumqbsk74nj4rpm4p2cpiky4dj6uws7nfmgpimuviaxcamwqnu
 - valory/realitio:0.1.0:bafybeic5ie4oodetj4krdogydvbfxg4qggc3matpiflocah626tpevpreq
 - valory/realitio_proxy:0.1.0:bafybeidx37xzjjmapwacedgzhum6grfzhp5vhouz4zu3pvpgdy5pgb2fr4
 - valory/agent_registry:0.1.0:bafybeibedc7ehebk3ikr4cowjbvgpxqpu65nforgqmraxqxiq5jv6rboqe
-- valory/service_staking_token:0.1.0:bafybeibpe24zfvpipaut77tsutmednncjviqeoekxltsndovdz3ugek7bu
+- valory/service_staking_token:0.1.0:bafybeid44l7qekvkwkvmfl4kcqchnaktttacp7lbx464mzqqs5cnefj35e
 - valory/transfer_nft_condition:0.1.0:bafybeicgpoag2lymofz3vnen76q7gtig5hzimn32o57php4uerr6t25em4
 protocols:
 - open_aea/signing:1.0.0:bafybeihv62fim3wl2bayavfcg3u5e5cxu3b7brtu4cn5xoxd6lqwachasi
@@ -44,13 +43,13 @@ skills:
 - valory/reset_pause_abci:0.1.0:bafybeidw4mbx3os3hmv7ley7b3g3gja7ydpitr7mxbjpwzxin2mzyt5yam
 - valory/termination_abci:0.1.0:bafybeihq6qtbwt6i53ayqym63vhjexkcppy26gguzhhjqywfmiuqghvv44
 - valory/transaction_settlement_abci:0.1.0:bafybeigtzlk4uakmd54rxnznorcrstsr52kta474lgrnvx5ovr546vj7sq
-- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeibl6b5negw35fumbvl6dvcu7dammqmac5x3htapu3p7yf7lkqr73a
+- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeifmyrqtgp4duq65ag3pnbid2xlgxemefln3mshccs6dnhdtieg4la
 - valory/market_manager_abci:0.1.0:bafybeidygkw7mwhbk3ry3au5c5265vms5eti375v5jthd4be5dfnnoache
-- valory/decision_maker_abci:0.1.0:bafybeigyrxb6ycg243crte5mmmut2znfhlnc43rqn3mnp3sylvf563teki
-- valory/trader_abci:0.1.0:bafybeigbex4w7e6jmuts7mmzwc466urybbkakd6walqubufocpnhqjxape
-- valory/staking_abci:0.1.0:bafybeibf565rftitlrlovlvchoe45ng72ctec74fsvrmegp3o4uepu4q2e
-- valory/check_stop_trading_abci:0.1.0:bafybeidqgwx3747hk3icoadjcly7ug2lp6nbg6p4afe2ziga3ph26j4e5u
-- valory/mech_interact_abci:0.1.0:bafybeig2kvyn52kskydyono5wmjsfwtzeq5pcsrtn7p72rfesjatzwgrnq
+- valory/decision_maker_abci:0.1.0:bafybeihl4fyyjj34kvouh3ujmekqm4vsn5eabpfsww7danwyqmfhxxlequ
+- valory/trader_abci:0.1.0:bafybeicwhwk7iax77ol5lpvuvftuah2yue5kbwskvw3pkb4dn3kbnxj2w4
+- valory/staking_abci:0.1.0:bafybeicrp3dbvxcb2wa7kdgpkxu7aqji5fwq6icwcfw7anfcpqv26irsr4
+- valory/check_stop_trading_abci:0.1.0:bafybeievqacjszo4u5ohfeajwzowoazdthqmdkoefookjjmvmkhbuj3yem
+- valory/mech_interact_abci:0.1.0:bafybeihovtfa2oocrx32pdq2af6ey37om7q7b2gy3kkd3azv6mjrclohsy
 customs:
 - valory/mike_strat:0.1.0:bafybeihjiol7f4ch4piwfikurdtfwzsh6qydkbsztpbwbwb2yrqdqf726m
 - valory/bet_amount_per_threshold:0.1.0:bafybeihufqu2ra7vud4h6g2nwahx7mvdido7ff6prwnib2tdlc4np7dw24

--- a/packages/valory/agents/trader/aea-config.yaml
+++ b/packages/valory/agents/trader/aea-config.yaml
@@ -46,9 +46,9 @@ skills:
 - valory/tx_settlement_multiplexer_abci:0.1.0:bafybeibcuvrm5fvmh7nuee4tmbof6debprdqzhvhdpzp2dbddtwva4wz3y
 - valory/market_manager_abci:0.1.0:bafybeidygkw7mwhbk3ry3au5c5265vms5eti375v5jthd4be5dfnnoache
 - valory/decision_maker_abci:0.1.0:bafybeibvq365gs7ibi7bkzoqyiirdcbpros2q7z3zpsqxhbcfy5d77y7je
-- valory/trader_abci:0.1.0:bafybeia25dej4nrhrtahbinvilwj4wywomkuryfjhcomieubw2n4mfarjq
+- valory/trader_abci:0.1.0:bafybeibss6panq224ec5eecn2jh5lqzyvptahnlrtxcfz6gvej5mdtdqei
 - valory/staking_abci:0.1.0:bafybeicrp3dbvxcb2wa7kdgpkxu7aqji5fwq6icwcfw7anfcpqv26irsr4
-- valory/check_stop_trading_abci:0.1.0:bafybeiegjhswbs4uxmyxrfppteunfhuzluigvf3b325e56vw2k764rklbu
+- valory/check_stop_trading_abci:0.1.0:bafybeiedpw6gudh7ddrcfpggnbxmbfaqn57a5geg645c2ymuzwy3rtckii
 - valory/mech_interact_abci:0.1.0:bafybeib3aytq2a5hk6vjsak3eznuilndx4p53utdylbyhcmt6ty7kk6euq
 customs:
 - valory/mike_strat:0.1.0:bafybeihjiol7f4ch4piwfikurdtfwzsh6qydkbsztpbwbwb2yrqdqf726m

--- a/packages/valory/agents/trader/aea-config.yaml
+++ b/packages/valory/agents/trader/aea-config.yaml
@@ -43,13 +43,13 @@ skills:
 - valory/reset_pause_abci:0.1.0:bafybeidw4mbx3os3hmv7ley7b3g3gja7ydpitr7mxbjpwzxin2mzyt5yam
 - valory/termination_abci:0.1.0:bafybeihq6qtbwt6i53ayqym63vhjexkcppy26gguzhhjqywfmiuqghvv44
 - valory/transaction_settlement_abci:0.1.0:bafybeigtzlk4uakmd54rxnznorcrstsr52kta474lgrnvx5ovr546vj7sq
-- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeifmyrqtgp4duq65ag3pnbid2xlgxemefln3mshccs6dnhdtieg4la
+- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeigwosmf2ltoh2wkwppgftqzucktzq2b7eiakhtclnfybpsusregde
 - valory/market_manager_abci:0.1.0:bafybeidygkw7mwhbk3ry3au5c5265vms5eti375v5jthd4be5dfnnoache
-- valory/decision_maker_abci:0.1.0:bafybeihl4fyyjj34kvouh3ujmekqm4vsn5eabpfsww7danwyqmfhxxlequ
-- valory/trader_abci:0.1.0:bafybeifheb2uynf2c2li6ldj2dpwsusp2vlctuewug3hzkky67b3rfvt3i
+- valory/decision_maker_abci:0.1.0:bafybeif64m3zztadm2jjonorlwc2lpppqmqktig4jvfvycz3w5qv6sfrpa
+- valory/trader_abci:0.1.0:bafybeia3pfyuea4wxwbtizq57vcx2tg4z6dk4i5twhhqqjwzoi5l37gkl4
 - valory/staking_abci:0.1.0:bafybeicrp3dbvxcb2wa7kdgpkxu7aqji5fwq6icwcfw7anfcpqv26irsr4
 - valory/check_stop_trading_abci:0.1.0:bafybeifho6gdnpx3j2czez4iotjhgropakiubzya6ceag556ijjqc5gfay
-- valory/mech_interact_abci:0.1.0:bafybeihovtfa2oocrx32pdq2af6ey37om7q7b2gy3kkd3azv6mjrclohsy
+- valory/mech_interact_abci:0.1.0:bafybeihvjtdg47pchoutcuh5l7jwiclpowriymtj7nyud22cetjjxggeiy
 customs:
 - valory/mike_strat:0.1.0:bafybeihjiol7f4ch4piwfikurdtfwzsh6qydkbsztpbwbwb2yrqdqf726m
 - valory/bet_amount_per_threshold:0.1.0:bafybeihufqu2ra7vud4h6g2nwahx7mvdido7ff6prwnib2tdlc4np7dw24
@@ -175,6 +175,8 @@ models:
       abt_error_mult: ${int:5}
       mech_contract_address: ${str:0x77af31De935740567Cf4fF1986D04B2c964A786a}
       request_price: ${int:null}
+      mech_chain_id: ${str:gnosis}
+      wrapped_native_token_address: ${str:0xe91D153E0b41518A2Ce8Dd3D7944Fa863463a97d}
       sample_bets_closing_days: ${int:10}
       trading_strategy: ${str:kelly_criterion}
       use_fallback_strategy: ${bool:true}

--- a/packages/valory/agents/trader/aea-config.yaml
+++ b/packages/valory/agents/trader/aea-config.yaml
@@ -43,13 +43,13 @@ skills:
 - valory/reset_pause_abci:0.1.0:bafybeidw4mbx3os3hmv7ley7b3g3gja7ydpitr7mxbjpwzxin2mzyt5yam
 - valory/termination_abci:0.1.0:bafybeihq6qtbwt6i53ayqym63vhjexkcppy26gguzhhjqywfmiuqghvv44
 - valory/transaction_settlement_abci:0.1.0:bafybeigtzlk4uakmd54rxnznorcrstsr52kta474lgrnvx5ovr546vj7sq
-- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeigwosmf2ltoh2wkwppgftqzucktzq2b7eiakhtclnfybpsusregde
+- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeibcuvrm5fvmh7nuee4tmbof6debprdqzhvhdpzp2dbddtwva4wz3y
 - valory/market_manager_abci:0.1.0:bafybeidygkw7mwhbk3ry3au5c5265vms5eti375v5jthd4be5dfnnoache
-- valory/decision_maker_abci:0.1.0:bafybeif64m3zztadm2jjonorlwc2lpppqmqktig4jvfvycz3w5qv6sfrpa
-- valory/trader_abci:0.1.0:bafybeia3pfyuea4wxwbtizq57vcx2tg4z6dk4i5twhhqqjwzoi5l37gkl4
+- valory/decision_maker_abci:0.1.0:bafybeibvq365gs7ibi7bkzoqyiirdcbpros2q7z3zpsqxhbcfy5d77y7je
+- valory/trader_abci:0.1.0:bafybeihzojyuubf3ka32ic55h2456wiptcbbh6fwwmcwo7jmh5znvjbaki
 - valory/staking_abci:0.1.0:bafybeicrp3dbvxcb2wa7kdgpkxu7aqji5fwq6icwcfw7anfcpqv26irsr4
 - valory/check_stop_trading_abci:0.1.0:bafybeifho6gdnpx3j2czez4iotjhgropakiubzya6ceag556ijjqc5gfay
-- valory/mech_interact_abci:0.1.0:bafybeihvjtdg47pchoutcuh5l7jwiclpowriymtj7nyud22cetjjxggeiy
+- valory/mech_interact_abci:0.1.0:bafybeib3aytq2a5hk6vjsak3eznuilndx4p53utdylbyhcmt6ty7kk6euq
 customs:
 - valory/mike_strat:0.1.0:bafybeihjiol7f4ch4piwfikurdtfwzsh6qydkbsztpbwbwb2yrqdqf726m
 - valory/bet_amount_per_threshold:0.1.0:bafybeihufqu2ra7vud4h6g2nwahx7mvdido7ff6prwnib2tdlc4np7dw24
@@ -174,9 +174,9 @@ models:
       average_block_time: ${int:5}
       abt_error_mult: ${int:5}
       mech_contract_address: ${str:0x77af31De935740567Cf4fF1986D04B2c964A786a}
-      request_price: ${int:null}
+      mech_request_price: ${int:null}
       mech_chain_id: ${str:gnosis}
-      wrapped_native_token_address: ${str:0xe91D153E0b41518A2Ce8Dd3D7944Fa863463a97d}
+      mech_wrapped_native_token_address: ${str:0xe91D153E0b41518A2Ce8Dd3D7944Fa863463a97d}
       sample_bets_closing_days: ${int:10}
       trading_strategy: ${str:kelly_criterion}
       use_fallback_strategy: ${bool:true}

--- a/packages/valory/agents/trader/aea-config.yaml
+++ b/packages/valory/agents/trader/aea-config.yaml
@@ -46,9 +46,9 @@ skills:
 - valory/tx_settlement_multiplexer_abci:0.1.0:bafybeifmyrqtgp4duq65ag3pnbid2xlgxemefln3mshccs6dnhdtieg4la
 - valory/market_manager_abci:0.1.0:bafybeidygkw7mwhbk3ry3au5c5265vms5eti375v5jthd4be5dfnnoache
 - valory/decision_maker_abci:0.1.0:bafybeihl4fyyjj34kvouh3ujmekqm4vsn5eabpfsww7danwyqmfhxxlequ
-- valory/trader_abci:0.1.0:bafybeihxgz7wwzipkuw673fetxzkexp2qzrysuos2od3unk4ycznz7lvai
+- valory/trader_abci:0.1.0:bafybeifheb2uynf2c2li6ldj2dpwsusp2vlctuewug3hzkky67b3rfvt3i
 - valory/staking_abci:0.1.0:bafybeicrp3dbvxcb2wa7kdgpkxu7aqji5fwq6icwcfw7anfcpqv26irsr4
-- valory/check_stop_trading_abci:0.1.0:bafybeigqdtgp44ocop6btftb5zfrq4yrjunsr5ija2dxpvpalxqmlqxzbm
+- valory/check_stop_trading_abci:0.1.0:bafybeifho6gdnpx3j2czez4iotjhgropakiubzya6ceag556ijjqc5gfay
 - valory/mech_interact_abci:0.1.0:bafybeihovtfa2oocrx32pdq2af6ey37om7q7b2gy3kkd3azv6mjrclohsy
 customs:
 - valory/mike_strat:0.1.0:bafybeihjiol7f4ch4piwfikurdtfwzsh6qydkbsztpbwbwb2yrqdqf726m

--- a/packages/valory/agents/trader/aea-config.yaml
+++ b/packages/valory/agents/trader/aea-config.yaml
@@ -47,9 +47,9 @@ skills:
 - valory/tx_settlement_multiplexer_abci:0.1.0:bafybeibl6b5negw35fumbvl6dvcu7dammqmac5x3htapu3p7yf7lkqr73a
 - valory/market_manager_abci:0.1.0:bafybeidygkw7mwhbk3ry3au5c5265vms5eti375v5jthd4be5dfnnoache
 - valory/decision_maker_abci:0.1.0:bafybeigyrxb6ycg243crte5mmmut2znfhlnc43rqn3mnp3sylvf563teki
-- valory/trader_abci:0.1.0:bafybeie3wjbqbcgeeuxw3irtcgofwhlhsq25tz4mpgywef52m3wmtrlpwa
+- valory/trader_abci:0.1.0:bafybeigbex4w7e6jmuts7mmzwc466urybbkakd6walqubufocpnhqjxape
 - valory/staking_abci:0.1.0:bafybeibf565rftitlrlovlvchoe45ng72ctec74fsvrmegp3o4uepu4q2e
-- valory/check_stop_trading_abci:0.1.0:bafybeihd2awwfnwboe4tnb6gmrhtheg5py4m37sdqtxxn7z3wnhxxntku4
+- valory/check_stop_trading_abci:0.1.0:bafybeidqgwx3747hk3icoadjcly7ug2lp6nbg6p4afe2ziga3ph26j4e5u
 - valory/mech_interact_abci:0.1.0:bafybeig2kvyn52kskydyono5wmjsfwtzeq5pcsrtn7p72rfesjatzwgrnq
 customs:
 - valory/mike_strat:0.1.0:bafybeihjiol7f4ch4piwfikurdtfwzsh6qydkbsztpbwbwb2yrqdqf726m
@@ -214,6 +214,8 @@ models:
         "0x0000000000000000000000000000000000000000"], ["order_address", "0xc7751eff5396a846e7bc83ac31d3cb7d37cb49e4"],
         ["price", "1000000000000000000"]]}
       staking_contract_address: ${str:0x2Ef503950Be67a98746F484DA0bBAdA339DF3326}
+      disable_trading: ${bool:false}
+      stop_trading_if_staking_kpi_met: ${bool:true}
       agent_balance_threshold: ${int:10000000000000000}
       refill_check_interval: ${int:10}
       tool_punishment_multiplier: ${int:1}

--- a/packages/valory/agents/trader/aea-config.yaml
+++ b/packages/valory/agents/trader/aea-config.yaml
@@ -47,8 +47,9 @@ skills:
 - valory/tx_settlement_multiplexer_abci:0.1.0:bafybeibl6b5negw35fumbvl6dvcu7dammqmac5x3htapu3p7yf7lkqr73a
 - valory/market_manager_abci:0.1.0:bafybeidygkw7mwhbk3ry3au5c5265vms5eti375v5jthd4be5dfnnoache
 - valory/decision_maker_abci:0.1.0:bafybeigyrxb6ycg243crte5mmmut2znfhlnc43rqn3mnp3sylvf563teki
-- valory/trader_abci:0.1.0:bafybeifupwnewnhskanrklryt2vxalc5jkqedr2ywt3ux6fpaugc6kuu6q
+- valory/trader_abci:0.1.0:bafybeie3wjbqbcgeeuxw3irtcgofwhlhsq25tz4mpgywef52m3wmtrlpwa
 - valory/staking_abci:0.1.0:bafybeibf565rftitlrlovlvchoe45ng72ctec74fsvrmegp3o4uepu4q2e
+- valory/check_stop_trading_abci:0.1.0:bafybeihd2awwfnwboe4tnb6gmrhtheg5py4m37sdqtxxn7z3wnhxxntku4
 - valory/mech_interact_abci:0.1.0:bafybeig2kvyn52kskydyono5wmjsfwtzeq5pcsrtn7p72rfesjatzwgrnq
 customs:
 - valory/mike_strat:0.1.0:bafybeihjiol7f4ch4piwfikurdtfwzsh6qydkbsztpbwbwb2yrqdqf726m

--- a/packages/valory/agents/trader/aea-config.yaml
+++ b/packages/valory/agents/trader/aea-config.yaml
@@ -46,9 +46,9 @@ skills:
 - valory/tx_settlement_multiplexer_abci:0.1.0:bafybeifmyrqtgp4duq65ag3pnbid2xlgxemefln3mshccs6dnhdtieg4la
 - valory/market_manager_abci:0.1.0:bafybeidygkw7mwhbk3ry3au5c5265vms5eti375v5jthd4be5dfnnoache
 - valory/decision_maker_abci:0.1.0:bafybeihl4fyyjj34kvouh3ujmekqm4vsn5eabpfsww7danwyqmfhxxlequ
-- valory/trader_abci:0.1.0:bafybeiduzcdjahjrxgx4twy4mm6l55kq7skf5g33fmsztqjsw37fzpgmui
+- valory/trader_abci:0.1.0:bafybeibaaj3pfykph7uuphh4nb3mty6azexpdhqxtgv47pzpjl6zogx2iu
 - valory/staking_abci:0.1.0:bafybeicrp3dbvxcb2wa7kdgpkxu7aqji5fwq6icwcfw7anfcpqv26irsr4
-- valory/check_stop_trading_abci:0.1.0:bafybeiamwtr56zmm7effymgo7jwgix4nwdbhwjrjix4csrdtlyk3qoky3i
+- valory/check_stop_trading_abci:0.1.0:bafybeihxs5gjblndvzipowu3576v6sq476j52leubezge7dixqexunbh3m
 - valory/mech_interact_abci:0.1.0:bafybeihovtfa2oocrx32pdq2af6ey37om7q7b2gy3kkd3azv6mjrclohsy
 customs:
 - valory/mike_strat:0.1.0:bafybeihjiol7f4ch4piwfikurdtfwzsh6qydkbsztpbwbwb2yrqdqf726m

--- a/packages/valory/agents/trader/aea-config.yaml
+++ b/packages/valory/agents/trader/aea-config.yaml
@@ -46,9 +46,9 @@ skills:
 - valory/tx_settlement_multiplexer_abci:0.1.0:bafybeifmyrqtgp4duq65ag3pnbid2xlgxemefln3mshccs6dnhdtieg4la
 - valory/market_manager_abci:0.1.0:bafybeidygkw7mwhbk3ry3au5c5265vms5eti375v5jthd4be5dfnnoache
 - valory/decision_maker_abci:0.1.0:bafybeihl4fyyjj34kvouh3ujmekqm4vsn5eabpfsww7danwyqmfhxxlequ
-- valory/trader_abci:0.1.0:bafybeihsj6o4oxc2nwmpeim35eifuasdiqilhwzdyyixcgmd3f2myvcmp4
+- valory/trader_abci:0.1.0:bafybeia7a6glncfuncgnupyhfldvp2qy5fau3n72pqdqf6zorvhug7kfiq
 - valory/staking_abci:0.1.0:bafybeicrp3dbvxcb2wa7kdgpkxu7aqji5fwq6icwcfw7anfcpqv26irsr4
-- valory/check_stop_trading_abci:0.1.0:bafybeiexye4ibyldvivlivngz4fdlghegapvz6bjm3k6zrszmi7mv34hpy
+- valory/check_stop_trading_abci:0.1.0:bafybeihs2yjqyqno6h5pmhrwlpgnoqunnho54p2y46ut2hmorsaz36quru
 - valory/mech_interact_abci:0.1.0:bafybeihovtfa2oocrx32pdq2af6ey37om7q7b2gy3kkd3azv6mjrclohsy
 customs:
 - valory/mike_strat:0.1.0:bafybeihjiol7f4ch4piwfikurdtfwzsh6qydkbsztpbwbwb2yrqdqf726m

--- a/packages/valory/agents/trader/aea-config.yaml
+++ b/packages/valory/agents/trader/aea-config.yaml
@@ -46,9 +46,9 @@ skills:
 - valory/tx_settlement_multiplexer_abci:0.1.0:bafybeibcuvrm5fvmh7nuee4tmbof6debprdqzhvhdpzp2dbddtwva4wz3y
 - valory/market_manager_abci:0.1.0:bafybeidygkw7mwhbk3ry3au5c5265vms5eti375v5jthd4be5dfnnoache
 - valory/decision_maker_abci:0.1.0:bafybeibvq365gs7ibi7bkzoqyiirdcbpros2q7z3zpsqxhbcfy5d77y7je
-- valory/trader_abci:0.1.0:bafybeih3lfegxuczo6navbdg2n365dtswjb3ekplpn4bjmk67dskeyqwuu
+- valory/trader_abci:0.1.0:bafybeia25dej4nrhrtahbinvilwj4wywomkuryfjhcomieubw2n4mfarjq
 - valory/staking_abci:0.1.0:bafybeicrp3dbvxcb2wa7kdgpkxu7aqji5fwq6icwcfw7anfcpqv26irsr4
-- valory/check_stop_trading_abci:0.1.0:bafybeiazbeawv7y6edcua6qa7z2kyckcgielwjt2metts6vuv5qecvvn4q
+- valory/check_stop_trading_abci:0.1.0:bafybeiegjhswbs4uxmyxrfppteunfhuzluigvf3b325e56vw2k764rklbu
 - valory/mech_interact_abci:0.1.0:bafybeib3aytq2a5hk6vjsak3eznuilndx4p53utdylbyhcmt6ty7kk6euq
 customs:
 - valory/mike_strat:0.1.0:bafybeihjiol7f4ch4piwfikurdtfwzsh6qydkbsztpbwbwb2yrqdqf726m

--- a/packages/valory/agents/trader/aea-config.yaml
+++ b/packages/valory/agents/trader/aea-config.yaml
@@ -46,9 +46,9 @@ skills:
 - valory/tx_settlement_multiplexer_abci:0.1.0:bafybeifmyrqtgp4duq65ag3pnbid2xlgxemefln3mshccs6dnhdtieg4la
 - valory/market_manager_abci:0.1.0:bafybeidygkw7mwhbk3ry3au5c5265vms5eti375v5jthd4be5dfnnoache
 - valory/decision_maker_abci:0.1.0:bafybeihl4fyyjj34kvouh3ujmekqm4vsn5eabpfsww7danwyqmfhxxlequ
-- valory/trader_abci:0.1.0:bafybeibaaj3pfykph7uuphh4nb3mty6azexpdhqxtgv47pzpjl6zogx2iu
+- valory/trader_abci:0.1.0:bafybeihsj6o4oxc2nwmpeim35eifuasdiqilhwzdyyixcgmd3f2myvcmp4
 - valory/staking_abci:0.1.0:bafybeicrp3dbvxcb2wa7kdgpkxu7aqji5fwq6icwcfw7anfcpqv26irsr4
-- valory/check_stop_trading_abci:0.1.0:bafybeihxs5gjblndvzipowu3576v6sq476j52leubezge7dixqexunbh3m
+- valory/check_stop_trading_abci:0.1.0:bafybeiexye4ibyldvivlivngz4fdlghegapvz6bjm3k6zrszmi7mv34hpy
 - valory/mech_interact_abci:0.1.0:bafybeihovtfa2oocrx32pdq2af6ey37om7q7b2gy3kkd3azv6mjrclohsy
 customs:
 - valory/mike_strat:0.1.0:bafybeihjiol7f4ch4piwfikurdtfwzsh6qydkbsztpbwbwb2yrqdqf726m

--- a/packages/valory/agents/trader/aea-config.yaml
+++ b/packages/valory/agents/trader/aea-config.yaml
@@ -46,9 +46,9 @@ skills:
 - valory/tx_settlement_multiplexer_abci:0.1.0:bafybeifmyrqtgp4duq65ag3pnbid2xlgxemefln3mshccs6dnhdtieg4la
 - valory/market_manager_abci:0.1.0:bafybeidygkw7mwhbk3ry3au5c5265vms5eti375v5jthd4be5dfnnoache
 - valory/decision_maker_abci:0.1.0:bafybeihl4fyyjj34kvouh3ujmekqm4vsn5eabpfsww7danwyqmfhxxlequ
-- valory/trader_abci:0.1.0:bafybeicwhwk7iax77ol5lpvuvftuah2yue5kbwskvw3pkb4dn3kbnxj2w4
+- valory/trader_abci:0.1.0:bafybeiduzcdjahjrxgx4twy4mm6l55kq7skf5g33fmsztqjsw37fzpgmui
 - valory/staking_abci:0.1.0:bafybeicrp3dbvxcb2wa7kdgpkxu7aqji5fwq6icwcfw7anfcpqv26irsr4
-- valory/check_stop_trading_abci:0.1.0:bafybeievqacjszo4u5ohfeajwzowoazdthqmdkoefookjjmvmkhbuj3yem
+- valory/check_stop_trading_abci:0.1.0:bafybeiamwtr56zmm7effymgo7jwgix4nwdbhwjrjix4csrdtlyk3qoky3i
 - valory/mech_interact_abci:0.1.0:bafybeihovtfa2oocrx32pdq2af6ey37om7q7b2gy3kkd3azv6mjrclohsy
 customs:
 - valory/mike_strat:0.1.0:bafybeihjiol7f4ch4piwfikurdtfwzsh6qydkbsztpbwbwb2yrqdqf726m

--- a/packages/valory/agents/trader/aea-config.yaml
+++ b/packages/valory/agents/trader/aea-config.yaml
@@ -46,9 +46,9 @@ skills:
 - valory/tx_settlement_multiplexer_abci:0.1.0:bafybeifmyrqtgp4duq65ag3pnbid2xlgxemefln3mshccs6dnhdtieg4la
 - valory/market_manager_abci:0.1.0:bafybeidygkw7mwhbk3ry3au5c5265vms5eti375v5jthd4be5dfnnoache
 - valory/decision_maker_abci:0.1.0:bafybeihl4fyyjj34kvouh3ujmekqm4vsn5eabpfsww7danwyqmfhxxlequ
-- valory/trader_abci:0.1.0:bafybeidmp5fbufsvbo2jyxmh3epazeni6jxauyf7h5vssuxr74i2jlgcdi
+- valory/trader_abci:0.1.0:bafybeihxgz7wwzipkuw673fetxzkexp2qzrysuos2od3unk4ycznz7lvai
 - valory/staking_abci:0.1.0:bafybeicrp3dbvxcb2wa7kdgpkxu7aqji5fwq6icwcfw7anfcpqv26irsr4
-- valory/check_stop_trading_abci:0.1.0:bafybeig7doeus3ezz57nazjmjd6qkkbkuptr3rf4btbbuxsx767jsxcnha
+- valory/check_stop_trading_abci:0.1.0:bafybeigqdtgp44ocop6btftb5zfrq4yrjunsr5ija2dxpvpalxqmlqxzbm
 - valory/mech_interact_abci:0.1.0:bafybeihovtfa2oocrx32pdq2af6ey37om7q7b2gy3kkd3azv6mjrclohsy
 customs:
 - valory/mike_strat:0.1.0:bafybeihjiol7f4ch4piwfikurdtfwzsh6qydkbsztpbwbwb2yrqdqf726m

--- a/packages/valory/agents/trader/aea-config.yaml
+++ b/packages/valory/agents/trader/aea-config.yaml
@@ -46,9 +46,9 @@ skills:
 - valory/tx_settlement_multiplexer_abci:0.1.0:bafybeibcuvrm5fvmh7nuee4tmbof6debprdqzhvhdpzp2dbddtwva4wz3y
 - valory/market_manager_abci:0.1.0:bafybeidygkw7mwhbk3ry3au5c5265vms5eti375v5jthd4be5dfnnoache
 - valory/decision_maker_abci:0.1.0:bafybeibvq365gs7ibi7bkzoqyiirdcbpros2q7z3zpsqxhbcfy5d77y7je
-- valory/trader_abci:0.1.0:bafybeihzojyuubf3ka32ic55h2456wiptcbbh6fwwmcwo7jmh5znvjbaki
+- valory/trader_abci:0.1.0:bafybeih3lfegxuczo6navbdg2n365dtswjb3ekplpn4bjmk67dskeyqwuu
 - valory/staking_abci:0.1.0:bafybeicrp3dbvxcb2wa7kdgpkxu7aqji5fwq6icwcfw7anfcpqv26irsr4
-- valory/check_stop_trading_abci:0.1.0:bafybeifho6gdnpx3j2czez4iotjhgropakiubzya6ceag556ijjqc5gfay
+- valory/check_stop_trading_abci:0.1.0:bafybeiazbeawv7y6edcua6qa7z2kyckcgielwjt2metts6vuv5qecvvn4q
 - valory/mech_interact_abci:0.1.0:bafybeib3aytq2a5hk6vjsak3eznuilndx4p53utdylbyhcmt6ty7kk6euq
 customs:
 - valory/mike_strat:0.1.0:bafybeihjiol7f4ch4piwfikurdtfwzsh6qydkbsztpbwbwb2yrqdqf726m

--- a/packages/valory/contracts/service_staking_token/contract.py
+++ b/packages/valory/contracts/service_staking_token/contract.py
@@ -122,6 +122,28 @@ class ServiceStakingTokenContract(Contract):
         return dict(data=ts)
 
     @classmethod
+    def ts_checkpoint(
+        cls,
+        ledger_api: LedgerApi,
+        contract_address: str,
+    ) -> JSONLike:
+        """Retrieve the checkpoint's timestamp."""
+        contract = cls.get_instance(ledger_api, contract_address)
+        ts_checkpoint = contract.functions.tsCheckpoint().call()
+        return dict(data=ts_checkpoint)
+
+    @classmethod
+    def liveness_ratio(
+        cls,
+        ledger_api: LedgerApi,
+        contract_address: str,
+    ) -> JSONLike:
+        """Retrieve the liveness ratio."""
+        contract = cls.get_instance(ledger_api, contract_address)
+        liveness_ratio = contract.functions.livenessRatio().call()
+        return dict(data=liveness_ratio)
+
+    @classmethod
     def get_liveness_period(
         cls,
         ledger_api: LedgerApi,

--- a/packages/valory/contracts/service_staking_token/contract.yaml
+++ b/packages/valory/contracts/service_staking_token/contract.yaml
@@ -8,7 +8,7 @@ aea_version: '>=1.0.0, <2.0.0'
 fingerprint:
   __init__.py: bafybeid3wfzglolebuo6jrrsopswzu4lk77bm76mvw3euizlsjtnt3wmgu
   build/ServiceStakingToken.json: bafybeib6frfpqtr4dfyxuylehqmic2iawofydx7u24t7j5zbrsc4m4ijoi
-  contract.py: bafybeicxwbqmiohfmbikc76cxlt5sext6ly2wmvemysr53alnp5qjq6jmm
+  contract.py: bafybeihtnccnhtqyiwqomythtuey6vdbsj5swufxl5pcu3ptepmiaolxy4
 fingerprint_ignore_patterns: []
 contracts: []
 class_name: ServiceStakingTokenContract

--- a/packages/valory/services/trader/service.yaml
+++ b/packages/valory/services/trader/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeigtuothskwyvrhfosps2bu6suauycolj67dpuxqvnicdrdu7yhtvq
 fingerprint_ignore_patterns: []
-agent: valory/trader:0.1.0:bafybeihjuzydhrkyqwxk3hmmmulc5gyemq24qujwbknt6psruiovtknv34
+agent: valory/trader:0.1.0:bafybeific5t6nud2pwvvsubve65injzil3gsftb5j7kxhgefwl5w2bbczq
 number_of_agents: 4
 deployment: {}
 ---

--- a/packages/valory/services/trader/service.yaml
+++ b/packages/valory/services/trader/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeigtuothskwyvrhfosps2bu6suauycolj67dpuxqvnicdrdu7yhtvq
 fingerprint_ignore_patterns: []
-agent: valory/trader:0.1.0:bafybeifyhkayzznnniw2huazh5zuuwox3g3woj3ulgv5zt4nm6zny2ctd4
+agent: valory/trader:0.1.0:bafybeib7l33g4py7b5aupvdcyk2qaa7ail2zunq5vwupeb3vifrer6v2cu
 number_of_agents: 4
 deployment: {}
 ---

--- a/packages/valory/services/trader/service.yaml
+++ b/packages/valory/services/trader/service.yaml
@@ -207,6 +207,8 @@ type: skill
           "stabilityai-stable-diffusion-xl-beta-v2-2-2", "stabilityai-stable-diffusion-512-v2-1",
           "stabilityai-stable-diffusion-768-v2-1"]}
         staking_contract_address: ${STAKING_CONTRACT_ADDRESS:str:0x2Ef503950Be67a98746F484DA0bBAdA339DF3326}
+        disable_trading: ${DISABLE_TRADING:bool:false}
+        stop_trading_if_staking_kpi_met: ${STOP_TRADING_IF_STAKING_KPI_MET:bool:true}
         agent_balance_threshold: ${AGENT_BALANCE_THRESHOLD:int:10000000000000000}
         refill_check_interval: ${REFILL_CHECK_INTERVAL:int:10}
         tool_punishment_multiplier: ${TOOL_PUNISHMENT_MULTIPLIER:int:1}
@@ -302,6 +304,8 @@ type: skill
           "stabilityai-stable-diffusion-xl-beta-v2-2-2", "stabilityai-stable-diffusion-512-v2-1",
           "stabilityai-stable-diffusion-768-v2-1"]}
         staking_contract_address: ${STAKING_CONTRACT_ADDRESS:str:0x2Ef503950Be67a98746F484DA0bBAdA339DF3326}
+        disable_trading: ${DISABLE_TRADING:bool:false}
+        stop_trading_if_staking_kpi_met: ${STOP_TRADING_IF_STAKING_KPI_MET:bool:true}
         agent_balance_threshold: ${AGENT_BALANCE_THRESHOLD:int:10000000000000000}
         refill_check_interval: ${REFILL_CHECK_INTERVAL:int:10}
         tool_punishment_multiplier: ${TOOL_PUNISHMENT_MULTIPLIER:int:1}
@@ -397,6 +401,8 @@ type: skill
           "stabilityai-stable-diffusion-xl-beta-v2-2-2", "stabilityai-stable-diffusion-512-v2-1",
           "stabilityai-stable-diffusion-768-v2-1"]}
         staking_contract_address: ${STAKING_CONTRACT_ADDRESS:str:0x2Ef503950Be67a98746F484DA0bBAdA339DF3326}
+        disable_trading: ${DISABLE_TRADING:bool:false}
+        stop_trading_if_staking_kpi_met: ${STOP_TRADING_IF_STAKING_KPI_MET:bool:true}
         agent_balance_threshold: ${AGENT_BALANCE_THRESHOLD:int:10000000000000000}
         refill_check_interval: ${REFILL_CHECK_INTERVAL:int:10}
         tool_punishment_multiplier: ${TOOL_PUNISHMENT_MULTIPLIER:int:1}

--- a/packages/valory/services/trader/service.yaml
+++ b/packages/valory/services/trader/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeigtuothskwyvrhfosps2bu6suauycolj67dpuxqvnicdrdu7yhtvq
 fingerprint_ignore_patterns: []
-agent: valory/trader:0.1.0:bafybeihibluqupq6si5ecm7zrbnxlrnlsnmnfsivc2jjbwguxcmptzxrxi
+agent: valory/trader:0.1.0:bafybeifyhkayzznnniw2huazh5zuuwox3g3woj3ulgv5zt4nm6zny2ctd4
 number_of_agents: 4
 deployment: {}
 ---
@@ -108,6 +108,8 @@ type: skill
           "stabilityai-stable-diffusion-xl-beta-v2-2-2", "stabilityai-stable-diffusion-512-v2-1",
           "stabilityai-stable-diffusion-768-v2-1"]}
         staking_contract_address: ${STAKING_CONTRACT_ADDRESS:str:0x2Ef503950Be67a98746F484DA0bBAdA339DF3326}
+        disable_trading: ${DISABLE_TRADING:bool:false}
+        stop_trading_if_staking_kpi_met: ${STOP_TRADING_IF_STAKING_KPI_MET:bool:true}
         agent_balance_threshold: ${AGENT_BALANCE_THRESHOLD:int:10000000000000000}
         refill_check_interval: ${REFILL_CHECK_INTERVAL:int:10}
         tool_punishment_multiplier: ${TOOL_PUNISHMENT_MULTIPLIER:int:1}

--- a/packages/valory/services/trader/service.yaml
+++ b/packages/valory/services/trader/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeigtuothskwyvrhfosps2bu6suauycolj67dpuxqvnicdrdu7yhtvq
 fingerprint_ignore_patterns: []
-agent: valory/trader:0.1.0:bafybeiexvfnp2wvxcon3plkx5jzpgkz36ricwioffnhpu4iueqtfbvzrpy
+agent: valory/trader:0.1.0:bafybeidq5r2wxn5qlo5rc5d4cvulhwv7udm3inforyiezkgvvkr34jmezm
 number_of_agents: 4
 deployment: {}
 ---

--- a/packages/valory/services/trader/service.yaml
+++ b/packages/valory/services/trader/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeigtuothskwyvrhfosps2bu6suauycolj67dpuxqvnicdrdu7yhtvq
 fingerprint_ignore_patterns: []
-agent: valory/trader:0.1.0:bafybeig2clkaul65rgkttohpj6c5dvry2brux2krjw2aua2mzxidfsjmn4
+agent: valory/trader:0.1.0:bafybeihlc6vtlokdt4wxxt7jqto6rokydpn2xhlqpmny3cs4s76flaeeoq
 number_of_agents: 4
 deployment: {}
 ---
@@ -81,6 +81,8 @@ type: skill
         abt_error_mult: ${ABT_ERROR_MULT:int:5}
         mech_contract_address: ${MECH_CONTRACT_ADDRESS:str:0x77af31De935740567Cf4fF1986D04B2c964A786a}
         request_price: ${REQUEST_PRICE:int:null}
+        mech_chain_id: ${MECH_CHAIN_ID:str:gnosis}
+        wrapped_native_token_address: ${WRAPPED_NATIVE_TOKEN_ADDRESS:str:0xe91D153E0b41518A2Ce8Dd3D7944Fa863463a97d}
         sample_bets_closing_days: ${SAMPLE_BETS_CLOSING_DAYS:int:10}
         trading_strategy: ${TRADING_STRATEGY:str:kelly_criterion}
         use_fallback_strategy: ${USE_FALLBACK_STRATEGY:bool:true}
@@ -180,6 +182,8 @@ type: skill
         abt_error_mult: ${ABT_ERROR_MULT:int:5}
         mech_contract_address: ${MECH_CONTRACT_ADDRESS:str:0x77af31De935740567Cf4fF1986D04B2c964A786a}
         request_price: ${REQUEST_PRICE:int:null}
+        mech_chain_id: ${MECH_CHAIN_ID:str:gnosis}
+        wrapped_native_token_address: ${WRAPPED_NATIVE_TOKEN_ADDRESS:str:0xe91D153E0b41518A2Ce8Dd3D7944Fa863463a97d}
         sample_bets_closing_days: ${SAMPLE_BETS_CLOSING_DAYS:int:10}
         trading_strategy: ${TRADING_STRATEGY:str:kelly_criterion}
         use_fallback_strategy: ${USE_FALLBACK_STRATEGY:bool:true}
@@ -277,6 +281,8 @@ type: skill
         abt_error_mult: ${ABT_ERROR_MULT:int:5}
         mech_contract_address: ${MECH_CONTRACT_ADDRESS:str:0x77af31De935740567Cf4fF1986D04B2c964A786a}
         request_price: ${REQUEST_PRICE:int:null}
+        mech_chain_id: ${MECH_CHAIN_ID:str:gnosis}
+        wrapped_native_token_address: ${WRAPPED_NATIVE_TOKEN_ADDRESS:str:0xe91D153E0b41518A2Ce8Dd3D7944Fa863463a97d}
         sample_bets_closing_days: ${SAMPLE_BETS_CLOSING_DAYS:int:10}
         trading_strategy: ${TRADING_STRATEGY:str:kelly_criterion}
         use_fallback_strategy: ${USE_FALLBACK_STRATEGY:bool:true}
@@ -374,6 +380,8 @@ type: skill
         abt_error_mult: ${ABT_ERROR_MULT:int:5}
         mech_contract_address: ${MECH_CONTRACT_ADDRESS:str:0x77af31De935740567Cf4fF1986D04B2c964A786a}
         request_price: ${REQUEST_PRICE:int:null}
+        mech_chain_id: ${MECH_CHAIN_ID:str:gnosis}
+        wrapped_native_token_address: ${WRAPPED_NATIVE_TOKEN_ADDRESS:str:0xe91D153E0b41518A2Ce8Dd3D7944Fa863463a97d}
         sample_bets_closing_days: ${SAMPLE_BETS_CLOSING_DAYS:int:10}
         trading_strategy: ${TRADING_STRATEGY:str:kelly_criterion}
         use_fallback_strategy: ${USE_FALLBACK_STRATEGY:bool:true}

--- a/packages/valory/services/trader/service.yaml
+++ b/packages/valory/services/trader/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeigtuothskwyvrhfosps2bu6suauycolj67dpuxqvnicdrdu7yhtvq
 fingerprint_ignore_patterns: []
-agent: valory/trader:0.1.0:bafybeibrtndmvq3sqnd6sznqreukjfe5776q25e4lqqscayznzjdrgfuu4
+agent: valory/trader:0.1.0:bafybeig2clkaul65rgkttohpj6c5dvry2brux2krjw2aua2mzxidfsjmn4
 number_of_agents: 4
 deployment: {}
 ---

--- a/packages/valory/services/trader/service.yaml
+++ b/packages/valory/services/trader/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeigtuothskwyvrhfosps2bu6suauycolj67dpuxqvnicdrdu7yhtvq
 fingerprint_ignore_patterns: []
-agent: valory/trader:0.1.0:bafybeihfsry4qd7gslcavioe4l6gkxjyhqvhmy6ayih2uxi4fgqav2r3ge
+agent: valory/trader:0.1.0:bafybeihjuzydhrkyqwxk3hmmmulc5gyemq24qujwbknt6psruiovtknv34
 number_of_agents: 4
 deployment: {}
 ---

--- a/packages/valory/services/trader/service.yaml
+++ b/packages/valory/services/trader/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeigtuothskwyvrhfosps2bu6suauycolj67dpuxqvnicdrdu7yhtvq
 fingerprint_ignore_patterns: []
-agent: valory/trader:0.1.0:bafybeihlc6vtlokdt4wxxt7jqto6rokydpn2xhlqpmny3cs4s76flaeeoq
+agent: valory/trader:0.1.0:bafybeiexvfnp2wvxcon3plkx5jzpgkz36ricwioffnhpu4iueqtfbvzrpy
 number_of_agents: 4
 deployment: {}
 ---
@@ -80,9 +80,9 @@ type: skill
         average_block_time: ${ABT:int:5}
         abt_error_mult: ${ABT_ERROR_MULT:int:5}
         mech_contract_address: ${MECH_CONTRACT_ADDRESS:str:0x77af31De935740567Cf4fF1986D04B2c964A786a}
-        request_price: ${REQUEST_PRICE:int:null}
+        mech_request_price: ${MECH_REQUEST_PRICE:int:null}
         mech_chain_id: ${MECH_CHAIN_ID:str:gnosis}
-        wrapped_native_token_address: ${WRAPPED_NATIVE_TOKEN_ADDRESS:str:0xe91D153E0b41518A2Ce8Dd3D7944Fa863463a97d}
+        mech_wrapped_native_token_address: ${MECH_WRAPPED_NATIVE_TOKEN_ADDRESS:str:0xe91D153E0b41518A2Ce8Dd3D7944Fa863463a97d}
         sample_bets_closing_days: ${SAMPLE_BETS_CLOSING_DAYS:int:10}
         trading_strategy: ${TRADING_STRATEGY:str:kelly_criterion}
         use_fallback_strategy: ${USE_FALLBACK_STRATEGY:bool:true}
@@ -181,9 +181,9 @@ type: skill
         average_block_time: ${ABT:int:5}
         abt_error_mult: ${ABT_ERROR_MULT:int:5}
         mech_contract_address: ${MECH_CONTRACT_ADDRESS:str:0x77af31De935740567Cf4fF1986D04B2c964A786a}
-        request_price: ${REQUEST_PRICE:int:null}
+        mech_request_price: ${MECH_REQUEST_PRICE:int:null}
         mech_chain_id: ${MECH_CHAIN_ID:str:gnosis}
-        wrapped_native_token_address: ${WRAPPED_NATIVE_TOKEN_ADDRESS:str:0xe91D153E0b41518A2Ce8Dd3D7944Fa863463a97d}
+        mech_wrapped_native_token_address: ${MECH_WRAPPED_NATIVE_TOKEN_ADDRESS:str:0xe91D153E0b41518A2Ce8Dd3D7944Fa863463a97d}
         sample_bets_closing_days: ${SAMPLE_BETS_CLOSING_DAYS:int:10}
         trading_strategy: ${TRADING_STRATEGY:str:kelly_criterion}
         use_fallback_strategy: ${USE_FALLBACK_STRATEGY:bool:true}
@@ -280,9 +280,9 @@ type: skill
         average_block_time: ${ABT:int:5}
         abt_error_mult: ${ABT_ERROR_MULT:int:5}
         mech_contract_address: ${MECH_CONTRACT_ADDRESS:str:0x77af31De935740567Cf4fF1986D04B2c964A786a}
-        request_price: ${REQUEST_PRICE:int:null}
+        mech_request_price: ${MECH_REQUEST_PRICE:int:null}
         mech_chain_id: ${MECH_CHAIN_ID:str:gnosis}
-        wrapped_native_token_address: ${WRAPPED_NATIVE_TOKEN_ADDRESS:str:0xe91D153E0b41518A2Ce8Dd3D7944Fa863463a97d}
+        mech_wrapped_native_token_address: ${MECH_WRAPPED_NATIVE_TOKEN_ADDRESS:str:0xe91D153E0b41518A2Ce8Dd3D7944Fa863463a97d}
         sample_bets_closing_days: ${SAMPLE_BETS_CLOSING_DAYS:int:10}
         trading_strategy: ${TRADING_STRATEGY:str:kelly_criterion}
         use_fallback_strategy: ${USE_FALLBACK_STRATEGY:bool:true}
@@ -379,9 +379,9 @@ type: skill
         average_block_time: ${ABT:int:5}
         abt_error_mult: ${ABT_ERROR_MULT:int:5}
         mech_contract_address: ${MECH_CONTRACT_ADDRESS:str:0x77af31De935740567Cf4fF1986D04B2c964A786a}
-        request_price: ${REQUEST_PRICE:int:null}
+        mech_request_price: ${MECH_REQUEST_PRICE:int:null}
         mech_chain_id: ${MECH_CHAIN_ID:str:gnosis}
-        wrapped_native_token_address: ${WRAPPED_NATIVE_TOKEN_ADDRESS:str:0xe91D153E0b41518A2Ce8Dd3D7944Fa863463a97d}
+        mech_wrapped_native_token_address: ${MECH_WRAPPED_NATIVE_TOKEN_ADDRESS:str:0xe91D153E0b41518A2Ce8Dd3D7944Fa863463a97d}
         sample_bets_closing_days: ${SAMPLE_BETS_CLOSING_DAYS:int:10}
         trading_strategy: ${TRADING_STRATEGY:str:kelly_criterion}
         use_fallback_strategy: ${USE_FALLBACK_STRATEGY:bool:true}

--- a/packages/valory/services/trader/service.yaml
+++ b/packages/valory/services/trader/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeigtuothskwyvrhfosps2bu6suauycolj67dpuxqvnicdrdu7yhtvq
 fingerprint_ignore_patterns: []
-agent: valory/trader:0.1.0:bafybeidq5r2wxn5qlo5rc5d4cvulhwv7udm3inforyiezkgvvkr34jmezm
+agent: valory/trader:0.1.0:bafybeicnz7hmbxgphadyauhn5h75jchvxyqkguhfyyd7zj54jre76usncq
 number_of_agents: 4
 deployment: {}
 ---

--- a/packages/valory/services/trader/service.yaml
+++ b/packages/valory/services/trader/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeigtuothskwyvrhfosps2bu6suauycolj67dpuxqvnicdrdu7yhtvq
 fingerprint_ignore_patterns: []
-agent: valory/trader:0.1.0:bafybeidxsseryfymbqeg67ezacy74p3e2i3sslz6fkiebf4lqmjxrx7zse
+agent: valory/trader:0.1.0:bafybeibrtndmvq3sqnd6sznqreukjfe5776q25e4lqqscayznzjdrgfuu4
 number_of_agents: 4
 deployment: {}
 ---

--- a/packages/valory/services/trader/service.yaml
+++ b/packages/valory/services/trader/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeigtuothskwyvrhfosps2bu6suauycolj67dpuxqvnicdrdu7yhtvq
 fingerprint_ignore_patterns: []
-agent: valory/trader:0.1.0:bafybeicxc3v3ungi6qindlyayahmngk23xf6carthxilva3jmd3jdkn3mu
+agent: valory/trader:0.1.0:bafybeihibluqupq6si5ecm7zrbnxlrnlsnmnfsivc2jjbwguxcmptzxrxi
 number_of_agents: 4
 deployment: {}
 ---

--- a/packages/valory/services/trader/service.yaml
+++ b/packages/valory/services/trader/service.yaml
@@ -79,7 +79,7 @@ type: skill
         languages: ${LANGUAGES:list:["en_US"]}
         average_block_time: ${ABT:int:5}
         abt_error_mult: ${ABT_ERROR_MULT:int:5}
-        mech_contract_address: ${MECH_CONTRACT_ADDRESS:str:0x77af31de935740567cf4ff1986d04b2c964a786a}
+        mech_contract_address: ${MECH_CONTRACT_ADDRESS:str:0x77af31De935740567Cf4fF1986D04B2c964A786a}
         request_price: ${REQUEST_PRICE:int:null}
         sample_bets_closing_days: ${SAMPLE_BETS_CLOSING_DAYS:int:10}
         trading_strategy: ${TRADING_STRATEGY:str:kelly_criterion}
@@ -176,7 +176,7 @@ type: skill
         languages: ${LANGUAGES:list:["en_US"]}
         average_block_time: ${ABT:int:5}
         abt_error_mult: ${ABT_ERROR_MULT:int:5}
-        mech_contract_address: ${MECH_CONTRACT_ADDRESS:str:0x77af31de935740567cf4ff1986d04b2c964a786a}
+        mech_contract_address: ${MECH_CONTRACT_ADDRESS:str:0x77af31De935740567Cf4fF1986D04B2c964A786a}
         request_price: ${REQUEST_PRICE:int:null}
         sample_bets_closing_days: ${SAMPLE_BETS_CLOSING_DAYS:int:10}
         trading_strategy: ${TRADING_STRATEGY:str:kelly_criterion}
@@ -271,7 +271,7 @@ type: skill
         languages: ${LANGUAGES:list:["en_US"]}
         average_block_time: ${ABT:int:5}
         abt_error_mult: ${ABT_ERROR_MULT:int:5}
-        mech_contract_address: ${MECH_CONTRACT_ADDRESS:str:0x77af31de935740567cf4ff1986d04b2c964a786a}
+        mech_contract_address: ${MECH_CONTRACT_ADDRESS:str:0x77af31De935740567Cf4fF1986D04B2c964A786a}
         request_price: ${REQUEST_PRICE:int:null}
         sample_bets_closing_days: ${SAMPLE_BETS_CLOSING_DAYS:int:10}
         trading_strategy: ${TRADING_STRATEGY:str:kelly_criterion}
@@ -366,7 +366,7 @@ type: skill
         languages: ${LANGUAGES:list:["en_US"]}
         average_block_time: ${ABT:int:5}
         abt_error_mult: ${ABT_ERROR_MULT:int:5}
-        mech_contract_address: ${MECH_CONTRACT_ADDRESS:str:0x77af31de935740567cf4ff1986d04b2c964a786a}
+        mech_contract_address: ${MECH_CONTRACT_ADDRESS:str:0x77af31De935740567Cf4fF1986D04B2c964A786a}
         request_price: ${REQUEST_PRICE:int:null}
         sample_bets_closing_days: ${SAMPLE_BETS_CLOSING_DAYS:int:10}
         trading_strategy: ${TRADING_STRATEGY:str:kelly_criterion}

--- a/packages/valory/services/trader/service.yaml
+++ b/packages/valory/services/trader/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeigtuothskwyvrhfosps2bu6suauycolj67dpuxqvnicdrdu7yhtvq
 fingerprint_ignore_patterns: []
-agent: valory/trader:0.1.0:bafybeib7l33g4py7b5aupvdcyk2qaa7ail2zunq5vwupeb3vifrer6v2cu
+agent: valory/trader:0.1.0:bafybeihfsry4qd7gslcavioe4l6gkxjyhqvhmy6ayih2uxi4fgqav2r3ge
 number_of_agents: 4
 deployment: {}
 ---

--- a/packages/valory/services/trader/service.yaml
+++ b/packages/valory/services/trader/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeigtuothskwyvrhfosps2bu6suauycolj67dpuxqvnicdrdu7yhtvq
 fingerprint_ignore_patterns: []
-agent: valory/trader:0.1.0:bafybeignyb7bcsysmks3v7wzspscocy5t63oc4ucpakcs5vmc2g3eebxm4
+agent: valory/trader:0.1.0:bafybeidxsseryfymbqeg67ezacy74p3e2i3sslz6fkiebf4lqmjxrx7zse
 number_of_agents: 4
 deployment: {}
 ---

--- a/packages/valory/services/trader/service.yaml
+++ b/packages/valory/services/trader/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeigtuothskwyvrhfosps2bu6suauycolj67dpuxqvnicdrdu7yhtvq
 fingerprint_ignore_patterns: []
-agent: valory/trader:0.1.0:bafybeicnz7hmbxgphadyauhn5h75jchvxyqkguhfyyd7zj54jre76usncq
+agent: valory/trader:0.1.0:bafybeieqcfsz3bgh5kkw5fg3zb7laznfv57riclspqfe4eooi4wkq5ds2e
 number_of_agents: 4
 deployment: {}
 ---

--- a/packages/valory/services/trader/service.yaml
+++ b/packages/valory/services/trader/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeigtuothskwyvrhfosps2bu6suauycolj67dpuxqvnicdrdu7yhtvq
 fingerprint_ignore_patterns: []
-agent: valory/trader:0.1.0:bafybeific5t6nud2pwvvsubve65injzil3gsftb5j7kxhgefwl5w2bbczq
+agent: valory/trader:0.1.0:bafybeignyb7bcsysmks3v7wzspscocy5t63oc4ucpakcs5vmc2g3eebxm4
 number_of_agents: 4
 deployment: {}
 ---

--- a/packages/valory/skills/check_stop_trading_abci/README.md
+++ b/packages/valory/skills/check_stop_trading_abci/README.md
@@ -1,0 +1,5 @@
+# Check stop trading abci
+
+## Description
+
+This module contains the check stop trading skill for an AEA.

--- a/packages/valory/skills/check_stop_trading_abci/README.md
+++ b/packages/valory/skills/check_stop_trading_abci/README.md
@@ -2,4 +2,4 @@
 
 ## Description
 
-This module contains the check stop trading skill for an AEA.
+This package contains the check stop trading skill for an AEA.

--- a/packages/valory/skills/check_stop_trading_abci/__init__.py
+++ b/packages/valory/skills/check_stop_trading_abci/__init__.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+# ------------------------------------------------------------------------------
+#
+#   Copyright 2024 Valory AG
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ------------------------------------------------------------------------------
+
+"""This module contains the check stop trading skill for an AEA."""
+
+from aea.configurations.base import PublicId
+
+
+PUBLIC_ID = PublicId.from_str("valory/check_stop_trading_abci:0.1.0")

--- a/packages/valory/skills/check_stop_trading_abci/behaviours.py
+++ b/packages/valory/skills/check_stop_trading_abci/behaviours.py
@@ -1,0 +1,85 @@
+# -*- coding: utf-8 -*-
+# ------------------------------------------------------------------------------
+#
+#   Copyright 2024 Valory AG
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ------------------------------------------------------------------------------
+
+"""This module contains the behaviours for the check stop trading skill."""
+
+from datetime import datetime, timedelta
+from typing import Any, Callable, Generator, Optional, Set, Type, cast
+
+from aea.configurations.data_types import PublicId
+
+from packages.valory.contracts.gnosis_safe.contract import GnosisSafeContract
+from packages.valory.contracts.service_staking_token.contract import (
+    ServiceStakingTokenContract,
+    StakingState,
+)
+from packages.valory.protocols.contract_api import ContractApiMessage
+from packages.valory.skills.abstract_round_abci.base import get_name
+from packages.valory.skills.abstract_round_abci.behaviour_utils import (
+    BaseBehaviour,
+    TimeoutException,
+)
+from packages.valory.skills.abstract_round_abci.behaviours import AbstractRoundBehaviour
+from packages.valory.skills.check_stop_trading_abci.models import CheckStopTradingParams
+from packages.valory.skills.check_stop_trading_abci.payloads import CheckStopTradingPayload
+from packages.valory.skills.check_stop_trading_abci.rounds import (
+    CheckStopTradingRound,
+    CheckStopTradingAbciApp,
+    SynchronizedData,
+)
+
+
+WaitableConditionType = Generator[None, None, bool]
+
+
+class CheckStopTradingBehaviour(BaseBehaviour):
+    """A behaviour that checks stop trading conditions."""
+
+    matching_round = CheckStopTradingRound
+
+    @property
+    def params(self) -> CheckStopTradingParams:
+        """Return the params."""
+        return cast(CheckStopTradingParams, self.context.params)
+
+    def async_act(self) -> Generator:
+        """Do the action."""
+        with self.context.benchmark_tool.measure(self.behaviour_id).local():
+            stop_trading = self.params.disable_trading
+            self.context.logger.info(
+                f"self.params.disable_trading={self.params.disable_trading}"
+            )
+
+            self.context.logger.info(f"stop_trading={stop_trading}")
+            payload = CheckStopTradingPayload(
+                self.context.agent_address, stop_trading
+            )
+
+        with self.context.benchmark_tool.measure(self.behaviour_id).consensus():
+            yield from self.send_a2a_transaction(payload)
+            yield from self.wait_until_round_end()
+            self.set_done()
+
+
+class CheckStopTradingRoundBehaviour(AbstractRoundBehaviour):
+    """This behaviour manages the consensus stages for the check stop trading behaviour."""
+
+    initial_behaviour_cls = CheckStopTradingBehaviour
+    abci_app_cls = CheckStopTradingAbciApp
+    behaviours: Set[Type[BaseBehaviour]] = {CheckStopTradingBehaviour}  # type: ignore

--- a/packages/valory/skills/check_stop_trading_abci/behaviours.py
+++ b/packages/valory/skills/check_stop_trading_abci/behaviours.py
@@ -39,6 +39,13 @@ from packages.valory.skills.staking_abci.behaviours import (
 from packages.valory.contracts.service_staking_token.contract import StakingState
 
 
+# Liveness ratio from the staking contract is expressed in calls per 10**18 seconds.
+LIVENESS_RATIO_SCALE_FACTOR = 10**18
+
+# A safety margin in case there is a delay between the moment the KPI condition is
+# satisfied, and the moment where the checkpoint is called.
+REQUIRED_MECH_REQUESTS_SAFETY_MARGIN = 1
+
 class CheckStopTradingBehaviour(StakingInteractBaseBehaviour):
     """A behaviour that checks stop trading conditions."""
 
@@ -110,9 +117,9 @@ class CheckStopTradingBehaviour(StakingInteractBaseBehaviour):
         self.context.logger.info(f"{current_timestamp=}")
 
         required_mech_requests = math.ceil(max(
-            (current_timestamp - last_ts_checkpoint) * liveness_ratio / 10**18,
-            (liveness_period) * liveness_ratio / 10**18
-        )) + 1
+            (current_timestamp - last_ts_checkpoint) * liveness_ratio / LIVENESS_RATIO_SCALE_FACTOR,
+            (liveness_period) * liveness_ratio / LIVENESS_RATIO_SCALE_FACTOR
+        )) + REQUIRED_MECH_REQUESTS_SAFETY_MARGIN
         self.context.logger.info(f"{required_mech_requests=}")
 
         if mech_requests_since_last_cp >= required_mech_requests:

--- a/packages/valory/skills/check_stop_trading_abci/behaviours.py
+++ b/packages/valory/skills/check_stop_trading_abci/behaviours.py
@@ -130,13 +130,18 @@ class CheckStopTradingBehaviour(StakingInteractBaseBehaviour):
             if self.is_first_period:
                 stop_trading = False
             else:
+                stop_trading_conditions = []
+
                 disable_trading = self.params.disable_trading
                 self.context.logger.info(f"{disable_trading=}")
+                stop_trading_conditions.append(disable_trading)
 
-                staking_kpi_met = yield from self.is_staking_kpi_met()
-                self.context.logger.info(f"{staking_kpi_met=}")
+                if self.params.stop_trading_if_staking_kpi_met:
+                    staking_kpi_met = yield from self.is_staking_kpi_met()
+                    self.context.logger.info(f"{staking_kpi_met=}")
+                    stop_trading_conditions.append(staking_kpi_met)
 
-                stop_trading = any([disable_trading, staking_kpi_met])
+                stop_trading = any(stop_trading_conditions)
 
             self.context.logger.info(f"{stop_trading=}")
             payload = CheckStopTradingPayload(

--- a/packages/valory/skills/check_stop_trading_abci/behaviours.py
+++ b/packages/valory/skills/check_stop_trading_abci/behaviours.py
@@ -20,7 +20,7 @@
 """This module contains the behaviours for the check stop trading skill."""
 
 import math
-from typing import Any, Generator, Set, Type, cast
+from typing import Generator, Set, Type, cast
 
 from packages.valory.contracts.mech.contract import Mech as MechContract
 from packages.valory.skills.abstract_round_abci.base import get_name
@@ -83,7 +83,7 @@ class CheckStopTradingBehaviour(StakingInteractBaseBehaviour):
         """Return the params."""
         return cast(CheckStopTradingParams, self.context.params)
 
-    def is_staking_kpi_met(self) -> WaitableConditionType:
+    def is_staking_kpi_met(self) -> Generator[None, None, bool]:
         """Return whether the staking KPI has been met (only for staked services)."""
         yield from self.wait_for_condition_with_sleep(self._check_service_staked)
         self.context.logger.debug(f"{self.service_staking_state=}")

--- a/packages/valory/skills/check_stop_trading_abci/dialogues.py
+++ b/packages/valory/skills/check_stop_trading_abci/dialogues.py
@@ -1,0 +1,81 @@
+# -*- coding: utf-8 -*-
+# ------------------------------------------------------------------------------
+#
+#   Copyright 2024 Valory AG
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ------------------------------------------------------------------------------
+
+"""This module contains the classes required for dialogue management."""
+
+from packages.valory.skills.abstract_round_abci.dialogues import (
+    AbciDialogue as BaseAbciDialogue,
+)
+from packages.valory.skills.abstract_round_abci.dialogues import (
+    AbciDialogues as BaseAbciDialogues,
+)
+from packages.valory.skills.abstract_round_abci.dialogues import (
+    ContractApiDialogue as BaseContractApiDialogue,
+)
+from packages.valory.skills.abstract_round_abci.dialogues import (
+    ContractApiDialogues as BaseContractApiDialogues,
+)
+from packages.valory.skills.abstract_round_abci.dialogues import (
+    HttpDialogue as BaseHttpDialogue,
+)
+from packages.valory.skills.abstract_round_abci.dialogues import (
+    HttpDialogues as BaseHttpDialogues,
+)
+from packages.valory.skills.abstract_round_abci.dialogues import (
+    LedgerApiDialogue as BaseLedgerApiDialogue,
+)
+from packages.valory.skills.abstract_round_abci.dialogues import (
+    LedgerApiDialogues as BaseLedgerApiDialogues,
+)
+from packages.valory.skills.abstract_round_abci.dialogues import (
+    SigningDialogue as BaseSigningDialogue,
+)
+from packages.valory.skills.abstract_round_abci.dialogues import (
+    SigningDialogues as BaseSigningDialogues,
+)
+from packages.valory.skills.abstract_round_abci.dialogues import (
+    TendermintDialogue as BaseTendermintDialogue,
+)
+from packages.valory.skills.abstract_round_abci.dialogues import (
+    TendermintDialogues as BaseTendermintDialogues,
+)
+
+
+AbciDialogue = BaseAbciDialogue
+AbciDialogues = BaseAbciDialogues
+
+
+HttpDialogue = BaseHttpDialogue
+HttpDialogues = BaseHttpDialogues
+
+
+SigningDialogue = BaseSigningDialogue
+SigningDialogues = BaseSigningDialogues
+
+
+LedgerApiDialogue = BaseLedgerApiDialogue
+LedgerApiDialogues = BaseLedgerApiDialogues
+
+
+ContractApiDialogue = BaseContractApiDialogue
+ContractApiDialogues = BaseContractApiDialogues
+
+
+TendermintDialogue = BaseTendermintDialogue
+TendermintDialogues = BaseTendermintDialogues

--- a/packages/valory/skills/check_stop_trading_abci/fsm_specification.yaml
+++ b/packages/valory/skills/check_stop_trading_abci/fsm_specification.yaml
@@ -1,0 +1,23 @@
+alphabet_in:
+- DONE
+- NONE
+- NO_MAJORITY
+- ROUND_TIMEOUT
+- SKIP_TRADING
+default_start_state: CheckStopTradingRound
+final_states:
+- FinishedCheckStopTradingRound
+- FinishedCheckStopTradingWithSkipTradingRound
+label: CheckStopTradingAbciApp
+start_states:
+- CheckStopTradingRound
+states:
+- CheckStopTradingRound
+- FinishedCheckStopTradingRound
+- FinishedCheckStopTradingWithSkipTradingRound
+transition_func:
+    (CheckStopTradingRound, DONE): FinishedCheckStopTradingRound
+    (CheckStopTradingRound, NONE): CheckStopTradingRound
+    (CheckStopTradingRound, NO_MAJORITY): CheckStopTradingRound
+    (CheckStopTradingRound, ROUND_TIMEOUT): CheckStopTradingRound
+    (CheckStopTradingRound, SKIP_TRADING): FinishedCheckStopTradingWithSkipTradingRound

--- a/packages/valory/skills/check_stop_trading_abci/fsm_specification.yaml
+++ b/packages/valory/skills/check_stop_trading_abci/fsm_specification.yaml
@@ -7,17 +7,17 @@ alphabet_in:
 default_start_state: CheckStopTradingRound
 final_states:
 - FinishedCheckStopTradingRound
-- FinishedCheckStopTradingWithSkipTradingRound
+- FinishedWithSkipTradingRound
 label: CheckStopTradingAbciApp
 start_states:
 - CheckStopTradingRound
 states:
 - CheckStopTradingRound
 - FinishedCheckStopTradingRound
-- FinishedCheckStopTradingWithSkipTradingRound
+- FinishedWithSkipTradingRound
 transition_func:
     (CheckStopTradingRound, DONE): FinishedCheckStopTradingRound
     (CheckStopTradingRound, NONE): CheckStopTradingRound
     (CheckStopTradingRound, NO_MAJORITY): CheckStopTradingRound
     (CheckStopTradingRound, ROUND_TIMEOUT): CheckStopTradingRound
-    (CheckStopTradingRound, SKIP_TRADING): FinishedCheckStopTradingWithSkipTradingRound
+    (CheckStopTradingRound, SKIP_TRADING): FinishedWithSkipTradingRound

--- a/packages/valory/skills/check_stop_trading_abci/handlers.py
+++ b/packages/valory/skills/check_stop_trading_abci/handlers.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+# ------------------------------------------------------------------------------
+#
+#   Copyright 2024 Valory AG
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ------------------------------------------------------------------------------
+
+
+"""This module contains the handlers for the check stop trading skill."""
+
+from packages.valory.skills.abstract_round_abci.handlers import ABCIRoundHandler
+from packages.valory.skills.abstract_round_abci.handlers import (
+    ContractApiHandler as BaseContractApiHandler,
+)
+from packages.valory.skills.abstract_round_abci.handlers import (
+    HttpHandler as BaseHttpHandler,
+)
+from packages.valory.skills.abstract_round_abci.handlers import (
+    LedgerApiHandler as BaseLedgerApiHandler,
+)
+from packages.valory.skills.abstract_round_abci.handlers import (
+    SigningHandler as BaseSigningHandler,
+)
+from packages.valory.skills.abstract_round_abci.handlers import (
+    TendermintHandler as BaseTendermintHandler,
+)
+
+
+ABCICheckStopTradingHandler = ABCIRoundHandler
+HttpHandler = BaseHttpHandler
+SigningHandler = BaseSigningHandler
+LedgerApiHandler = BaseLedgerApiHandler
+ContractApiHandler = BaseContractApiHandler
+TendermintHandler = BaseTendermintHandler

--- a/packages/valory/skills/check_stop_trading_abci/handlers.py
+++ b/packages/valory/skills/check_stop_trading_abci/handlers.py
@@ -28,6 +28,9 @@ from packages.valory.skills.abstract_round_abci.handlers import (
     HttpHandler as BaseHttpHandler,
 )
 from packages.valory.skills.abstract_round_abci.handlers import (
+    IpfsHandler as BaseIpfsHandler,
+)
+from packages.valory.skills.abstract_round_abci.handlers import (
     LedgerApiHandler as BaseLedgerApiHandler,
 )
 from packages.valory.skills.abstract_round_abci.handlers import (
@@ -44,3 +47,4 @@ SigningHandler = BaseSigningHandler
 LedgerApiHandler = BaseLedgerApiHandler
 ContractApiHandler = BaseContractApiHandler
 TendermintHandler = BaseTendermintHandler
+IpfsHandler = BaseIpfsHandler

--- a/packages/valory/skills/check_stop_trading_abci/models.py
+++ b/packages/valory/skills/check_stop_trading_abci/models.py
@@ -41,6 +41,7 @@ class CheckStopTradingParams(BaseParams):
     """CheckStopTrading parameters."""
 
     staking_contract_address: str
+    mech_contract_address: str
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         """Initialize the parameters' object."""

--- a/packages/valory/skills/check_stop_trading_abci/models.py
+++ b/packages/valory/skills/check_stop_trading_abci/models.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+# ------------------------------------------------------------------------------
+#
+#   Copyright 2024 Valory AG
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ------------------------------------------------------------------------------
+
+
+"""Models for the check stop trading ABCI application."""
+
+from typing import Any
+
+from packages.valory.skills.abstract_round_abci.models import BaseParams
+from packages.valory.skills.abstract_round_abci.models import (
+    BenchmarkTool as BaseBenchmarkTool,
+)
+from packages.valory.skills.abstract_round_abci.models import Requests as BaseRequests
+from packages.valory.skills.abstract_round_abci.models import (
+    SharedState as BaseSharedState,
+)
+from packages.valory.skills.check_stop_trading_abci.rounds import CheckStopTradingAbciApp
+
+
+Requests = BaseRequests
+BenchmarkTool = BaseBenchmarkTool
+
+
+class CheckStopTradingParams(BaseParams):
+    """CheckStopTrading parameters."""
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        """Initialize the parameters' object."""
+        self.staking_contract_address: str = self._ensure(
+            "staking_contract_address", kwargs, str
+        )
+        self.disable_trading: bool = self._ensure(
+            "disable_trading", kwargs, bool
+        )
+        self.stop_trading_if_staking_kpi_met: bool = self._ensure(
+            "stop_trading_if_staking_kpi_met", kwargs, bool
+        )
+        super().__init__(*args, **kwargs)
+
+
+class SharedState(BaseSharedState):
+    """Keep the current shared state of the skill."""
+
+    abci_app_cls = CheckStopTradingAbciApp

--- a/packages/valory/skills/check_stop_trading_abci/models.py
+++ b/packages/valory/skills/check_stop_trading_abci/models.py
@@ -31,17 +31,15 @@ from packages.valory.skills.abstract_round_abci.models import (
     SharedState as BaseSharedState,
 )
 from packages.valory.skills.check_stop_trading_abci.rounds import CheckStopTradingAbciApp
+from packages.valory.skills.staking_abci.models import StakingParams
 
 
 Requests = BaseRequests
 BenchmarkTool = BaseBenchmarkTool
 
 
-class CheckStopTradingParams(BaseParams):
+class CheckStopTradingParams(StakingParams):
     """CheckStopTrading parameters."""
-
-    staking_contract_address: str
-    mech_contract_address: str
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         """Initialize the parameters' object."""

--- a/packages/valory/skills/check_stop_trading_abci/models.py
+++ b/packages/valory/skills/check_stop_trading_abci/models.py
@@ -40,11 +40,14 @@ BenchmarkTool = BaseBenchmarkTool
 class CheckStopTradingParams(BaseParams):
     """CheckStopTrading parameters."""
 
+    staking_contract_address: str
+
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         """Initialize the parameters' object."""
-        self.staking_contract_address: str = self._ensure(
-            "staking_contract_address", kwargs, str
-        )
+        # TODO: inherit from staking abci?
+        #self.staking_contract_address: str = self._ensure(
+        #    "staking_contract_address", kwargs, str
+        #)
         self.disable_trading: bool = self._ensure(
             "disable_trading", kwargs, bool
         )

--- a/packages/valory/skills/check_stop_trading_abci/models.py
+++ b/packages/valory/skills/check_stop_trading_abci/models.py
@@ -45,10 +45,6 @@ class CheckStopTradingParams(BaseParams):
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         """Initialize the parameters' object."""
-        # TODO: inherit from staking abci?
-        #self.staking_contract_address: str = self._ensure(
-        #    "staking_contract_address", kwargs, str
-        #)
         self.disable_trading: bool = self._ensure(
             "disable_trading", kwargs, bool
         )

--- a/packages/valory/skills/check_stop_trading_abci/payloads.py
+++ b/packages/valory/skills/check_stop_trading_abci/payloads.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+# ------------------------------------------------------------------------------
+#
+#   Copyright 2024 Valory AG
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ------------------------------------------------------------------------------
+
+"""This module contains the transaction payloads for the check stop trading abci."""
+
+from dataclasses import dataclass
+
+from packages.valory.skills.abstract_round_abci.base import BaseTxPayload
+
+
+@dataclass(frozen=True)
+class CheckStopTradingPayload(BaseTxPayload):
+    """A transaction payload for the check stop trading abci."""
+
+    stop_trading: bool

--- a/packages/valory/skills/check_stop_trading_abci/payloads.py
+++ b/packages/valory/skills/check_stop_trading_abci/payloads.py
@@ -28,4 +28,4 @@ from packages.valory.skills.abstract_round_abci.base import BaseTxPayload
 class CheckStopTradingPayload(BaseTxPayload):
     """A transaction payload for the check stop trading abci."""
 
-    stop_trading: bool
+    vote: bool

--- a/packages/valory/skills/check_stop_trading_abci/rounds.py
+++ b/packages/valory/skills/check_stop_trading_abci/rounds.py
@@ -1,0 +1,154 @@
+# -*- coding: utf-8 -*-
+# ------------------------------------------------------------------------------
+#
+#   Copyright 2024 Valory AG
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ------------------------------------------------------------------------------
+
+"""This module contains the rounds for the check stop trading ABCI application."""
+
+from abc import ABC
+from enum import Enum
+from typing import Dict, Optional, Set, Tuple, Type, cast
+
+from packages.valory.contracts.service_staking_token.contract import StakingState
+from packages.valory.skills.abstract_round_abci.base import (
+    AbciApp,
+    AbciAppTransitionFunction,
+    AbstractRound,
+    AppState,
+    BaseSynchronizedData,
+    CollectSameUntilThresholdRound,
+    CollectionRound,
+    DegenerateRound,
+    DeserializedCollection,
+    get_name,
+)
+from packages.valory.skills.check_stop_trading_abci.payloads import CheckStopTradingPayload
+
+
+class Event(Enum):
+    """Event enumeration for the check stop trading skill."""
+
+    DONE = "done"
+    NONE = "none"
+    ROUND_TIMEOUT = "round_timeout"
+    NO_MAJORITY = "no_majority"
+    SKIP_TRADING = "skip_trading"
+
+
+class SynchronizedData(BaseSynchronizedData):
+    """Class to represent the synchronized data.
+
+    This data is replicated by the tendermint application.
+    """
+
+    def _get_deserialized(self, key: str) -> DeserializedCollection:
+        """Strictly get a collection and return it deserialized."""
+        serialized = self.db.get_strict(key)
+        return CollectionRound.deserialize_collection(serialized)
+
+    @property
+    def stop_trading(self) -> bool:
+        """Get if the service must stop trading."""
+        return bool(self.db.get("stop_trading", False))
+
+    @property
+    def participant_to_selection(self) -> DeserializedCollection:
+        """Get the participants to selection round."""
+        return self._get_deserialized("participant_to_selection")
+
+
+class CheckStopTradingRound(CollectSameUntilThresholdRound):
+    """A round for checking stop trading conditions."""
+
+    payload_class = CheckStopTradingPayload
+    synchronized_data_class = SynchronizedData
+    done_event = Event.DONE
+    none_event = Event.NONE
+    no_majority_event = Event.NO_MAJORITY
+    selection_key = (get_name(SynchronizedData.stop_trading),)
+    collection_key = get_name(SynchronizedData.participant_to_selection)
+
+    def end_block(self) -> Optional[Tuple[SynchronizedData, Enum]]:
+        """Process the end of the block."""
+        res = super().end_block()
+        if res is None:
+            return None
+
+        synced_data, event = cast(Tuple[SynchronizedData, Enum], res)
+        stop_trading_payload = self.most_voted_payload
+
+        if event == Event.DONE and stop_trading_payload == True:
+            return synced_data, Event.SKIP_TRADING
+
+        return synced_data, event
+
+
+class FinishedCheckStopTradingRound(DegenerateRound, ABC):
+    """A round that represents check stop trading has finished."""
+
+
+class FinishedCheckStopTradingWithSkipTradingRound(DegenerateRound, ABC):
+    """A round that represents check stop trading has finished with skip trading."""
+
+
+class CheckStopTradingAbciApp(AbciApp[Event]):  # pylint: disable=too-few-public-methods
+    """CheckStopTradingAbciApp
+
+    Initial round: CheckStopTradingRound
+
+    Initial states: {CheckStopTradingRound}
+
+    Transition states:
+        0. CheckStopTradingRound
+            - done: 1.
+            - none: 0.
+            - round timeout: 0.
+            - no majority: 0.
+            - skip trading: 2.
+        1. FinishedCheckStopTradingRound
+        2. FinishedCheckStopTradingWithSkipTradingRound
+
+    Final states: {FinishedCheckStopTradingRound, FinishedCheckStopTradingWithSkipTradingRound}
+
+    Timeouts:
+        round timeout: 30.0
+    """
+
+    initial_round_cls: Type[AbstractRound] = CheckStopTradingRound
+    transition_function: AbciAppTransitionFunction = {
+        CheckStopTradingRound: {
+            Event.DONE: FinishedCheckStopTradingRound,
+            Event.NONE: CheckStopTradingRound,
+            Event.ROUND_TIMEOUT: CheckStopTradingRound,
+            Event.NO_MAJORITY: CheckStopTradingRound,
+            Event.SKIP_TRADING: FinishedCheckStopTradingWithSkipTradingRound,
+        },
+        FinishedCheckStopTradingRound: {},
+        FinishedCheckStopTradingWithSkipTradingRound: {},
+    }
+    final_states: Set[AppState] = {
+        FinishedCheckStopTradingRound,
+        FinishedCheckStopTradingWithSkipTradingRound,
+    }
+    event_to_timeout: Dict[Event, float] = {
+        Event.ROUND_TIMEOUT: 30.0,
+    }
+    db_pre_conditions: Dict[AppState, Set[str]] = {CheckStopTradingRound: set()}
+    db_post_conditions: Dict[AppState, Set[str]] = {
+        FinishedCheckStopTradingRound: set(),
+        FinishedCheckStopTradingWithSkipTradingRound: set(),
+    }

--- a/packages/valory/skills/check_stop_trading_abci/rounds.py
+++ b/packages/valory/skills/check_stop_trading_abci/rounds.py
@@ -21,7 +21,7 @@
 
 from abc import ABC
 from enum import Enum
-from typing import Dict, Set, Tuple, Type, cast
+from typing import Dict, Set, Type
 
 from packages.valory.skills.abstract_round_abci.base import (
     AbciApp,
@@ -29,6 +29,7 @@ from packages.valory.skills.abstract_round_abci.base import (
     AbstractRound,
     AppState,
     BaseSynchronizedData,
+    get_name,
     VotingRound,
     CollectionRound,
     DegenerateRound,
@@ -68,6 +69,7 @@ class CheckStopTradingRound(VotingRound):
     negative_event = Event.DONE
     none_event = Event.NONE
     no_majority_event = Event.NO_MAJORITY
+    collection_key = get_name(SynchronizedData.participant_to_votes)
 
 
 class FinishedCheckStopTradingRound(DegenerateRound, ABC):

--- a/packages/valory/skills/check_stop_trading_abci/skill.yaml
+++ b/packages/valory/skills/check_stop_trading_abci/skill.yaml
@@ -14,7 +14,7 @@ fingerprint:
   handlers.py: bafybeiard64fwxib3rtyp67ymhf222uongcyqhfhdyttpsyqkmyh5ajipu
   models.py: bafybeietyrst4ng4dtncerz4cz4urqoqar5rui3mbqfeemhjns4jgxhrzy
   payloads.py: bafybeidh5bqywun4chrbsci2xbcrnnzuys5sswxwbxq3yl2ksawi3xsi5q
-  rounds.py: bafybeic5zbjlwaqerx7u5dski2ylr5pahpjftqdfmjayc6p66df3wx3zxq
+  rounds.py: bafybeieif76cskoxxi7d6rptvj6iq5joevfcpgwhm3jwzrd46rdfahb2oa
 fingerprint_ignore_patterns: []
 connections: []
 contracts:

--- a/packages/valory/skills/check_stop_trading_abci/skill.yaml
+++ b/packages/valory/skills/check_stop_trading_abci/skill.yaml
@@ -8,7 +8,7 @@ aea_version: '>=1.0.0, <2.0.0'
 fingerprint:
   README.md: bafybeicxomwratfnu3yqo5eav65ddxxrjfrzadqfgdcsp53dvft3xlv6ze
   __init__.py: bafybeifc23rlw2hzhplp3wfceixnmwq5ztnixhh7jp4dd5av3crwp3x22a
-  behaviours.py: bafybeihawg6bsggsrbbhlsplolzjgtr4ms2ypoxryp7hfugtdstf7u2jkq
+  behaviours.py: bafybeieaps6wnm7ovxljp5mlfsgldb5qkwy35hjslhlugmdg256ifhjcqy
   dialogues.py: bafybeictrrnwcijiejczy23dfvbx5kujgef3dulzqhs3etl2juvz5spm2e
   fsm_specification.yaml: bafybeiefujlpmnqdbfxntv5vwtuwinnu6furbteghbunuv2m4dtfeijvyi
   handlers.py: bafybeiard64fwxib3rtyp67ymhf222uongcyqhfhdyttpsyqkmyh5ajipu

--- a/packages/valory/skills/check_stop_trading_abci/skill.yaml
+++ b/packages/valory/skills/check_stop_trading_abci/skill.yaml
@@ -8,7 +8,7 @@ aea_version: '>=1.0.0, <2.0.0'
 fingerprint:
   README.md: bafybeif2pq7fg5upl6vmfgfzpiwsh4nbk4zaeyz6upyucqi5tasrxgq4ee
   __init__.py: bafybeifc23rlw2hzhplp3wfceixnmwq5ztnixhh7jp4dd5av3crwp3x22a
-  behaviours.py: bafybeiahuhxgagbmo672j37tndl5rmb7s6udq6dvfumam5ura4zq3nprji
+  behaviours.py: bafybeifun2lehddh6az5h7unpa5kix7vi6e2obejfhfwwzjbdhelagmeoe
   dialogues.py: bafybeictrrnwcijiejczy23dfvbx5kujgef3dulzqhs3etl2juvz5spm2e
   fsm_specification.yaml: bafybeihhau35a5xclncjpxh5lg7qiw34xs4d5qlez7dnjpkf45d3gc57ai
   handlers.py: bafybeiard64fwxib3rtyp67ymhf222uongcyqhfhdyttpsyqkmyh5ajipu

--- a/packages/valory/skills/check_stop_trading_abci/skill.yaml
+++ b/packages/valory/skills/check_stop_trading_abci/skill.yaml
@@ -6,15 +6,15 @@ description: This skill implements the check for stop trading for an AEA.
 license: Apache-2.0
 aea_version: '>=1.0.0, <2.0.0'
 fingerprint:
-  README.md: bafybeicxomwratfnu3yqo5eav65ddxxrjfrzadqfgdcsp53dvft3xlv6ze
+  README.md: bafybeif2pq7fg5upl6vmfgfzpiwsh4nbk4zaeyz6upyucqi5tasrxgq4ee
   __init__.py: bafybeifc23rlw2hzhplp3wfceixnmwq5ztnixhh7jp4dd5av3crwp3x22a
-  behaviours.py: bafybeieaps6wnm7ovxljp5mlfsgldb5qkwy35hjslhlugmdg256ifhjcqy
+  behaviours.py: bafybeifuppqvkvx276mlxsggyw3eaph3msyp573f2rmwlxyszy6fyzk7kq
   dialogues.py: bafybeictrrnwcijiejczy23dfvbx5kujgef3dulzqhs3etl2juvz5spm2e
-  fsm_specification.yaml: bafybeiefujlpmnqdbfxntv5vwtuwinnu6furbteghbunuv2m4dtfeijvyi
+  fsm_specification.yaml: bafybeihhau35a5xclncjpxh5lg7qiw34xs4d5qlez7dnjpkf45d3gc57ai
   handlers.py: bafybeiard64fwxib3rtyp67ymhf222uongcyqhfhdyttpsyqkmyh5ajipu
   models.py: bafybeiecrxmuts2whh3vz5a7thoy55ef3dkjidkdgyn6amy3uxss4x2fwa
   payloads.py: bafybeih7byn5bno2ecmm3fx3yr4iw4rdcffvnqjpovxjvzqqfi34aykoee
-  rounds.py: bafybeib5w6zlsmhf2w65le57e7dkvghunfu6b5qu5jtyoiunrgptmjgckm
+  rounds.py: bafybeifr63su5tzshv6vh4vdn4swxw3qruatwrns7flzu42bznevsxifwi
 fingerprint_ignore_patterns: []
 connections: []
 contracts:
@@ -126,7 +126,6 @@ models:
       slash_threshold_amount: 10000000000000000
       light_slash_unit_amount: 5000000000000000
       serious_slash_unit_amount: 8000000000000000
-      staking_contract_address: '0x2Ef503950Be67a98746F484DA0bBAdA339DF3326'
       disable_trading: false
       stop_trading_if_staking_kpi_met: true
     class_name: CheckStopTradingParams

--- a/packages/valory/skills/check_stop_trading_abci/skill.yaml
+++ b/packages/valory/skills/check_stop_trading_abci/skill.yaml
@@ -12,7 +12,7 @@ fingerprint:
   dialogues.py: bafybeictrrnwcijiejczy23dfvbx5kujgef3dulzqhs3etl2juvz5spm2e
   fsm_specification.yaml: bafybeiefujlpmnqdbfxntv5vwtuwinnu6furbteghbunuv2m4dtfeijvyi
   handlers.py: bafybeieo2n2khyzon3taqzo3jlsxf6lxhemu2pcszuiqfqt3p7gfqbsqzm
-  models.py: bafybeigbfnddkph4s5jwhvvd2nl5z6q7y26i2knc4btetvw2ovfwaa4nmm
+  models.py: bafybeif3ttgnf3jaxy4c47koa7tsha7yaa3d4eysvcyz4e5o5oh3jlu6ye
   payloads.py: bafybeih7byn5bno2ecmm3fx3yr4iw4rdcffvnqjpovxjvzqqfi34aykoee
   rounds.py: bafybeib5w6zlsmhf2w65le57e7dkvghunfu6b5qu5jtyoiunrgptmjgckm
 fingerprint_ignore_patterns: []

--- a/packages/valory/skills/check_stop_trading_abci/skill.yaml
+++ b/packages/valory/skills/check_stop_trading_abci/skill.yaml
@@ -11,7 +11,7 @@ fingerprint:
   behaviours.py: bafybeibuhzke27ne5es46sh35coahmg5wkqy7nbegjmvg44mhvg7xxz72e
   dialogues.py: bafybeictrrnwcijiejczy23dfvbx5kujgef3dulzqhs3etl2juvz5spm2e
   fsm_specification.yaml: bafybeiefujlpmnqdbfxntv5vwtuwinnu6furbteghbunuv2m4dtfeijvyi
-  handlers.py: bafybeieo2n2khyzon3taqzo3jlsxf6lxhemu2pcszuiqfqt3p7gfqbsqzm
+  handlers.py: bafybeiard64fwxib3rtyp67ymhf222uongcyqhfhdyttpsyqkmyh5ajipu
   models.py: bafybeid6dvmwzchqep52e3uzfrnjvd5n3sswkgqtoszkneeclcvkrgbfma
   payloads.py: bafybeih7byn5bno2ecmm3fx3yr4iw4rdcffvnqjpovxjvzqqfi34aykoee
   rounds.py: bafybeib5w6zlsmhf2w65le57e7dkvghunfu6b5qu5jtyoiunrgptmjgckm

--- a/packages/valory/skills/check_stop_trading_abci/skill.yaml
+++ b/packages/valory/skills/check_stop_trading_abci/skill.yaml
@@ -12,7 +12,7 @@ fingerprint:
   dialogues.py: bafybeictrrnwcijiejczy23dfvbx5kujgef3dulzqhs3etl2juvz5spm2e
   fsm_specification.yaml: bafybeihhau35a5xclncjpxh5lg7qiw34xs4d5qlez7dnjpkf45d3gc57ai
   handlers.py: bafybeiard64fwxib3rtyp67ymhf222uongcyqhfhdyttpsyqkmyh5ajipu
-  models.py: bafybeiecrxmuts2whh3vz5a7thoy55ef3dkjidkdgyn6amy3uxss4x2fwa
+  models.py: bafybeietyrst4ng4dtncerz4cz4urqoqar5rui3mbqfeemhjns4jgxhrzy
   payloads.py: bafybeih7byn5bno2ecmm3fx3yr4iw4rdcffvnqjpovxjvzqqfi34aykoee
   rounds.py: bafybeifr63su5tzshv6vh4vdn4swxw3qruatwrns7flzu42bznevsxifwi
 fingerprint_ignore_patterns: []

--- a/packages/valory/skills/check_stop_trading_abci/skill.yaml
+++ b/packages/valory/skills/check_stop_trading_abci/skill.yaml
@@ -12,7 +12,7 @@ fingerprint:
   dialogues.py: bafybeictrrnwcijiejczy23dfvbx5kujgef3dulzqhs3etl2juvz5spm2e
   fsm_specification.yaml: bafybeiefujlpmnqdbfxntv5vwtuwinnu6furbteghbunuv2m4dtfeijvyi
   handlers.py: bafybeiard64fwxib3rtyp67ymhf222uongcyqhfhdyttpsyqkmyh5ajipu
-  models.py: bafybeid6dvmwzchqep52e3uzfrnjvd5n3sswkgqtoszkneeclcvkrgbfma
+  models.py: bafybeiecrxmuts2whh3vz5a7thoy55ef3dkjidkdgyn6amy3uxss4x2fwa
   payloads.py: bafybeih7byn5bno2ecmm3fx3yr4iw4rdcffvnqjpovxjvzqqfi34aykoee
   rounds.py: bafybeib5w6zlsmhf2w65le57e7dkvghunfu6b5qu5jtyoiunrgptmjgckm
 fingerprint_ignore_patterns: []

--- a/packages/valory/skills/check_stop_trading_abci/skill.yaml
+++ b/packages/valory/skills/check_stop_trading_abci/skill.yaml
@@ -13,8 +13,8 @@ fingerprint:
   fsm_specification.yaml: bafybeihhau35a5xclncjpxh5lg7qiw34xs4d5qlez7dnjpkf45d3gc57ai
   handlers.py: bafybeiard64fwxib3rtyp67ymhf222uongcyqhfhdyttpsyqkmyh5ajipu
   models.py: bafybeietyrst4ng4dtncerz4cz4urqoqar5rui3mbqfeemhjns4jgxhrzy
-  payloads.py: bafybeih7byn5bno2ecmm3fx3yr4iw4rdcffvnqjpovxjvzqqfi34aykoee
-  rounds.py: bafybeifr63su5tzshv6vh4vdn4swxw3qruatwrns7flzu42bznevsxifwi
+  payloads.py: bafybeidh5bqywun4chrbsci2xbcrnnzuys5sswxwbxq3yl2ksawi3xsi5q
+  rounds.py: bafybeic5zbjlwaqerx7u5dski2ylr5pahpjftqdfmjayc6p66df3wx3zxq
 fingerprint_ignore_patterns: []
 connections: []
 contracts:

--- a/packages/valory/skills/check_stop_trading_abci/skill.yaml
+++ b/packages/valory/skills/check_stop_trading_abci/skill.yaml
@@ -24,7 +24,6 @@ protocols:
 - valory/contract_api:1.0.0:bafybeidgu7o5llh26xp3u3ebq3yluull5lupiyeu6iooi2xyymdrgnzq5i
 skills:
 - valory/abstract_round_abci:0.1.0:bafybeih3enhagoql7kzpeyzzu2scpkif6y3ubakpralfnwxcvxexdyvy5i
-- valory/transaction_settlement_abci:0.1.0:bafybeigtzlk4uakmd54rxnznorcrstsr52kta474lgrnvx5ovr546vj7sq
 behaviours:
   main:
     args: {}

--- a/packages/valory/skills/check_stop_trading_abci/skill.yaml
+++ b/packages/valory/skills/check_stop_trading_abci/skill.yaml
@@ -8,22 +8,22 @@ aea_version: '>=1.0.0, <2.0.0'
 fingerprint:
   README.md: bafybeicxomwratfnu3yqo5eav65ddxxrjfrzadqfgdcsp53dvft3xlv6ze
   __init__.py: bafybeifc23rlw2hzhplp3wfceixnmwq5ztnixhh7jp4dd5av3crwp3x22a
-  behaviours.py: bafybeihqlyxdilwnn65teagzlw76bsubscgqafupw54hwxxnpj57og4rku
+  behaviours.py: bafybeibuhzke27ne5es46sh35coahmg5wkqy7nbegjmvg44mhvg7xxz72e
   dialogues.py: bafybeictrrnwcijiejczy23dfvbx5kujgef3dulzqhs3etl2juvz5spm2e
   fsm_specification.yaml: bafybeiefujlpmnqdbfxntv5vwtuwinnu6furbteghbunuv2m4dtfeijvyi
   handlers.py: bafybeieo2n2khyzon3taqzo3jlsxf6lxhemu2pcszuiqfqt3p7gfqbsqzm
-  models.py: bafybeif3ttgnf3jaxy4c47koa7tsha7yaa3d4eysvcyz4e5o5oh3jlu6ye
+  models.py: bafybeid6dvmwzchqep52e3uzfrnjvd5n3sswkgqtoszkneeclcvkrgbfma
   payloads.py: bafybeih7byn5bno2ecmm3fx3yr4iw4rdcffvnqjpovxjvzqqfi34aykoee
   rounds.py: bafybeib5w6zlsmhf2w65le57e7dkvghunfu6b5qu5jtyoiunrgptmjgckm
 fingerprint_ignore_patterns: []
 connections: []
 contracts:
-- valory/gnosis_safe:0.1.0:bafybeibq77mgzhyb23blf2eqmia3kc6io5karedfzhntvpcebeqdzrgyqa
-- valory/service_staking_token:0.1.0:bafybeibpe24zfvpipaut77tsutmednncjviqeoekxltsndovdz3ugek7bu
-protocols:
-- valory/contract_api:1.0.0:bafybeidgu7o5llh26xp3u3ebq3yluull5lupiyeu6iooi2xyymdrgnzq5i
+- valory/service_staking_token:0.1.0:bafybeid44l7qekvkwkvmfl4kcqchnaktttacp7lbx464mzqqs5cnefj35e
+- valory/mech:0.1.0:bafybeiejkna5d7hllaxm6avsnffxfs6n4nx2lncmjz6iodkt2xhcy3mbva
+protocols: []
 skills:
 - valory/abstract_round_abci:0.1.0:bafybeih3enhagoql7kzpeyzzu2scpkif6y3ubakpralfnwxcvxexdyvy5i
+- valory/staking_abci:0.1.0:bafybeicrp3dbvxcb2wa7kdgpkxu7aqji5fwq6icwcfw7anfcpqv26irsr4
 behaviours:
   main:
     args: {}

--- a/packages/valory/skills/check_stop_trading_abci/skill.yaml
+++ b/packages/valory/skills/check_stop_trading_abci/skill.yaml
@@ -8,7 +8,7 @@ aea_version: '>=1.0.0, <2.0.0'
 fingerprint:
   README.md: bafybeif2pq7fg5upl6vmfgfzpiwsh4nbk4zaeyz6upyucqi5tasrxgq4ee
   __init__.py: bafybeifc23rlw2hzhplp3wfceixnmwq5ztnixhh7jp4dd5av3crwp3x22a
-  behaviours.py: bafybeifuppqvkvx276mlxsggyw3eaph3msyp573f2rmwlxyszy6fyzk7kq
+  behaviours.py: bafybeiahuhxgagbmo672j37tndl5rmb7s6udq6dvfumam5ura4zq3nprji
   dialogues.py: bafybeictrrnwcijiejczy23dfvbx5kujgef3dulzqhs3etl2juvz5spm2e
   fsm_specification.yaml: bafybeihhau35a5xclncjpxh5lg7qiw34xs4d5qlez7dnjpkf45d3gc57ai
   handlers.py: bafybeiard64fwxib3rtyp67ymhf222uongcyqhfhdyttpsyqkmyh5ajipu

--- a/packages/valory/skills/check_stop_trading_abci/skill.yaml
+++ b/packages/valory/skills/check_stop_trading_abci/skill.yaml
@@ -1,0 +1,144 @@
+name: check_stop_trading_abci
+author: valory
+version: 0.1.0
+type: skill
+description: This skill implements the check for stop trading for an AEA.
+license: Apache-2.0
+aea_version: '>=1.0.0, <2.0.0'
+fingerprint:
+  README.md: bafybeicxomwratfnu3yqo5eav65ddxxrjfrzadqfgdcsp53dvft3xlv6ze
+  __init__.py: bafybeifc23rlw2hzhplp3wfceixnmwq5ztnixhh7jp4dd5av3crwp3x22a
+  behaviours.py: bafybeihqlyxdilwnn65teagzlw76bsubscgqafupw54hwxxnpj57og4rku
+  dialogues.py: bafybeictrrnwcijiejczy23dfvbx5kujgef3dulzqhs3etl2juvz5spm2e
+  fsm_specification.yaml: bafybeiefujlpmnqdbfxntv5vwtuwinnu6furbteghbunuv2m4dtfeijvyi
+  handlers.py: bafybeieo2n2khyzon3taqzo3jlsxf6lxhemu2pcszuiqfqt3p7gfqbsqzm
+  models.py: bafybeigbfnddkph4s5jwhvvd2nl5z6q7y26i2knc4btetvw2ovfwaa4nmm
+  payloads.py: bafybeih7byn5bno2ecmm3fx3yr4iw4rdcffvnqjpovxjvzqqfi34aykoee
+  rounds.py: bafybeib5w6zlsmhf2w65le57e7dkvghunfu6b5qu5jtyoiunrgptmjgckm
+fingerprint_ignore_patterns: []
+connections: []
+contracts:
+- valory/gnosis_safe:0.1.0:bafybeibq77mgzhyb23blf2eqmia3kc6io5karedfzhntvpcebeqdzrgyqa
+- valory/service_staking_token:0.1.0:bafybeibpe24zfvpipaut77tsutmednncjviqeoekxltsndovdz3ugek7bu
+protocols:
+- valory/contract_api:1.0.0:bafybeidgu7o5llh26xp3u3ebq3yluull5lupiyeu6iooi2xyymdrgnzq5i
+skills:
+- valory/abstract_round_abci:0.1.0:bafybeih3enhagoql7kzpeyzzu2scpkif6y3ubakpralfnwxcvxexdyvy5i
+- valory/transaction_settlement_abci:0.1.0:bafybeigtzlk4uakmd54rxnznorcrstsr52kta474lgrnvx5ovr546vj7sq
+behaviours:
+  main:
+    args: {}
+    class_name: CheckStopTradingRoundBehaviour
+handlers:
+  abci:
+    args: {}
+    class_name: ABCICheckStopTradingHandler
+  contract_api:
+    args: {}
+    class_name: ContractApiHandler
+  http:
+    args: {}
+    class_name: HttpHandler
+  ipfs:
+    args: {}
+    class_name: IpfsHandler
+  ledger_api:
+    args: {}
+    class_name: LedgerApiHandler
+  signing:
+    args: {}
+    class_name: SigningHandler
+  tendermint:
+    args: {}
+    class_name: TendermintHandler
+models:
+  abci_dialogues:
+    args: {}
+    class_name: AbciDialogues
+  benchmark_tool:
+    args:
+      log_dir: /logs
+    class_name: BenchmarkTool
+  contract_api_dialogues:
+    args: {}
+    class_name: ContractApiDialogues
+  http_dialogues:
+    args: {}
+    class_name: HttpDialogues
+  ipfs_dialogues:
+    args: {}
+    class_name: IpfsDialogues
+  ledger_api_dialogues:
+    args: {}
+    class_name: LedgerApiDialogues
+  params:
+    args:
+      cleanup_history_depth: 1
+      cleanup_history_depth_current: null
+      drand_public_key: 868f005eb8e6e4ca0a47c8a77ceaa5309a47978a7c71bc5cce96366b5d7a569937c529eeda66c7293784a9402801af31
+      genesis_config:
+        genesis_time: '2022-05-20T16:00:21.735122717Z'
+        chain_id: chain-c4daS1
+        consensus_params:
+          block:
+            max_bytes: '22020096'
+            max_gas: '-1'
+            time_iota_ms: '1000'
+          evidence:
+            max_age_num_blocks: '100000'
+            max_age_duration: '172800000000000'
+            max_bytes: '1048576'
+          validator:
+            pub_key_types:
+            - ed25519
+          version: {}
+        voting_power: '10'
+      keeper_timeout: 30.0
+      max_attempts: 10
+      max_healthcheck: 120
+      multisend_address: '0x0000000000000000000000000000000000000000'
+      on_chain_service_id: null
+      request_retry_delay: 1.0
+      request_timeout: 10.0
+      reset_pause_duration: 10
+      reset_tendermint_after: 2
+      retry_attempts: 400
+      retry_timeout: 3
+      round_timeout_seconds: 350.0
+      service_id: check_stop_trading
+      service_registry_address: null
+      setup:
+        all_participants:
+        - '0x0000000000000000000000000000000000000000'
+        safe_contract_address: '0x0000000000000000000000000000000000000000'
+        consensus_threshold: null
+      share_tm_config_on_startup: false
+      sleep_time: 5
+      tendermint_check_sleep_delay: 3
+      tendermint_com_url: http://localhost:8080
+      tendermint_max_retries: 5
+      tendermint_p2p_url: localhost:26656
+      tendermint_url: http://localhost:26657
+      termination_sleep: 900
+      tx_timeout: 10.0
+      use_termination: false
+      use_slashing: false
+      slash_cooldown_hours: 3
+      slash_threshold_amount: 10000000000000000
+      light_slash_unit_amount: 5000000000000000
+      serious_slash_unit_amount: 8000000000000000
+      staking_contract_address: '0x2Ef503950Be67a98746F484DA0bBAdA339DF3326'
+      disable_trading: false
+      stop_trading_if_staking_kpi_met: true
+    class_name: CheckStopTradingParams
+  requests:
+    args: {}
+    class_name: Requests
+  signing_dialogues:
+    args: {}
+    class_name: SigningDialogues
+  state:
+    args: {}
+    class_name: SharedState
+dependencies: {}
+is_abstract: true

--- a/packages/valory/skills/check_stop_trading_abci/skill.yaml
+++ b/packages/valory/skills/check_stop_trading_abci/skill.yaml
@@ -8,7 +8,7 @@ aea_version: '>=1.0.0, <2.0.0'
 fingerprint:
   README.md: bafybeicxomwratfnu3yqo5eav65ddxxrjfrzadqfgdcsp53dvft3xlv6ze
   __init__.py: bafybeifc23rlw2hzhplp3wfceixnmwq5ztnixhh7jp4dd5av3crwp3x22a
-  behaviours.py: bafybeibuhzke27ne5es46sh35coahmg5wkqy7nbegjmvg44mhvg7xxz72e
+  behaviours.py: bafybeihawg6bsggsrbbhlsplolzjgtr4ms2ypoxryp7hfugtdstf7u2jkq
   dialogues.py: bafybeictrrnwcijiejczy23dfvbx5kujgef3dulzqhs3etl2juvz5spm2e
   fsm_specification.yaml: bafybeiefujlpmnqdbfxntv5vwtuwinnu6furbteghbunuv2m4dtfeijvyi
   handlers.py: bafybeiard64fwxib3rtyp67ymhf222uongcyqhfhdyttpsyqkmyh5ajipu

--- a/packages/valory/skills/decision_maker_abci/skill.yaml
+++ b/packages/valory/skills/decision_maker_abci/skill.yaml
@@ -76,7 +76,7 @@ skills:
 - valory/abstract_round_abci:0.1.0:bafybeih3enhagoql7kzpeyzzu2scpkif6y3ubakpralfnwxcvxexdyvy5i
 - valory/market_manager_abci:0.1.0:bafybeidygkw7mwhbk3ry3au5c5265vms5eti375v5jthd4be5dfnnoache
 - valory/transaction_settlement_abci:0.1.0:bafybeigtzlk4uakmd54rxnznorcrstsr52kta474lgrnvx5ovr546vj7sq
-- valory/mech_interact_abci:0.1.0:bafybeihovtfa2oocrx32pdq2af6ey37om7q7b2gy3kkd3azv6mjrclohsy
+- valory/mech_interact_abci:0.1.0:bafybeihvjtdg47pchoutcuh5l7jwiclpowriymtj7nyud22cetjjxggeiy
 behaviours:
   main:
     args: {}

--- a/packages/valory/skills/decision_maker_abci/skill.yaml
+++ b/packages/valory/skills/decision_maker_abci/skill.yaml
@@ -62,7 +62,7 @@ contracts:
 - valory/market_maker:0.1.0:bafybeihyi42hkmu2knrunfdbunjh6j3ibfrnwj7rmqw7mm7pmerzcwzfiq
 - valory/erc20:0.1.0:bafybeigvftdxjgnlsoemst5d57cor36idywk7bwcfj2bjqijxdxo3xpurq
 - valory/multisend:0.1.0:bafybeig5byt5urg2d2bsecufxe5ql7f4mezg3mekfleeh32nmuusx66p4y
-- valory/mech:0.1.0:bafybeiejdn3rqqa7smbeiypajy63um7okteimvj6bsud3gezneycmdc6te
+- valory/mech:0.1.0:bafybeiejkna5d7hllaxm6avsnffxfs6n4nx2lncmjz6iodkt2xhcy3mbva
 - valory/conditional_tokens:0.1.0:bafybeigucumqbsk74nj4rpm4p2cpiky4dj6uws7nfmgpimuviaxcamwqnu
 - valory/realitio:0.1.0:bafybeic5ie4oodetj4krdogydvbfxg4qggc3matpiflocah626tpevpreq
 - valory/realitio_proxy:0.1.0:bafybeidx37xzjjmapwacedgzhum6grfzhp5vhouz4zu3pvpgdy5pgb2fr4
@@ -76,7 +76,7 @@ skills:
 - valory/abstract_round_abci:0.1.0:bafybeih3enhagoql7kzpeyzzu2scpkif6y3ubakpralfnwxcvxexdyvy5i
 - valory/market_manager_abci:0.1.0:bafybeidygkw7mwhbk3ry3au5c5265vms5eti375v5jthd4be5dfnnoache
 - valory/transaction_settlement_abci:0.1.0:bafybeigtzlk4uakmd54rxnznorcrstsr52kta474lgrnvx5ovr546vj7sq
-- valory/mech_interact_abci:0.1.0:bafybeig2kvyn52kskydyono5wmjsfwtzeq5pcsrtn7p72rfesjatzwgrnq
+- valory/mech_interact_abci:0.1.0:bafybeihovtfa2oocrx32pdq2af6ey37om7q7b2gy3kkd3azv6mjrclohsy
 behaviours:
   main:
     args: {}

--- a/packages/valory/skills/decision_maker_abci/skill.yaml
+++ b/packages/valory/skills/decision_maker_abci/skill.yaml
@@ -76,7 +76,7 @@ skills:
 - valory/abstract_round_abci:0.1.0:bafybeih3enhagoql7kzpeyzzu2scpkif6y3ubakpralfnwxcvxexdyvy5i
 - valory/market_manager_abci:0.1.0:bafybeidygkw7mwhbk3ry3au5c5265vms5eti375v5jthd4be5dfnnoache
 - valory/transaction_settlement_abci:0.1.0:bafybeigtzlk4uakmd54rxnznorcrstsr52kta474lgrnvx5ovr546vj7sq
-- valory/mech_interact_abci:0.1.0:bafybeihvjtdg47pchoutcuh5l7jwiclpowriymtj7nyud22cetjjxggeiy
+- valory/mech_interact_abci:0.1.0:bafybeib3aytq2a5hk6vjsak3eznuilndx4p53utdylbyhcmt6ty7kk6euq
 behaviours:
   main:
     args: {}
@@ -181,7 +181,9 @@ models:
       tx_timeout: 10.0
       use_termination: false
       mech_contract_address: '0x77af31de935740567cf4ff1986d04b2c964a786a'
-      request_price: null
+      mech_request_price: null
+      mech_chain_id: gnosis
+      mech_wrapped_native_token_address: '0xe91D153E0b41518A2Ce8Dd3D7944Fa863463a97d'
       sample_bets_closing_days: 10
       trading_strategy: strategy_name
       use_fallback_strategy: true

--- a/packages/valory/skills/staking_abci/skill.yaml
+++ b/packages/valory/skills/staking_abci/skill.yaml
@@ -8,7 +8,7 @@ aea_version: '>=1.0.0, <2.0.0'
 fingerprint:
   README.md: bafybeifrpl36fddmgvniwvghqtxdzc44ry6l2zvqy37vu3y2xvwyd23ugy
   __init__.py: bafybeiageyes36ujnvvodqd5vlnihgz44rupysrk2ebbhskjkueetj6dai
-  behaviours.py: bafybeickkxb3stdbz5dwvs27t4vrji3uig673tmbl56py3tnwesydgcyn4
+  behaviours.py: bafybeibio2hl5vic3zpx4oyco2jsqfhc2nn5xyoazfjosdk4r7o5d7oj74
   dialogues.py: bafybeiebofyykseqp3fmif36cqmmyf3k7d2zbocpl6t6wnlpv4szghrxbm
   fsm_specification.yaml: bafybeicuoejmaks3ndwhbflp64kkfdkrdyn74a2fplarg4l3gxlonfmeoq
   handlers.py: bafybeichsi2y5zvzffupj2vhgagocwvnm7cbzr6jmavp656mfrzsdvkfnu
@@ -19,7 +19,7 @@ fingerprint_ignore_patterns: []
 connections: []
 contracts:
 - valory/gnosis_safe:0.1.0:bafybeibq77mgzhyb23blf2eqmia3kc6io5karedfzhntvpcebeqdzrgyqa
-- valory/service_staking_token:0.1.0:bafybeibpe24zfvpipaut77tsutmednncjviqeoekxltsndovdz3ugek7bu
+- valory/service_staking_token:0.1.0:bafybeid44l7qekvkwkvmfl4kcqchnaktttacp7lbx464mzqqs5cnefj35e
 protocols:
 - valory/contract_api:1.0.0:bafybeidgu7o5llh26xp3u3ebq3yluull5lupiyeu6iooi2xyymdrgnzq5i
 skills:

--- a/packages/valory/skills/trader_abci/behaviours.py
+++ b/packages/valory/skills/trader_abci/behaviours.py
@@ -25,6 +25,9 @@ from packages.valory.skills.abstract_round_abci.behaviours import (
     AbstractRoundBehaviour,
     BaseBehaviour,
 )
+from packages.valory.skills.check_stop_trading_abci.behaviours import (
+    CheckStopTradingRoundBehaviour,
+)
 from packages.valory.skills.decision_maker_abci.behaviours.round_behaviour import (
     AgentDecisionMakerRoundBehaviour,
 )
@@ -71,5 +74,6 @@ class TraderConsensusBehaviour(AbstractRoundBehaviour):
         *TransactionSettlementRoundBehaviour.behaviours,
         *PostTxSettlementFullBehaviour.behaviours,
         *StakingRoundBehaviour.behaviours,
+        *CheckStopTradingRoundBehaviour.behaviours,
     }
     background_behaviours_cls = {BackgroundBehaviour}  # type: ignore

--- a/packages/valory/skills/trader_abci/composition.py
+++ b/packages/valory/skills/trader_abci/composition.py
@@ -28,7 +28,7 @@ from packages.valory.skills.check_stop_trading_abci.rounds import (
     CheckStopTradingAbciApp,
     CheckStopTradingRound,
     FinishedCheckStopTradingRound,
-    FinishedCheckStopTradingWithSkipTradingRound,
+    FinishedWithSkipTradingRound,
 )
 from packages.valory.skills.decision_maker_abci.rounds import DecisionMakerAbciApp
 from packages.valory.skills.decision_maker_abci.states.claim_subscription import (
@@ -111,7 +111,7 @@ abci_app_transition_mapping: AbciAppTransitionMapping = {
     FinishedRegistrationRound: UpdateBetsRound,
     FinishedMarketManagerRound: CheckStopTradingRound,
     FinishedCheckStopTradingRound: SamplingRound,
-    FinishedCheckStopTradingWithSkipTradingRound: RedeemRound,
+    FinishedWithSkipTradingRound: RedeemRound,
     FailedMarketManagerRound: ResetAndPauseRound,
     FinishedDecisionMakerRound: PreTxSettlementRound,
     ChecksPassedRound: RandomnessTransactionSubmissionRound,

--- a/packages/valory/skills/trader_abci/composition.py
+++ b/packages/valory/skills/trader_abci/composition.py
@@ -24,6 +24,12 @@ from packages.valory.skills.abstract_round_abci.abci_app_chain import (
     chain,
 )
 from packages.valory.skills.abstract_round_abci.base import BackgroundAppConfig
+from packages.valory.skills.check_stop_trading_abci.rounds import (
+    CheckStopTradingAbciApp,
+    CheckStopTradingRound,
+    FinishedCheckStopTradingRound,
+    FinishedCheckStopTradingWithSkipTradingRound,
+)
 from packages.valory.skills.decision_maker_abci.rounds import DecisionMakerAbciApp
 from packages.valory.skills.decision_maker_abci.states.claim_subscription import (
     ClaimRound,
@@ -103,7 +109,9 @@ from packages.valory.skills.tx_settlement_multiplexer_abci.rounds import (
 
 abci_app_transition_mapping: AbciAppTransitionMapping = {
     FinishedRegistrationRound: UpdateBetsRound,
-    FinishedMarketManagerRound: SamplingRound,
+    FinishedMarketManagerRound: CheckStopTradingRound,
+    FinishedCheckStopTradingRound: SamplingRound,
+    FinishedCheckStopTradingWithSkipTradingRound: RedeemRound,
     FailedMarketManagerRound: ResetAndPauseRound,
     FinishedDecisionMakerRound: PreTxSettlementRound,
     ChecksPassedRound: RandomnessTransactionSubmissionRound,
@@ -146,6 +154,7 @@ TraderAbciApp = chain(
         TxSettlementMultiplexerAbciApp,
         ResetPauseAbciApp,
         StakingAbciApp,
+        CheckStopTradingAbciApp,
     ),
     abci_app_transition_mapping,
 ).add_background_app(termination_config)

--- a/packages/valory/skills/trader_abci/fsm_specification.yaml
+++ b/packages/valory/skills/trader_abci/fsm_specification.yaml
@@ -30,6 +30,7 @@ alphabet_in:
 - SERVICE_EVICTED
 - SERVICE_NOT_STAKED
 - SKIP_REQUEST
+- SKIP_TRADING
 - SLOTS_UNSUPPORTED_ERROR
 - STAKING_DONE
 - SUBSCRIPTION_DONE
@@ -53,6 +54,7 @@ states:
 - BlacklistingRound
 - CallCheckpointRound
 - CheckLateTxHashesRound
+- CheckStopTradingRound
 - CheckTransactionHistoryRound
 - ClaimRound
 - CollectSignatureRound
@@ -106,6 +108,11 @@ transition_func:
     (CheckLateTxHashesRound, NEGATIVE): HandleFailedTxRound
     (CheckLateTxHashesRound, NONE): HandleFailedTxRound
     (CheckLateTxHashesRound, NO_MAJORITY): HandleFailedTxRound
+    (CheckStopTradingRound, DONE): SamplingRound
+    (CheckStopTradingRound, NONE): CheckStopTradingRound
+    (CheckStopTradingRound, NO_MAJORITY): CheckStopTradingRound
+    (CheckStopTradingRound, ROUND_TIMEOUT): CheckStopTradingRound
+    (CheckStopTradingRound, SKIP_TRADING): RedeemRound
     (CheckTransactionHistoryRound, CHECK_LATE_ARRIVING_MESSAGE): SynchronizeLateMessagesRound
     (CheckTransactionHistoryRound, CHECK_TIMEOUT): CheckTransactionHistoryRound
     (CheckTransactionHistoryRound, DONE): PostTxSettlementRound
@@ -210,7 +217,7 @@ transition_func:
     (ToolSelectionRound, NONE): ToolSelectionRound
     (ToolSelectionRound, NO_MAJORITY): ToolSelectionRound
     (ToolSelectionRound, ROUND_TIMEOUT): ToolSelectionRound
-    (UpdateBetsRound, DONE): SamplingRound
+    (UpdateBetsRound, DONE): CheckStopTradingRound
     (UpdateBetsRound, FETCH_ERROR): ResetAndPauseRound
     (UpdateBetsRound, NO_MAJORITY): UpdateBetsRound
     (UpdateBetsRound, ROUND_TIMEOUT): UpdateBetsRound

--- a/packages/valory/skills/trader_abci/models.py
+++ b/packages/valory/skills/trader_abci/models.py
@@ -59,7 +59,6 @@ from packages.valory.skills.mech_interact_abci.models import (
     MechResponseSpecs as BaseMechResponseSpecs,
 )
 from packages.valory.skills.reset_pause_abci.rounds import Event as ResetPauseEvent
-from packages.valory.skills.staking_abci.models import StakingParams
 from packages.valory.skills.termination_abci.models import TerminationParams
 from packages.valory.skills.trader_abci.composition import TraderAbciApp
 from packages.valory.skills.transaction_settlement_abci.rounds import Event as TSEvent
@@ -101,9 +100,8 @@ class RandomnessApi(ApiSpecs):
 class TraderParams(
     DecisionMakerParams,  # It also contains MechInteractParams
     TerminationParams,
-    StakingParams,
     TxSettlementMultiplexerParams,
-    CheckStopTradingParams,
+    CheckStopTradingParams,  # It also contains StakingParams
 ):
     """A model to represent the trader params."""
 

--- a/packages/valory/skills/trader_abci/models.py
+++ b/packages/valory/skills/trader_abci/models.py
@@ -26,6 +26,7 @@ from packages.valory.skills.abstract_round_abci.models import (
     BenchmarkTool as BaseBenchmarkTool,
 )
 from packages.valory.skills.abstract_round_abci.models import Requests as BaseRequests
+from packages.valory.skills.check_stop_trading_abci.models import CheckStopTradingParams
 from packages.valory.skills.decision_maker_abci.models import (
     AgentToolsSpecs as DecisionMakerAgentToolsSpecs,
 )
@@ -102,6 +103,7 @@ class TraderParams(
     TerminationParams,
     StakingParams,
     TxSettlementMultiplexerParams,
+    CheckStopTradingParams,
 ):
     """A model to represent the trader params."""
 

--- a/packages/valory/skills/trader_abci/skill.yaml
+++ b/packages/valory/skills/trader_abci/skill.yaml
@@ -28,7 +28,7 @@ skills:
 - valory/decision_maker_abci:0.1.0:bafybeibvq365gs7ibi7bkzoqyiirdcbpros2q7z3zpsqxhbcfy5d77y7je
 - valory/tx_settlement_multiplexer_abci:0.1.0:bafybeibcuvrm5fvmh7nuee4tmbof6debprdqzhvhdpzp2dbddtwva4wz3y
 - valory/staking_abci:0.1.0:bafybeicrp3dbvxcb2wa7kdgpkxu7aqji5fwq6icwcfw7anfcpqv26irsr4
-- valory/check_stop_trading_abci:0.1.0:bafybeiazbeawv7y6edcua6qa7z2kyckcgielwjt2metts6vuv5qecvvn4q
+- valory/check_stop_trading_abci:0.1.0:bafybeiegjhswbs4uxmyxrfppteunfhuzluigvf3b325e56vw2k764rklbu
 - valory/mech_interact_abci:0.1.0:bafybeib3aytq2a5hk6vjsak3eznuilndx4p53utdylbyhcmt6ty7kk6euq
 behaviours:
   main:

--- a/packages/valory/skills/trader_abci/skill.yaml
+++ b/packages/valory/skills/trader_abci/skill.yaml
@@ -25,11 +25,11 @@ skills:
 - valory/transaction_settlement_abci:0.1.0:bafybeigtzlk4uakmd54rxnznorcrstsr52kta474lgrnvx5ovr546vj7sq
 - valory/termination_abci:0.1.0:bafybeihq6qtbwt6i53ayqym63vhjexkcppy26gguzhhjqywfmiuqghvv44
 - valory/market_manager_abci:0.1.0:bafybeidygkw7mwhbk3ry3au5c5265vms5eti375v5jthd4be5dfnnoache
-- valory/decision_maker_abci:0.1.0:bafybeif64m3zztadm2jjonorlwc2lpppqmqktig4jvfvycz3w5qv6sfrpa
-- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeigwosmf2ltoh2wkwppgftqzucktzq2b7eiakhtclnfybpsusregde
+- valory/decision_maker_abci:0.1.0:bafybeibvq365gs7ibi7bkzoqyiirdcbpros2q7z3zpsqxhbcfy5d77y7je
+- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeibcuvrm5fvmh7nuee4tmbof6debprdqzhvhdpzp2dbddtwva4wz3y
 - valory/staking_abci:0.1.0:bafybeicrp3dbvxcb2wa7kdgpkxu7aqji5fwq6icwcfw7anfcpqv26irsr4
 - valory/check_stop_trading_abci:0.1.0:bafybeifho6gdnpx3j2czez4iotjhgropakiubzya6ceag556ijjqc5gfay
-- valory/mech_interact_abci:0.1.0:bafybeihvjtdg47pchoutcuh5l7jwiclpowriymtj7nyud22cetjjxggeiy
+- valory/mech_interact_abci:0.1.0:bafybeib3aytq2a5hk6vjsak3eznuilndx4p53utdylbyhcmt6ty7kk6euq
 behaviours:
   main:
     args: {}
@@ -149,9 +149,9 @@ models:
       average_block_time: 5
       abt_error_mult: 5
       mech_contract_address: '0x77af31de935740567cf4ff1986d04b2c964a786a'
-      request_price: null
+      mech_request_price: null
       mech_chain_id: gnosis
-      wrapped_native_token_address: '0xe91D153E0b41518A2Ce8Dd3D7944Fa863463a97d'
+      mech_wrapped_native_token_address: '0xe91D153E0b41518A2Ce8Dd3D7944Fa863463a97d'
       sample_bets_closing_days: 10
       trading_strategy: strategy_name
       use_fallback_strategy: true

--- a/packages/valory/skills/trader_abci/skill.yaml
+++ b/packages/valory/skills/trader_abci/skill.yaml
@@ -28,7 +28,7 @@ skills:
 - valory/decision_maker_abci:0.1.0:bafybeihl4fyyjj34kvouh3ujmekqm4vsn5eabpfsww7danwyqmfhxxlequ
 - valory/tx_settlement_multiplexer_abci:0.1.0:bafybeifmyrqtgp4duq65ag3pnbid2xlgxemefln3mshccs6dnhdtieg4la
 - valory/staking_abci:0.1.0:bafybeicrp3dbvxcb2wa7kdgpkxu7aqji5fwq6icwcfw7anfcpqv26irsr4
-- valory/check_stop_trading_abci:0.1.0:bafybeihxs5gjblndvzipowu3576v6sq476j52leubezge7dixqexunbh3m
+- valory/check_stop_trading_abci:0.1.0:bafybeiexye4ibyldvivlivngz4fdlghegapvz6bjm3k6zrszmi7mv34hpy
 - valory/mech_interact_abci:0.1.0:bafybeihovtfa2oocrx32pdq2af6ey37om7q7b2gy3kkd3azv6mjrclohsy
 behaviours:
   main:

--- a/packages/valory/skills/trader_abci/skill.yaml
+++ b/packages/valory/skills/trader_abci/skill.yaml
@@ -13,7 +13,7 @@ fingerprint:
   dialogues.py: bafybeiebofyykseqp3fmif36cqmmyf3k7d2zbocpl6t6wnlpv4szghrxbm
   fsm_specification.yaml: bafybeicibuzg6mf6632jin3d6xylkb7if5o4dqpire6ijhor5v2e6rvo7u
   handlers.py: bafybeibkiqwe7hoqccjirimd44nzeqkabc7oo74romqklssion27s5sa2a
-  models.py: bafybeiffamdk53bhywlwiplfbsrhslaygl6jirfoxckqdnhqwpoevnisfa
+  models.py: bafybeih2bhwwqms32da3zlcpxfwoy725xdbs42e7u55enwuscacffwchaa
 fingerprint_ignore_patterns: []
 connections: []
 contracts: []
@@ -28,7 +28,7 @@ skills:
 - valory/decision_maker_abci:0.1.0:bafybeihl4fyyjj34kvouh3ujmekqm4vsn5eabpfsww7danwyqmfhxxlequ
 - valory/tx_settlement_multiplexer_abci:0.1.0:bafybeifmyrqtgp4duq65ag3pnbid2xlgxemefln3mshccs6dnhdtieg4la
 - valory/staking_abci:0.1.0:bafybeicrp3dbvxcb2wa7kdgpkxu7aqji5fwq6icwcfw7anfcpqv26irsr4
-- valory/check_stop_trading_abci:0.1.0:bafybeig7doeus3ezz57nazjmjd6qkkbkuptr3rf4btbbuxsx767jsxcnha
+- valory/check_stop_trading_abci:0.1.0:bafybeigqdtgp44ocop6btftb5zfrq4yrjunsr5ija2dxpvpalxqmlqxzbm
 - valory/mech_interact_abci:0.1.0:bafybeihovtfa2oocrx32pdq2af6ey37om7q7b2gy3kkd3azv6mjrclohsy
 behaviours:
   main:

--- a/packages/valory/skills/trader_abci/skill.yaml
+++ b/packages/valory/skills/trader_abci/skill.yaml
@@ -28,7 +28,7 @@ skills:
 - valory/decision_maker_abci:0.1.0:bafybeibvq365gs7ibi7bkzoqyiirdcbpros2q7z3zpsqxhbcfy5d77y7je
 - valory/tx_settlement_multiplexer_abci:0.1.0:bafybeibcuvrm5fvmh7nuee4tmbof6debprdqzhvhdpzp2dbddtwva4wz3y
 - valory/staking_abci:0.1.0:bafybeicrp3dbvxcb2wa7kdgpkxu7aqji5fwq6icwcfw7anfcpqv26irsr4
-- valory/check_stop_trading_abci:0.1.0:bafybeifho6gdnpx3j2czez4iotjhgropakiubzya6ceag556ijjqc5gfay
+- valory/check_stop_trading_abci:0.1.0:bafybeiazbeawv7y6edcua6qa7z2kyckcgielwjt2metts6vuv5qecvvn4q
 - valory/mech_interact_abci:0.1.0:bafybeib3aytq2a5hk6vjsak3eznuilndx4p53utdylbyhcmt6ty7kk6euq
 behaviours:
   main:

--- a/packages/valory/skills/trader_abci/skill.yaml
+++ b/packages/valory/skills/trader_abci/skill.yaml
@@ -25,11 +25,11 @@ skills:
 - valory/transaction_settlement_abci:0.1.0:bafybeigtzlk4uakmd54rxnznorcrstsr52kta474lgrnvx5ovr546vj7sq
 - valory/termination_abci:0.1.0:bafybeihq6qtbwt6i53ayqym63vhjexkcppy26gguzhhjqywfmiuqghvv44
 - valory/market_manager_abci:0.1.0:bafybeidygkw7mwhbk3ry3au5c5265vms5eti375v5jthd4be5dfnnoache
-- valory/decision_maker_abci:0.1.0:bafybeigyrxb6ycg243crte5mmmut2znfhlnc43rqn3mnp3sylvf563teki
-- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeibl6b5negw35fumbvl6dvcu7dammqmac5x3htapu3p7yf7lkqr73a
-- valory/staking_abci:0.1.0:bafybeibf565rftitlrlovlvchoe45ng72ctec74fsvrmegp3o4uepu4q2e
-- valory/check_stop_trading_abci:0.1.0:bafybeidqgwx3747hk3icoadjcly7ug2lp6nbg6p4afe2ziga3ph26j4e5u
-- valory/mech_interact_abci:0.1.0:bafybeig2kvyn52kskydyono5wmjsfwtzeq5pcsrtn7p72rfesjatzwgrnq
+- valory/decision_maker_abci:0.1.0:bafybeihl4fyyjj34kvouh3ujmekqm4vsn5eabpfsww7danwyqmfhxxlequ
+- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeifmyrqtgp4duq65ag3pnbid2xlgxemefln3mshccs6dnhdtieg4la
+- valory/staking_abci:0.1.0:bafybeicrp3dbvxcb2wa7kdgpkxu7aqji5fwq6icwcfw7anfcpqv26irsr4
+- valory/check_stop_trading_abci:0.1.0:bafybeievqacjszo4u5ohfeajwzowoazdthqmdkoefookjjmvmkhbuj3yem
+- valory/mech_interact_abci:0.1.0:bafybeihovtfa2oocrx32pdq2af6ey37om7q7b2gy3kkd3azv6mjrclohsy
 behaviours:
   main:
     args: {}

--- a/packages/valory/skills/trader_abci/skill.yaml
+++ b/packages/valory/skills/trader_abci/skill.yaml
@@ -28,7 +28,7 @@ skills:
 - valory/decision_maker_abci:0.1.0:bafybeihl4fyyjj34kvouh3ujmekqm4vsn5eabpfsww7danwyqmfhxxlequ
 - valory/tx_settlement_multiplexer_abci:0.1.0:bafybeifmyrqtgp4duq65ag3pnbid2xlgxemefln3mshccs6dnhdtieg4la
 - valory/staking_abci:0.1.0:bafybeicrp3dbvxcb2wa7kdgpkxu7aqji5fwq6icwcfw7anfcpqv26irsr4
-- valory/check_stop_trading_abci:0.1.0:bafybeievqacjszo4u5ohfeajwzowoazdthqmdkoefookjjmvmkhbuj3yem
+- valory/check_stop_trading_abci:0.1.0:bafybeiamwtr56zmm7effymgo7jwgix4nwdbhwjrjix4csrdtlyk3qoky3i
 - valory/mech_interact_abci:0.1.0:bafybeihovtfa2oocrx32pdq2af6ey37om7q7b2gy3kkd3azv6mjrclohsy
 behaviours:
   main:

--- a/packages/valory/skills/trader_abci/skill.yaml
+++ b/packages/valory/skills/trader_abci/skill.yaml
@@ -28,7 +28,7 @@ skills:
 - valory/decision_maker_abci:0.1.0:bafybeibvq365gs7ibi7bkzoqyiirdcbpros2q7z3zpsqxhbcfy5d77y7je
 - valory/tx_settlement_multiplexer_abci:0.1.0:bafybeibcuvrm5fvmh7nuee4tmbof6debprdqzhvhdpzp2dbddtwva4wz3y
 - valory/staking_abci:0.1.0:bafybeicrp3dbvxcb2wa7kdgpkxu7aqji5fwq6icwcfw7anfcpqv26irsr4
-- valory/check_stop_trading_abci:0.1.0:bafybeiegjhswbs4uxmyxrfppteunfhuzluigvf3b325e56vw2k764rklbu
+- valory/check_stop_trading_abci:0.1.0:bafybeiedpw6gudh7ddrcfpggnbxmbfaqn57a5geg645c2ymuzwy3rtckii
 - valory/mech_interact_abci:0.1.0:bafybeib3aytq2a5hk6vjsak3eznuilndx4p53utdylbyhcmt6ty7kk6euq
 behaviours:
   main:

--- a/packages/valory/skills/trader_abci/skill.yaml
+++ b/packages/valory/skills/trader_abci/skill.yaml
@@ -9,7 +9,7 @@ fingerprint:
   README.md: bafybeiab4xgadptz4mhvno4p6xvkh7p4peg7iuhotabydriu74dmj6ljga
   __init__.py: bafybeido7wa33h4dtleap57vzgyb4fsofk4vindsqcekyfo5i56i2rll2a
   behaviours.py: bafybeigc6hszbu66ccajny5eh7thfgsrlr36je4mzziwp4mupgvtaeu6aa
-  composition.py: bafybeidlwhwbcj3v62eqpte6saykvi4zijpxks2rin4ahk2e7kdfwggwom
+  composition.py: bafybeidazh2w4do27n2fmwh5eyca7tet5dxw4uilh4wkhoazlgyhr7w3eu
   dialogues.py: bafybeiebofyykseqp3fmif36cqmmyf3k7d2zbocpl6t6wnlpv4szghrxbm
   fsm_specification.yaml: bafybeicibuzg6mf6632jin3d6xylkb7if5o4dqpire6ijhor5v2e6rvo7u
   handlers.py: bafybeibkiqwe7hoqccjirimd44nzeqkabc7oo74romqklssion27s5sa2a
@@ -28,7 +28,7 @@ skills:
 - valory/decision_maker_abci:0.1.0:bafybeihl4fyyjj34kvouh3ujmekqm4vsn5eabpfsww7danwyqmfhxxlequ
 - valory/tx_settlement_multiplexer_abci:0.1.0:bafybeifmyrqtgp4duq65ag3pnbid2xlgxemefln3mshccs6dnhdtieg4la
 - valory/staking_abci:0.1.0:bafybeicrp3dbvxcb2wa7kdgpkxu7aqji5fwq6icwcfw7anfcpqv26irsr4
-- valory/check_stop_trading_abci:0.1.0:bafybeihs2yjqyqno6h5pmhrwlpgnoqunnho54p2y46ut2hmorsaz36quru
+- valory/check_stop_trading_abci:0.1.0:bafybeig7doeus3ezz57nazjmjd6qkkbkuptr3rf4btbbuxsx767jsxcnha
 - valory/mech_interact_abci:0.1.0:bafybeihovtfa2oocrx32pdq2af6ey37om7q7b2gy3kkd3azv6mjrclohsy
 behaviours:
   main:

--- a/packages/valory/skills/trader_abci/skill.yaml
+++ b/packages/valory/skills/trader_abci/skill.yaml
@@ -28,7 +28,7 @@ skills:
 - valory/decision_maker_abci:0.1.0:bafybeihl4fyyjj34kvouh3ujmekqm4vsn5eabpfsww7danwyqmfhxxlequ
 - valory/tx_settlement_multiplexer_abci:0.1.0:bafybeifmyrqtgp4duq65ag3pnbid2xlgxemefln3mshccs6dnhdtieg4la
 - valory/staking_abci:0.1.0:bafybeicrp3dbvxcb2wa7kdgpkxu7aqji5fwq6icwcfw7anfcpqv26irsr4
-- valory/check_stop_trading_abci:0.1.0:bafybeiamwtr56zmm7effymgo7jwgix4nwdbhwjrjix4csrdtlyk3qoky3i
+- valory/check_stop_trading_abci:0.1.0:bafybeihxs5gjblndvzipowu3576v6sq476j52leubezge7dixqexunbh3m
 - valory/mech_interact_abci:0.1.0:bafybeihovtfa2oocrx32pdq2af6ey37om7q7b2gy3kkd3azv6mjrclohsy
 behaviours:
   main:

--- a/packages/valory/skills/trader_abci/skill.yaml
+++ b/packages/valory/skills/trader_abci/skill.yaml
@@ -28,6 +28,7 @@ skills:
 - valory/decision_maker_abci:0.1.0:bafybeigyrxb6ycg243crte5mmmut2znfhlnc43rqn3mnp3sylvf563teki
 - valory/tx_settlement_multiplexer_abci:0.1.0:bafybeibl6b5negw35fumbvl6dvcu7dammqmac5x3htapu3p7yf7lkqr73a
 - valory/staking_abci:0.1.0:bafybeibf565rftitlrlovlvchoe45ng72ctec74fsvrmegp3o4uepu4q2e
+- valory/check_stop_trading_abci:0.1.0:bafybeihd2awwfnwboe4tnb6gmrhtheg5py4m37sdqtxxn7z3wnhxxntku4
 - valory/mech_interact_abci:0.1.0:bafybeig2kvyn52kskydyono5wmjsfwtzeq5pcsrtn7p72rfesjatzwgrnq
 behaviours:
   main:

--- a/packages/valory/skills/trader_abci/skill.yaml
+++ b/packages/valory/skills/trader_abci/skill.yaml
@@ -28,7 +28,7 @@ skills:
 - valory/decision_maker_abci:0.1.0:bafybeihl4fyyjj34kvouh3ujmekqm4vsn5eabpfsww7danwyqmfhxxlequ
 - valory/tx_settlement_multiplexer_abci:0.1.0:bafybeifmyrqtgp4duq65ag3pnbid2xlgxemefln3mshccs6dnhdtieg4la
 - valory/staking_abci:0.1.0:bafybeicrp3dbvxcb2wa7kdgpkxu7aqji5fwq6icwcfw7anfcpqv26irsr4
-- valory/check_stop_trading_abci:0.1.0:bafybeiexye4ibyldvivlivngz4fdlghegapvz6bjm3k6zrszmi7mv34hpy
+- valory/check_stop_trading_abci:0.1.0:bafybeihs2yjqyqno6h5pmhrwlpgnoqunnho54p2y46ut2hmorsaz36quru
 - valory/mech_interact_abci:0.1.0:bafybeihovtfa2oocrx32pdq2af6ey37om7q7b2gy3kkd3azv6mjrclohsy
 behaviours:
   main:

--- a/packages/valory/skills/trader_abci/skill.yaml
+++ b/packages/valory/skills/trader_abci/skill.yaml
@@ -25,11 +25,11 @@ skills:
 - valory/transaction_settlement_abci:0.1.0:bafybeigtzlk4uakmd54rxnznorcrstsr52kta474lgrnvx5ovr546vj7sq
 - valory/termination_abci:0.1.0:bafybeihq6qtbwt6i53ayqym63vhjexkcppy26gguzhhjqywfmiuqghvv44
 - valory/market_manager_abci:0.1.0:bafybeidygkw7mwhbk3ry3au5c5265vms5eti375v5jthd4be5dfnnoache
-- valory/decision_maker_abci:0.1.0:bafybeihl4fyyjj34kvouh3ujmekqm4vsn5eabpfsww7danwyqmfhxxlequ
-- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeifmyrqtgp4duq65ag3pnbid2xlgxemefln3mshccs6dnhdtieg4la
+- valory/decision_maker_abci:0.1.0:bafybeif64m3zztadm2jjonorlwc2lpppqmqktig4jvfvycz3w5qv6sfrpa
+- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeigwosmf2ltoh2wkwppgftqzucktzq2b7eiakhtclnfybpsusregde
 - valory/staking_abci:0.1.0:bafybeicrp3dbvxcb2wa7kdgpkxu7aqji5fwq6icwcfw7anfcpqv26irsr4
 - valory/check_stop_trading_abci:0.1.0:bafybeifho6gdnpx3j2czez4iotjhgropakiubzya6ceag556ijjqc5gfay
-- valory/mech_interact_abci:0.1.0:bafybeihovtfa2oocrx32pdq2af6ey37om7q7b2gy3kkd3azv6mjrclohsy
+- valory/mech_interact_abci:0.1.0:bafybeihvjtdg47pchoutcuh5l7jwiclpowriymtj7nyud22cetjjxggeiy
 behaviours:
   main:
     args: {}
@@ -150,6 +150,8 @@ models:
       abt_error_mult: 5
       mech_contract_address: '0x77af31de935740567cf4ff1986d04b2c964a786a'
       request_price: null
+      mech_chain_id: gnosis
+      wrapped_native_token_address: '0xe91D153E0b41518A2Ce8Dd3D7944Fa863463a97d'
       sample_bets_closing_days: 10
       trading_strategy: strategy_name
       use_fallback_strategy: true

--- a/packages/valory/skills/trader_abci/skill.yaml
+++ b/packages/valory/skills/trader_abci/skill.yaml
@@ -28,7 +28,7 @@ skills:
 - valory/decision_maker_abci:0.1.0:bafybeihl4fyyjj34kvouh3ujmekqm4vsn5eabpfsww7danwyqmfhxxlequ
 - valory/tx_settlement_multiplexer_abci:0.1.0:bafybeifmyrqtgp4duq65ag3pnbid2xlgxemefln3mshccs6dnhdtieg4la
 - valory/staking_abci:0.1.0:bafybeicrp3dbvxcb2wa7kdgpkxu7aqji5fwq6icwcfw7anfcpqv26irsr4
-- valory/check_stop_trading_abci:0.1.0:bafybeigqdtgp44ocop6btftb5zfrq4yrjunsr5ija2dxpvpalxqmlqxzbm
+- valory/check_stop_trading_abci:0.1.0:bafybeifho6gdnpx3j2czez4iotjhgropakiubzya6ceag556ijjqc5gfay
 - valory/mech_interact_abci:0.1.0:bafybeihovtfa2oocrx32pdq2af6ey37om7q7b2gy3kkd3azv6mjrclohsy
 behaviours:
   main:

--- a/packages/valory/skills/trader_abci/skill.yaml
+++ b/packages/valory/skills/trader_abci/skill.yaml
@@ -8,12 +8,12 @@ aea_version: '>=1.0.0, <2.0.0'
 fingerprint:
   README.md: bafybeiab4xgadptz4mhvno4p6xvkh7p4peg7iuhotabydriu74dmj6ljga
   __init__.py: bafybeido7wa33h4dtleap57vzgyb4fsofk4vindsqcekyfo5i56i2rll2a
-  behaviours.py: bafybeigx2uevbnytt6hpwfsrk32u6pyv5scyqvyyzm2a25xaufrxvkldxi
-  composition.py: bafybeidvxtqoghju4tkesiwi6qfzxe3zf2nbqmehimwvp5skmohkeozmei
+  behaviours.py: bafybeigc6hszbu66ccajny5eh7thfgsrlr36je4mzziwp4mupgvtaeu6aa
+  composition.py: bafybeidlwhwbcj3v62eqpte6saykvi4zijpxks2rin4ahk2e7kdfwggwom
   dialogues.py: bafybeiebofyykseqp3fmif36cqmmyf3k7d2zbocpl6t6wnlpv4szghrxbm
-  fsm_specification.yaml: bafybeiaulbsq76cc5h7jjz6oiezoui452mtyk6g2kbmhhzsggqrjqw4cuy
+  fsm_specification.yaml: bafybeicibuzg6mf6632jin3d6xylkb7if5o4dqpire6ijhor5v2e6rvo7u
   handlers.py: bafybeibkiqwe7hoqccjirimd44nzeqkabc7oo74romqklssion27s5sa2a
-  models.py: bafybeigk7hs7xsfjoszsque6r6yvbrrhattfuli2nfend4istk465e6try
+  models.py: bafybeiffamdk53bhywlwiplfbsrhslaygl6jirfoxckqdnhqwpoevnisfa
 fingerprint_ignore_patterns: []
 connections: []
 contracts: []
@@ -28,7 +28,7 @@ skills:
 - valory/decision_maker_abci:0.1.0:bafybeigyrxb6ycg243crte5mmmut2znfhlnc43rqn3mnp3sylvf563teki
 - valory/tx_settlement_multiplexer_abci:0.1.0:bafybeibl6b5negw35fumbvl6dvcu7dammqmac5x3htapu3p7yf7lkqr73a
 - valory/staking_abci:0.1.0:bafybeibf565rftitlrlovlvchoe45ng72ctec74fsvrmegp3o4uepu4q2e
-- valory/check_stop_trading_abci:0.1.0:bafybeihd2awwfnwboe4tnb6gmrhtheg5py4m37sdqtxxn7z3wnhxxntku4
+- valory/check_stop_trading_abci:0.1.0:bafybeidqgwx3747hk3icoadjcly7ug2lp6nbg6p4afe2ziga3ph26j4e5u
 - valory/mech_interact_abci:0.1.0:bafybeig2kvyn52kskydyono5wmjsfwtzeq5pcsrtn7p72rfesjatzwgrnq
 behaviours:
   main:
@@ -182,6 +182,8 @@ models:
       - stabilityai-stable-diffusion-512-v2-1
       - stabilityai-stable-diffusion-768-v2-1
       staking_contract_address: '0x2Ef503950Be67a98746F484DA0bBAdA339DF3326'
+      disable_trading: false
+      stop_trading_if_staking_kpi_met: true
       agent_balance_threshold: 10000000000000000
       refill_check_interval: 10
       redeem_round_timeout: 3600.0

--- a/packages/valory/skills/tx_settlement_multiplexer_abci/skill.yaml
+++ b/packages/valory/skills/tx_settlement_multiplexer_abci/skill.yaml
@@ -21,9 +21,9 @@ protocols:
 - valory/ledger_api:1.0.0:bafybeihdk6psr4guxmbcrc26jr2cbgzpd5aljkqvpwo64bvaz7tdti2oni
 skills:
 - valory/abstract_round_abci:0.1.0:bafybeih3enhagoql7kzpeyzzu2scpkif6y3ubakpralfnwxcvxexdyvy5i
-- valory/decision_maker_abci:0.1.0:bafybeihl4fyyjj34kvouh3ujmekqm4vsn5eabpfsww7danwyqmfhxxlequ
+- valory/decision_maker_abci:0.1.0:bafybeif64m3zztadm2jjonorlwc2lpppqmqktig4jvfvycz3w5qv6sfrpa
 - valory/staking_abci:0.1.0:bafybeicrp3dbvxcb2wa7kdgpkxu7aqji5fwq6icwcfw7anfcpqv26irsr4
-- valory/mech_interact_abci:0.1.0:bafybeihovtfa2oocrx32pdq2af6ey37om7q7b2gy3kkd3azv6mjrclohsy
+- valory/mech_interact_abci:0.1.0:bafybeihvjtdg47pchoutcuh5l7jwiclpowriymtj7nyud22cetjjxggeiy
 behaviours:
   main:
     args: {}

--- a/packages/valory/skills/tx_settlement_multiplexer_abci/skill.yaml
+++ b/packages/valory/skills/tx_settlement_multiplexer_abci/skill.yaml
@@ -21,9 +21,9 @@ protocols:
 - valory/ledger_api:1.0.0:bafybeihdk6psr4guxmbcrc26jr2cbgzpd5aljkqvpwo64bvaz7tdti2oni
 skills:
 - valory/abstract_round_abci:0.1.0:bafybeih3enhagoql7kzpeyzzu2scpkif6y3ubakpralfnwxcvxexdyvy5i
-- valory/decision_maker_abci:0.1.0:bafybeif64m3zztadm2jjonorlwc2lpppqmqktig4jvfvycz3w5qv6sfrpa
+- valory/decision_maker_abci:0.1.0:bafybeibvq365gs7ibi7bkzoqyiirdcbpros2q7z3zpsqxhbcfy5d77y7je
 - valory/staking_abci:0.1.0:bafybeicrp3dbvxcb2wa7kdgpkxu7aqji5fwq6icwcfw7anfcpqv26irsr4
-- valory/mech_interact_abci:0.1.0:bafybeihvjtdg47pchoutcuh5l7jwiclpowriymtj7nyud22cetjjxggeiy
+- valory/mech_interact_abci:0.1.0:bafybeib3aytq2a5hk6vjsak3eznuilndx4p53utdylbyhcmt6ty7kk6euq
 behaviours:
   main:
     args: {}

--- a/packages/valory/skills/tx_settlement_multiplexer_abci/skill.yaml
+++ b/packages/valory/skills/tx_settlement_multiplexer_abci/skill.yaml
@@ -21,9 +21,9 @@ protocols:
 - valory/ledger_api:1.0.0:bafybeihdk6psr4guxmbcrc26jr2cbgzpd5aljkqvpwo64bvaz7tdti2oni
 skills:
 - valory/abstract_round_abci:0.1.0:bafybeih3enhagoql7kzpeyzzu2scpkif6y3ubakpralfnwxcvxexdyvy5i
-- valory/decision_maker_abci:0.1.0:bafybeigyrxb6ycg243crte5mmmut2znfhlnc43rqn3mnp3sylvf563teki
-- valory/staking_abci:0.1.0:bafybeibf565rftitlrlovlvchoe45ng72ctec74fsvrmegp3o4uepu4q2e
-- valory/mech_interact_abci:0.1.0:bafybeig2kvyn52kskydyono5wmjsfwtzeq5pcsrtn7p72rfesjatzwgrnq
+- valory/decision_maker_abci:0.1.0:bafybeihl4fyyjj34kvouh3ujmekqm4vsn5eabpfsww7danwyqmfhxxlequ
+- valory/staking_abci:0.1.0:bafybeicrp3dbvxcb2wa7kdgpkxu7aqji5fwq6icwcfw7anfcpqv26irsr4
+- valory/mech_interact_abci:0.1.0:bafybeihovtfa2oocrx32pdq2af6ey37om7q7b2gy3kkd3azv6mjrclohsy
 behaviours:
   main:
     args: {}


### PR DESCRIPTION
Check for stop trading conditions.

The trader will stop trading and transit to RedeemRound if any of these conditions occur:

* The parameter/env variable `DISABLE_TRADING` is set to `true`.
* The KPI fot the staking contract has been met.

This PR requires to reactor the staking_abci Skill to extract common functionality to be used in the check_stop_trading_abci.
This PR contains a small hack to solve an issue with non-initialized data. Namely, it always requires that the trader don't skip going to the "trading path" on the first period. See detailed comment.

