### PR TITLE
Do not blacklist if the tool selection has not been run

### DIFF
--- a/packages/packages.json
+++ b/packages/packages.json
@@ -13,13 +13,13 @@
         "contract/valory/transfer_nft_condition/0.1.0": "bafybeihnict3irtvnyxtkwyg6wphe44wz3dogijiha45xrkcrh5ktq2lsi",
         "contract/valory/relayer/0.1.0": "bafybeiaabvxim4blp5fxb6qjlzjivtvkme3fk24h5jte7w6vr6rsx72j6u",
         "skill/valory/market_manager_abci/0.1.0": "bafybeicbvxvjkoksbknujaid5hx7krjlgm6barcjcwo33tdccanrcp674a",
-        "skill/valory/decision_maker_abci/0.1.0": "bafybeifcv22lf2qulw5egxxmbux2dzuqnyeu2cpvwyipptoub5r54zbyc4",
-        "skill/valory/trader_abci/0.1.0": "bafybeic3bui5ry3i7ekazbcvisf2z7udjwxyywwgv4au6opzzufpwpcvhm",
-        "skill/valory/tx_settlement_multiplexer_abci/0.1.0": "bafybeic6tizt4rabpntz56evu7jnucvelciehhveh2baaojg7w6xke4ika",
+        "skill/valory/decision_maker_abci/0.1.0": "bafybeiaw5kilhtdu7fcmk5553l3m6v366myaflekvipe4qa2vp4arbzlva",
+        "skill/valory/trader_abci/0.1.0": "bafybeibvlfhotlobiuemgra677qrmb5juumhpg4wz5uayi42sa6asxlona",
+        "skill/valory/tx_settlement_multiplexer_abci/0.1.0": "bafybeidkr6vthdixhjxe423bur7deeynzfwqmqc2gyylhxadfsbzo22faa",
         "skill/valory/staking_abci/0.1.0": "bafybeigo7bicej5t2rbki37cmcwkzgwpcnopokn7ijhylmkihsbqw47xr4",
         "skill/valory/check_stop_trading_abci/0.1.0": "bafybeickfeuqlpmryegnfvfu2duk2v4ycowwloohu3xxrafd5md6xl5swi",
-        "agent/valory/trader/0.1.0": "bafybeidvindh7eho6wdeoi4ylaqarsputtlvz7ujsros7pgjhoemuhqzy4",
-        "service/valory/trader/0.1.0": "bafybeiamleh4h26jsce25gc7szoemg7sy65h45bn6ptjq27pxajvpc35pi"
+        "agent/valory/trader/0.1.0": "bafybeidt6cy3vo33dcue5ocyi7j2y6gxomzdotlgjq7hresembhdam533i",
+        "service/valory/trader/0.1.0": "bafybeid6wzptaugaeyf3mfgjop2buxjawnuignycbdod46dh2kazja6eim"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeihv62fim3wl2bayavfcg3u5e5cxu3b7brtu4cn5xoxd6lqwachasi",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -13,13 +13,13 @@
         "contract/valory/transfer_nft_condition/0.1.0": "bafybeihnict3irtvnyxtkwyg6wphe44wz3dogijiha45xrkcrh5ktq2lsi",
         "contract/valory/relayer/0.1.0": "bafybeiaabvxim4blp5fxb6qjlzjivtvkme3fk24h5jte7w6vr6rsx72j6u",
         "skill/valory/market_manager_abci/0.1.0": "bafybeicbvxvjkoksbknujaid5hx7krjlgm6barcjcwo33tdccanrcp674a",
