### PR TITLE
Fix blacklisting behaviour when in benchmarking mode

### DIFF
--- a/packages/packages.json
+++ b/packages/packages.json
@@ -12,13 +12,13 @@
         "contract/valory/service_staking_token/0.1.0": "bafybeid44l7qekvkwkvmfl4kcqchnaktttacp7lbx464mzqqs5cnefj35e",
         "contract/valory/transfer_nft_condition/0.1.0": "bafybeicgpoag2lymofz3vnen76q7gtig5hzimn32o57php4uerr6t25em4",
         "skill/valory/market_manager_abci/0.1.0": "bafybeidygkw7mwhbk3ry3au5c5265vms5eti375v5jthd4be5dfnnoache",
-        "skill/valory/decision_maker_abci/0.1.0": "bafybeiaravgcubvq4wh5parmm4hkloufrmudg5qgtuto5knqxjaieogbty",
-        "skill/valory/trader_abci/0.1.0": "bafybeib254ejjkklb7riuarbf3a5qz24kryyjsfxhtcnniikstjwsizoyy",
-        "skill/valory/tx_settlement_multiplexer_abci/0.1.0": "bafybeidhhidtrxtoomri3gia4fqcj7jahylrbtqlwhesgrf43xwihtq7eu",
+        "skill/valory/decision_maker_abci/0.1.0": "bafybeibjy72eh5fdqknvi7eabiojhksz6ls7do6ltedpspawtw7ns4v3ka",
+        "skill/valory/trader_abci/0.1.0": "bafybeif5vg5onbu5j6327pq76uoawmgri2katotwpgw7w37zmdox5rfh64",
+        "skill/valory/tx_settlement_multiplexer_abci/0.1.0": "bafybeifjwsosgd5hfx26uok23s2z6wzkeh6khjl2fmqfvc3onhk6naya34",
         "skill/valory/staking_abci/0.1.0": "bafybeicsydq6fdansf7qrmrygzchl3h6rtkdw5rmx2jyrwecj4laj5nehy",
         "skill/valory/check_stop_trading_abci/0.1.0": "bafybeidyc5fvw5wosbc3anxxxog5b67cfmvrsrltjh3cfllye3bb43r3z4",
-        "agent/valory/trader/0.1.0": "bafybeiddk43i56ckj7dvb7my6ed6flgbelgn2s6d3sgo75kpxtnl2kh3ti",
-        "service/valory/trader/0.1.0": "bafybeicworqlhilplnbwczweqk3gleb2ywkz537dy6qqsh2fyiufgjvgdi"
+        "agent/valory/trader/0.1.0": "bafybeiebv47c2772agpgeswjum4cqws7t3uc7elmpdau6wd2vysqi5sexe",
+        "service/valory/trader/0.1.0": "bafybeic2zqf2i6auwl326xrvzkust3ubt2ropb6ubxn55dlbo6kqz6iucq"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeihv62fim3wl2bayavfcg3u5e5cxu3b7brtu4cn5xoxd6lqwachasi",

--- a/packages/valory/agents/trader/aea-config.yaml
+++ b/packages/valory/agents/trader/aea-config.yaml
@@ -44,10 +44,10 @@ skills:
 - valory/reset_pause_abci:0.1.0:bafybeidw4mbx3os3hmv7ley7b3g3gja7ydpitr7mxbjpwzxin2mzyt5yam
 - valory/termination_abci:0.1.0:bafybeihq6qtbwt6i53ayqym63vhjexkcppy26gguzhhjqywfmiuqghvv44
 - valory/transaction_settlement_abci:0.1.0:bafybeigtzlk4uakmd54rxnznorcrstsr52kta474lgrnvx5ovr546vj7sq
-- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeidhhidtrxtoomri3gia4fqcj7jahylrbtqlwhesgrf43xwihtq7eu
+- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeifjwsosgd5hfx26uok23s2z6wzkeh6khjl2fmqfvc3onhk6naya34
 - valory/market_manager_abci:0.1.0:bafybeidygkw7mwhbk3ry3au5c5265vms5eti375v5jthd4be5dfnnoache
-- valory/decision_maker_abci:0.1.0:bafybeiaravgcubvq4wh5parmm4hkloufrmudg5qgtuto5knqxjaieogbty
-- valory/trader_abci:0.1.0:bafybeib254ejjkklb7riuarbf3a5qz24kryyjsfxhtcnniikstjwsizoyy
+- valory/decision_maker_abci:0.1.0:bafybeibjy72eh5fdqknvi7eabiojhksz6ls7do6ltedpspawtw7ns4v3ka
+- valory/trader_abci:0.1.0:bafybeif5vg5onbu5j6327pq76uoawmgri2katotwpgw7w37zmdox5rfh64
 - valory/staking_abci:0.1.0:bafybeicsydq6fdansf7qrmrygzchl3h6rtkdw5rmx2jyrwecj4laj5nehy
 - valory/check_stop_trading_abci:0.1.0:bafybeidyc5fvw5wosbc3anxxxog5b67cfmvrsrltjh3cfllye3bb43r3z4
 - valory/mech_interact_abci:0.1.0:bafybeigkvcluq2kejpxdcb54iwqtvwhov5elg3cv4v2yomwjxyu5u7g7hi

--- a/packages/valory/services/trader/service.yaml
+++ b/packages/valory/services/trader/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeigtuothskwyvrhfosps2bu6suauycolj67dpuxqvnicdrdu7yhtvq
 fingerprint_ignore_patterns: []