-        "skill/valory/decision_maker_abci/0.1.0": "bafybeiaw5kilhtdu7fcmk5553l3m6v366myaflekvipe4qa2vp4arbzlva",
-        "skill/valory/trader_abci/0.1.0": "bafybeibvlfhotlobiuemgra677qrmb5juumhpg4wz5uayi42sa6asxlona",
-        "skill/valory/tx_settlement_multiplexer_abci/0.1.0": "bafybeidkr6vthdixhjxe423bur7deeynzfwqmqc2gyylhxadfsbzo22faa",
+        "skill/valory/decision_maker_abci/0.1.0": "bafybeibb2qs73ug56hazdmuirwa2avbbdmenuhbmmwcp7zn4fdgztd6sjy",
+        "skill/valory/trader_abci/0.1.0": "bafybeietcp2q726jgo3wwoautzkxuwjoa4jdv2bllcx4o44plsh5gqt7fu",
+        "skill/valory/tx_settlement_multiplexer_abci/0.1.0": "bafybeiaybhcckjudnmelw3vc4mhw7fmydisyguanvlb2h6kdbhke3kjsvi",
         "skill/valory/staking_abci/0.1.0": "bafybeigo7bicej5t2rbki37cmcwkzgwpcnopokn7ijhylmkihsbqw47xr4",
         "skill/valory/check_stop_trading_abci/0.1.0": "bafybeickfeuqlpmryegnfvfu2duk2v4ycowwloohu3xxrafd5md6xl5swi",
-        "agent/valory/trader/0.1.0": "bafybeidt6cy3vo33dcue5ocyi7j2y6gxomzdotlgjq7hresembhdam533i",
-        "service/valory/trader/0.1.0": "bafybeid6wzptaugaeyf3mfgjop2buxjawnuignycbdod46dh2kazja6eim"
+        "agent/valory/trader/0.1.0": "bafybeiczhuenxymwnoankdarwogerydxmzkjeefe6anokksaok25dto6nu",
+        "service/valory/trader/0.1.0": "bafybeih3l6tcadclvaumuvgyle3jgt52d6o7s5rb4r34tfmzsic25bmwje"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeihv62fim3wl2bayavfcg3u5e5cxu3b7brtu4cn5xoxd6lqwachasi",

--- a/packages/valory/agents/trader/aea-config.yaml
+++ b/packages/valory/agents/trader/aea-config.yaml
@@ -45,10 +45,10 @@ skills:
 - valory/reset_pause_abci:0.1.0:bafybeiameewywqigpupy3u2iwnkfczeiiucue74x2l5lbge74rmw6bgaie
 - valory/termination_abci:0.1.0:bafybeif2zim2de356eo3sipkmoev5emwadpqqzk3huwqarywh4tmqt3vzq
 - valory/transaction_settlement_abci:0.1.0:bafybeic3tccdjypuge2lewtlgprwkbb53lhgsgn7oiwzyrcrrptrbeyote
-- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeic6tizt4rabpntz56evu7jnucvelciehhveh2baaojg7w6xke4ika
+- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeidkr6vthdixhjxe423bur7deeynzfwqmqc2gyylhxadfsbzo22faa
 - valory/market_manager_abci:0.1.0:bafybeicbvxvjkoksbknujaid5hx7krjlgm6barcjcwo33tdccanrcp674a
-- valory/decision_maker_abci:0.1.0:bafybeifcv22lf2qulw5egxxmbux2dzuqnyeu2cpvwyipptoub5r54zbyc4
-- valory/trader_abci:0.1.0:bafybeic3bui5ry3i7ekazbcvisf2z7udjwxyywwgv4au6opzzufpwpcvhm
+- valory/decision_maker_abci:0.1.0:bafybeiaw5kilhtdu7fcmk5553l3m6v366myaflekvipe4qa2vp4arbzlva
+- valory/trader_abci:0.1.0:bafybeibvlfhotlobiuemgra677qrmb5juumhpg4wz5uayi42sa6asxlona
 - valory/staking_abci:0.1.0:bafybeigo7bicej5t2rbki37cmcwkzgwpcnopokn7ijhylmkihsbqw47xr4
 - valory/check_stop_trading_abci:0.1.0:bafybeickfeuqlpmryegnfvfu2duk2v4ycowwloohu3xxrafd5md6xl5swi
 - valory/mech_interact_abci:0.1.0:bafybeih2cck5xu6yaibomwtm5zbcp6llghr3ighdnk56fzwu3ihu5xx35e

--- a/packages/valory/agents/trader/aea-config.yaml
+++ b/packages/valory/agents/trader/aea-config.yaml
@@ -45,10 +45,10 @@ skills:
 - valory/reset_pause_abci:0.1.0:bafybeiameewywqigpupy3u2iwnkfczeiiucue74x2l5lbge74rmw6bgaie
 - valory/termination_abci:0.1.0:bafybeif2zim2de356eo3sipkmoev5emwadpqqzk3huwqarywh4tmqt3vzq
 - valory/transaction_settlement_abci:0.1.0:bafybeic3tccdjypuge2lewtlgprwkbb53lhgsgn7oiwzyrcrrptrbeyote
-- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeidkr6vthdixhjxe423bur7deeynzfwqmqc2gyylhxadfsbzo22faa
+- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeiaybhcckjudnmelw3vc4mhw7fmydisyguanvlb2h6kdbhke3kjsvi
 - valory/market_manager_abci:0.1.0:bafybeicbvxvjkoksbknujaid5hx7krjlgm6barcjcwo33tdccanrcp674a
-- valory/decision_maker_abci:0.1.0:bafybeiaw5kilhtdu7fcmk5553l3m6v366myaflekvipe4qa2vp4arbzlva
-- valory/trader_abci:0.1.0:bafybeibvlfhotlobiuemgra677qrmb5juumhpg4wz5uayi42sa6asxlona
+- valory/decision_maker_abci:0.1.0:bafybeibb2qs73ug56hazdmuirwa2avbbdmenuhbmmwcp7zn4fdgztd6sjy
+- valory/trader_abci:0.1.0:bafybeietcp2q726jgo3wwoautzkxuwjoa4jdv2bllcx4o44plsh5gqt7fu
 - valory/staking_abci:0.1.0:bafybeigo7bicej5t2rbki37cmcwkzgwpcnopokn7ijhylmkihsbqw47xr4
 - valory/check_stop_trading_abci:0.1.0:bafybeickfeuqlpmryegnfvfu2duk2v4ycowwloohu3xxrafd5md6xl5swi
 - valory/mech_interact_abci:0.1.0:bafybeih2cck5xu6yaibomwtm5zbcp6llghr3ighdnk56fzwu3ihu5xx35e

--- a/packages/valory/services/trader/service.yaml
+++ b/packages/valory/services/trader/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeigtuothskwyvrhfosps2bu6suauycolj67dpuxqvnicdrdu7yhtvq
 fingerprint_ignore_patterns: []
-agent: valory/trader:0.1.0:bafybeidvindh7eho6wdeoi4ylaqarsputtlvz7ujsros7pgjhoemuhqzy4
+agent: valory/trader:0.1.0:bafybeidt6cy3vo33dcue5ocyi7j2y6gxomzdotlgjq7hresembhdam533i
 number_of_agents: 4
 deployment:
   agent:

--- a/packages/valory/services/trader/service.yaml
+++ b/packages/valory/services/trader/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeigtuothskwyvrhfosps2bu6suauycolj67dpuxqvnicdrdu7yhtvq
 fingerprint_ignore_patterns: []
-agent: valory/trader:0.1.0:bafybeidt6cy3vo33dcue5ocyi7j2y6gxomzdotlgjq7hresembhdam533i
+agent: valory/trader:0.1.0:bafybeiczhuenxymwnoankdarwogerydxmzkjeefe6anokksaok25dto6nu
 number_of_agents: 4
 deployment:
   agent:

--- a/packages/valory/skills/decision_maker_abci/behaviours/blacklisting.py
+++ b/packages/valory/skills/decision_maker_abci/behaviours/blacklisting.py
@@ -82,6 +82,11 @@ class BlacklistingBehaviour(DecisionMakerBaseBehaviour):
 
     def async_act(self) -> Generator:
         """Do the action."""