-agent: valory/trader:0.1.0:bafybeiddk43i56ckj7dvb7my6ed6flgbelgn2s6d3sgo75kpxtnl2kh3ti
+agent: valory/trader:0.1.0:bafybeiebv47c2772agpgeswjum4cqws7t3uc7elmpdau6wd2vysqi5sexe
 number_of_agents: 4
 deployment: {}
 ---

--- a/packages/valory/skills/decision_maker_abci/behaviours/blacklisting.py
+++ b/packages/valory/skills/decision_maker_abci/behaviours/blacklisting.py
@@ -89,7 +89,9 @@ class BlacklistingBehaviour(DecisionMakerBaseBehaviour):
             self.read_bets()
             self._blacklist()
             self.store_bets()
-            bets_hash = self.hash_stored_bets()
+            bets_hash = (
+                None if self.benchmarking_mode.enabled else self.hash_stored_bets()
+            )
             policy = self.policy.serialize()
             payload = BlacklistingPayload(self.context.agent_address, bets_hash, policy)
 

--- a/packages/valory/skills/decision_maker_abci/skill.yaml
+++ b/packages/valory/skills/decision_maker_abci/skill.yaml
@@ -14,7 +14,7 @@ fingerprint:
   behaviours/__init__.py: bafybeih6ddz2ocvm6x6ytvlbcz6oi4snb5ee5xh5h65nq4w2qf7fd7zfky
   behaviours/base.py: bafybeiap6bqx627tz775mdkppjude7az7yg6awwqfvrieq37hreiztscgy
   behaviours/bet_placement.py: bafybeia62an6dpkf6b46fzc4epcyh3zuvpvoge3ewmussclxbldjf3bdue
-  behaviours/blacklisting.py: bafybeieyczuqecp2bzqxfu3jupqvjdxran5tsmy4lhvntokd6d2qwg2fre
+  behaviours/blacklisting.py: bafybeigamu43kwg4wdooviw3fb73casqeigokzy5zqshgybe4tmn6utcrm
   behaviours/check_benchmarking.py: bafybeiao2lyj7apezkqrpgsyzb3dwvrdgsrgtprf6iuhsmlsufvxfl5bci
   behaviours/claim_subscription.py: bafybeihv5dg74deifzk46ppdwcvz6lgamgl6m7qr6sgqv2zie35j2576ca
   behaviours/decision_receive.py: bafybeieuqggknaggmxkhcxa47jh7yiyv4xjzi4zyfjuamwvowqun7lx3b4

--- a/packages/valory/skills/trader_abci/skill.yaml
+++ b/packages/valory/skills/trader_abci/skill.yaml
@@ -25,8 +25,8 @@ skills:
 - valory/transaction_settlement_abci:0.1.0:bafybeigtzlk4uakmd54rxnznorcrstsr52kta474lgrnvx5ovr546vj7sq
 - valory/termination_abci:0.1.0:bafybeihq6qtbwt6i53ayqym63vhjexkcppy26gguzhhjqywfmiuqghvv44
 - valory/market_manager_abci:0.1.0:bafybeidygkw7mwhbk3ry3au5c5265vms5eti375v5jthd4be5dfnnoache
-- valory/decision_maker_abci:0.1.0:bafybeiaravgcubvq4wh5parmm4hkloufrmudg5qgtuto5knqxjaieogbty
-- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeidhhidtrxtoomri3gia4fqcj7jahylrbtqlwhesgrf43xwihtq7eu
+- valory/decision_maker_abci:0.1.0:bafybeibjy72eh5fdqknvi7eabiojhksz6ls7do6ltedpspawtw7ns4v3ka
+- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeifjwsosgd5hfx26uok23s2z6wzkeh6khjl2fmqfvc3onhk6naya34
 - valory/staking_abci:0.1.0:bafybeicsydq6fdansf7qrmrygzchl3h6rtkdw5rmx2jyrwecj4laj5nehy
 - valory/check_stop_trading_abci:0.1.0:bafybeidyc5fvw5wosbc3anxxxog5b67cfmvrsrltjh3cfllye3bb43r3z4
 - valory/mech_interact_abci:0.1.0:bafybeigkvcluq2kejpxdcb54iwqtvwhov5elg3cv4v2yomwjxyu5u7g7hi

--- a/packages/valory/skills/tx_settlement_multiplexer_abci/skill.yaml
+++ b/packages/valory/skills/tx_settlement_multiplexer_abci/skill.yaml
@@ -21,7 +21,7 @@ protocols:
 - valory/ledger_api:1.0.0:bafybeihdk6psr4guxmbcrc26jr2cbgzpd5aljkqvpwo64bvaz7tdti2oni
 skills:
 - valory/abstract_round_abci:0.1.0:bafybeih3enhagoql7kzpeyzzu2scpkif6y3ubakpralfnwxcvxexdyvy5i
-- valory/decision_maker_abci:0.1.0:bafybeiaravgcubvq4wh5parmm4hkloufrmudg5qgtuto5knqxjaieogbty
+- valory/decision_maker_abci:0.1.0:bafybeibjy72eh5fdqknvi7eabiojhksz6ls7do6ltedpspawtw7ns4v3ka
 - valory/staking_abci:0.1.0:bafybeicsydq6fdansf7qrmrygzchl3h6rtkdw5rmx2jyrwecj4laj5nehy
 - valory/mech_interact_abci:0.1.0:bafybeigkvcluq2kejpxdcb54iwqtvwhov5elg3cv4v2yomwjxyu5u7g7hi
 behaviours:


### PR DESCRIPTION
No bets are fetched when running in benchmarking mode. Instead, the local input data are used. Therefore, `self.hash_stored_bets()` raises:

```
FileNotFoundError: [Errno 2] No such file or directory: '/root/agent/bets.json'
```