+        # if the tool selection has not been run for the current period, do not do anything
+        if not self.synchronized_data.has_tool_selection_run:
+            policy = self.policy.serialize()
+            payload = BlacklistingPayload(self.context.agent_address, None, policy)
+            yield from self.finish_behaviour(payload)
 
         with self.context.benchmark_tool.measure(self.behaviour_id).local():
             self.read_bets()

--- a/packages/valory/skills/decision_maker_abci/skill.yaml
+++ b/packages/valory/skills/decision_maker_abci/skill.yaml
@@ -25,7 +25,7 @@ fingerprint:
   behaviours/reedem.py: bafybeieyqb2w7bvvl4wkgpqwryyyb4lex4wmwoykylehr2zljz3a7tkeja
   behaviours/round_behaviour.py: bafybeibvhobpvzzd37ecleuyp2jrbed6nontcw7urtsilbbzvqsmmupx64
   behaviours/sampling.py: bafybeibtkli72qsvotkrsepkgpiumtr5sershtkpb427oygnszs3dpgxry
-  behaviours/tool_selection.py: bafybeie7xhopohfoct7jggerk6nu3vkhlx7uhcowo3dfktoqmr7227j4ke
+  behaviours/tool_selection.py: bafybeicjfo5pqaupv4bpupvkccfffg65sygcgzlg4cieoiktjfilzf5l3a
   dialogues.py: bafybeigpwuzku3we7axmxeamg7vn656maww6emuztau5pg3ebsoquyfdqm
   fsm_specification.yaml: bafybeif2kas4eho4aielucf3ihjzjsog32icccbxrvje6kkw7aw4m4zg6q
   handlers.py: bafybeielhwnfm2blt6clmwr557g2g3gddnt5bpb4cqul6p3wiwsfoksvlu

--- a/packages/valory/skills/decision_maker_abci/skill.yaml
+++ b/packages/valory/skills/decision_maker_abci/skill.yaml
@@ -14,7 +14,7 @@ fingerprint:
   behaviours/__init__.py: bafybeih6ddz2ocvm6x6ytvlbcz6oi4snb5ee5xh5h65nq4w2qf7fd7zfky
   behaviours/base.py: bafybeie2a3p2aimyizrofos5y55ha7peyyf657phcknllf7kuv6u6ojgca
   behaviours/bet_placement.py: bafybeia62an6dpkf6b46fzc4epcyh3zuvpvoge3ewmussclxbldjf3bdue
-  behaviours/blacklisting.py: bafybeiaghjvhzyeltk6necqwqfwgwp6z4ckpgt3ee2yj3qhcneg5eorowi
+  behaviours/blacklisting.py: bafybeiascy4axrqofvv3yivpxxdhkkoe2loyidl46el35wqfjbb6lm6hha
   behaviours/check_benchmarking.py: bafybeiao2lyj7apezkqrpgsyzb3dwvrdgsrgtprf6iuhsmlsufvxfl5bci
   behaviours/claim_subscription.py: bafybeihv5dg74deifzk46ppdwcvz6lgamgl6m7qr6sgqv2zie35j2576ca
   behaviours/decision_receive.py: bafybeiggpof3f6b5epdoywyfpi6xhnrdy5brbsjfq2r6bww2cusqcqb7g4
@@ -37,7 +37,7 @@ fingerprint:
   redeem_info.py: bafybeifiiix4gihfo4avraxt34sfw35v6dqq45do2drrssei2shbps63mm
   rounds.py: bafybeihzr4tovdz2dzgzm4elwifejrtkto6mcdb5zwfk5lyzp63nmuzepa
   states/__init__.py: bafybeid23llnyp6j257dluxmrnztugo5llsrog7kua53hllyktz4dqhqoy
-  states/base.py: bafybeier54hauln3hb6aqzsrt56q3txjwdlgzehugmx3ip2ee7zjzbn4i4
+  states/base.py: bafybeigyynuezlgpqcs7cw35tnjd3l3bcdy6nzvqol2mcehgm5d7lv2zei
   states/bet_placement.py: bafybeibalhxhp2c4oljmiwqi6ds3g36fgtabmf42mb5sgq6z22znrcbhda
   states/blacklisting.py: bafybeiapelgjhbjjn4uq4z5gspyirqzwzgccg5anktrp5kxdwamfnfw5mi
   states/check_benchmarking.py: bafybeiabv6pq7q45jd3nkor5afmlycqgec5ctuwcfbdukkjjm4imesv4ni

--- a/packages/valory/skills/decision_maker_abci/states/base.py
+++ b/packages/valory/skills/decision_maker_abci/states/base.py
@@ -97,6 +97,12 @@ class SynchronizedData(MarketManagerSyncedData, TxSettlementSyncedData):
         return EGreedyPolicy.deserialize(policy)
 
     @property
+    def has_tool_selection_run(self) -> bool:
+        """Get whether the tool selection has run."""
+        mech_tool_idx = self.db.get("mech_tool_idx", None)
+        return mech_tool_idx is not None
+
+    @property
     def mech_tool_idx(self) -> int:
         """Get the mech tool's index."""
         return int(self.db.get_strict("mech_tool_idx"))

--- a/packages/valory/skills/trader_abci/skill.yaml
+++ b/packages/valory/skills/trader_abci/skill.yaml
@@ -25,8 +25,8 @@ skills:
 - valory/transaction_settlement_abci:0.1.0:bafybeic3tccdjypuge2lewtlgprwkbb53lhgsgn7oiwzyrcrrptrbeyote
 - valory/termination_abci:0.1.0:bafybeif2zim2de356eo3sipkmoev5emwadpqqzk3huwqarywh4tmqt3vzq
 - valory/market_manager_abci:0.1.0:bafybeicbvxvjkoksbknujaid5hx7krjlgm6barcjcwo33tdccanrcp674a
-- valory/decision_maker_abci:0.1.0:bafybeifcv22lf2qulw5egxxmbux2dzuqnyeu2cpvwyipptoub5r54zbyc4
-- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeic6tizt4rabpntz56evu7jnucvelciehhveh2baaojg7w6xke4ika
+- valory/decision_maker_abci:0.1.0:bafybeiaw5kilhtdu7fcmk5553l3m6v366myaflekvipe4qa2vp4arbzlva
+- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeidkr6vthdixhjxe423bur7deeynzfwqmqc2gyylhxadfsbzo22faa
 - valory/staking_abci:0.1.0:bafybeigo7bicej5t2rbki37cmcwkzgwpcnopokn7ijhylmkihsbqw47xr4
 - valory/check_stop_trading_abci:0.1.0:bafybeickfeuqlpmryegnfvfu2duk2v4ycowwloohu3xxrafd5md6xl5swi
 - valory/mech_interact_abci:0.1.0:bafybeih2cck5xu6yaibomwtm5zbcp6llghr3ighdnk56fzwu3ihu5xx35e

--- a/packages/valory/skills/trader_abci/skill.yaml
+++ b/packages/valory/skills/trader_abci/skill.yaml
@@ -25,8 +25,8 @@ skills:
 - valory/transaction_settlement_abci:0.1.0:bafybeic3tccdjypuge2lewtlgprwkbb53lhgsgn7oiwzyrcrrptrbeyote
 - valory/termination_abci:0.1.0:bafybeif2zim2de356eo3sipkmoev5emwadpqqzk3huwqarywh4tmqt3vzq
 - valory/market_manager_abci:0.1.0:bafybeicbvxvjkoksbknujaid5hx7krjlgm6barcjcwo33tdccanrcp674a
-- valory/decision_maker_abci:0.1.0:bafybeiaw5kilhtdu7fcmk5553l3m6v366myaflekvipe4qa2vp4arbzlva
-- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeidkr6vthdixhjxe423bur7deeynzfwqmqc2gyylhxadfsbzo22faa
+- valory/decision_maker_abci:0.1.0:bafybeibb2qs73ug56hazdmuirwa2avbbdmenuhbmmwcp7zn4fdgztd6sjy
+- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeiaybhcckjudnmelw3vc4mhw7fmydisyguanvlb2h6kdbhke3kjsvi
 - valory/staking_abci:0.1.0:bafybeigo7bicej5t2rbki37cmcwkzgwpcnopokn7ijhylmkihsbqw47xr4
 - valory/check_stop_trading_abci:0.1.0:bafybeickfeuqlpmryegnfvfu2duk2v4ycowwloohu3xxrafd5md6xl5swi
 - valory/mech_interact_abci:0.1.0:bafybeih2cck5xu6yaibomwtm5zbcp6llghr3ighdnk56fzwu3ihu5xx35e

--- a/packages/valory/skills/tx_settlement_multiplexer_abci/skill.yaml
+++ b/packages/valory/skills/tx_settlement_multiplexer_abci/skill.yaml
@@ -21,7 +21,7 @@ protocols:
 - valory/ledger_api:1.0.0:bafybeihdk6psr4guxmbcrc26jr2cbgzpd5aljkqvpwo64bvaz7tdti2oni
 skills:
 - valory/abstract_round_abci:0.1.0:bafybeiar2yhzxacfe3qqamqhaihtlcimquwedffctw55sowx6rac3cm3ui
-- valory/decision_maker_abci:0.1.0:bafybeiaw5kilhtdu7fcmk5553l3m6v366myaflekvipe4qa2vp4arbzlva
+- valory/decision_maker_abci:0.1.0:bafybeibb2qs73ug56hazdmuirwa2avbbdmenuhbmmwcp7zn4fdgztd6sjy
 - valory/staking_abci:0.1.0:bafybeigo7bicej5t2rbki37cmcwkzgwpcnopokn7ijhylmkihsbqw47xr4
 - valory/mech_interact_abci:0.1.0:bafybeih2cck5xu6yaibomwtm5zbcp6llghr3ighdnk56fzwu3ihu5xx35e
 behaviours:

--- a/packages/valory/skills/tx_settlement_multiplexer_abci/skill.yaml
+++ b/packages/valory/skills/tx_settlement_multiplexer_abci/skill.yaml
@@ -21,7 +21,7 @@ protocols:
 - valory/ledger_api:1.0.0:bafybeihdk6psr4guxmbcrc26jr2cbgzpd5aljkqvpwo64bvaz7tdti2oni
 skills:
 - valory/abstract_round_abci:0.1.0:bafybeiar2yhzxacfe3qqamqhaihtlcimquwedffctw55sowx6rac3cm3ui
-- valory/decision_maker_abci:0.1.0:bafybeifcv22lf2qulw5egxxmbux2dzuqnyeu2cpvwyipptoub5r54zbyc4
+- valory/decision_maker_abci:0.1.0:bafybeiaw5kilhtdu7fcmk5553l3m6v366myaflekvipe4qa2vp4arbzlva
 - valory/staking_abci:0.1.0:bafybeigo7bicej5t2rbki37cmcwkzgwpcnopokn7ijhylmkihsbqw47xr4
 - valory/mech_interact_abci:0.1.0:bafybeih2cck5xu6yaibomwtm5zbcp6llghr3ighdnk56fzwu3ihu5xx35e
 behaviours:


### PR DESCRIPTION
This fixes an edge case caused when the tx settlement round fails and no tool has been selected. This can happen in two cases:
1. After the nevermined subscription round
2. After the KPI has been met and the tool selection is skipped intentionally. 

If this happens, the `HandleFailedTxRound` is called, and then the `BlacklistingRound`. During the blacklisting, no tool has been selected for the current round, and therefore we get:

```
ValueError: 'mech_tool_idx' field is not set for this period [x] and no default value was provided.
```

In order to fix this, we simply check whether the tool selection has been run, and only then proceed to the blacklisting operation.