### PR TITLE
Fix blocking behaviour on Pearl agent

### DIFF
--- a/packages/packages.json
+++ b/packages/packages.json
@@ -22,7 +22,7 @@
         "skill/valory/check_stop_trading_abci/0.1.0": "bafybeig4xbc4izvanftxjvmhhuzuolqdx5fb3xtmnsvmhoghg7lrgn6rmq",
         "agent/valory/trader/0.1.0": "bafybeic7qgdwowkeffq56g44wg5h7otfhcvgbigdxstryxc3lw35vtfofa",
         "service/valory/trader/0.1.0": "bafybeiagay3wff3ieso2rlzbtypi6657bu5yep5eshcogo2habfkjg3xy4",
-        "service/valory/trader_omen_gnosis/0.1.0": "bafybeibcel7tvcc3yhqobiro7klrmuv7ues3goaesozybhq6jlrxkjpw3u"
+        "service/valory/trader_omen_gnosis/0.1.0": "bafybeihv3nyh43rim6kcxdscdgsiojhbqfwndhwcrtxhi3gkxbnasdc7ui"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeihv62fim3wl2bayavfcg3u5e5cxu3b7brtu4cn5xoxd6lqwachasi",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -21,7 +21,7 @@
         "skill/valory/staking_abci/0.1.0": "bafybeidpc3vvcri7tzx2cuxgtoabaunux5jjc7sa3mibsqho2agiv64pim",
         "skill/valory/check_stop_trading_abci/0.1.0": "bafybeig4xbc4izvanftxjvmhhuzuolqdx5fb3xtmnsvmhoghg7lrgn6rmq",
         "agent/valory/trader/0.1.0": "bafybeiajgc36fmbvxrflj4mgkdpesjykjelajutttkiqqnfcb6ycvwn5o4",
-        "service/valory/trader/0.1.0": "bafybeih7horukvnp7dq2iumxznhjyustpxvimiseusyx4muvpgb7tdt3vu",
+        "service/valory/trader/0.1.0": "bafybeidftggpk4qfsgxock7wt2pou4e227s6odjuoupsufytyw2mkujyay",
         "service/valory/trader_omen_gnosis/0.1.0": "bafybeibbloa4w33vj4bvdkso7pzk6tr3duvxjpecbx4mur4ix6ehnwb5uu"
     },
     "third_party": {

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -16,13 +16,13 @@
         "contract/valory/relayer/0.1.0": "bafybeiaabvxim4blp5fxb6qjlzjivtvkme3fk24h5jte7w6vr6rsx72j6u",
         "skill/valory/market_manager_abci/0.1.0": "bafybeicbvxvjkoksbknujaid5hx7krjlgm6barcjcwo33tdccanrcp674a",
         "skill/valory/decision_maker_abci/0.1.0": "bafybeihvaze22cfs7djtbduficbtmbcv4n5nc3g45irnczhwuqzzcvkr6y",
-        "skill/valory/trader_abci/0.1.0": "bafybeietewrf35mcpiza52lcybolh4czedxphkmwesg4kawce4f6hmgq7i",
-        "skill/valory/tx_settlement_multiplexer_abci/0.1.0": "bafybeicm7jbix6qnptanwg34agi4kndaazywzzwr3httv6xtlfgcn47rcy",
-        "skill/valory/staking_abci/0.1.0": "bafybeidt4bcu257zb4nge357j3llbodajeaeo4atapaadki2qiznvnvlni",
-        "skill/valory/check_stop_trading_abci/0.1.0": "bafybeiebravnf2aqk2rhxkala5auws3t5bhdmzjfm2drgrorcurt3pznfa",
-        "agent/valory/trader/0.1.0": "bafybeiahhjwk4chbeenr77uzr7ryrgxjhtkkpdb3htwo6y3fmz6fpgop6u",
-        "service/valory/trader/0.1.0": "bafybeicmfj4dxknm6gueod5perbtunz6ypalr74v5bv3q5c3nrb2ymclsm",
-        "service/valory/trader_omen_gnosis/0.1.0": "bafybeifjtoqigilzka5kxqegdvcswji246a67536qfovhswdqterfxnw2q"
+        "skill/valory/trader_abci/0.1.0": "bafybeic5stbbd6q2vgtweb4ifnjgjb3mobehuijhn6pbaa7hmzn7om4h4q",
+        "skill/valory/tx_settlement_multiplexer_abci/0.1.0": "bafybeif6yp475vtskwp7jk3lbrtgkzmbim5o74rlrhp6fwy65dfhzuazgi",
+        "skill/valory/staking_abci/0.1.0": "bafybeicbzbfyngqjllkpfvwo62zewotebebstdlpykmmhlzezknkaphdni",
+        "skill/valory/check_stop_trading_abci/0.1.0": "bafybeigiavk6dwd5clx32paza7qsmkkmhc4tvgy5tteazmdkhj7v32p6fq",
+        "agent/valory/trader/0.1.0": "bafybeif2sjvwqa7dzz4ieajtffl3eftscc4xfnruxnrg5dlrrwe53b5bgu",
+        "service/valory/trader/0.1.0": "bafybeie5kacqtjpmdtlqz2grk53z2mzs7guonuy327ks25q3kuhzgau4ge",
+        "service/valory/trader_omen_gnosis/0.1.0": "bafybeieg45wcjcwd5znuwpjcp5scfhgdqwpfq43pzaare6nwvmy5bb56cm"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeihv62fim3wl2bayavfcg3u5e5cxu3b7brtu4cn5xoxd6lqwachasi",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -16,13 +16,13 @@
         "contract/valory/relayer/0.1.0": "bafybeiaabvxim4blp5fxb6qjlzjivtvkme3fk24h5jte7w6vr6rsx72j6u",
         "skill/valory/market_manager_abci/0.1.0": "bafybeicbvxvjkoksbknujaid5hx7krjlgm6barcjcwo33tdccanrcp674a",
         "skill/valory/decision_maker_abci/0.1.0": "bafybeihvaze22cfs7djtbduficbtmbcv4n5nc3g45irnczhwuqzzcvkr6y",
-        "skill/valory/trader_abci/0.1.0": "bafybeib5t4rbvoybx6qv4fjdxhjd72rrz3jdcko4uksgim2gedldeoij5a",
-        "skill/valory/tx_settlement_multiplexer_abci/0.1.0": "bafybeialmq3grz5eurvoad7gjl4hpvqapnqtlehy2qj5isxtx43s2e5zlq",
-        "skill/valory/staking_abci/0.1.0": "bafybeihmqmf37cyik5naiiofsrwsw27ey3qm4tq7bgjp5gghvrbcb4nati",
-        "skill/valory/check_stop_trading_abci/0.1.0": "bafybeignyejmijrwpdwubkolchqliz323faheeywol6xlqcll2e55a7gly",
-        "agent/valory/trader/0.1.0": "bafybeida4fgx2k33fr27kulnl3y2e7z5zkrsq6w5sb7a6tfu43oeonrzui",
-        "service/valory/trader/0.1.0": "bafybeigrgjinmacqzd6v6jzdkukv7gwk4v2b2ufyajfc7yfgjuso3avun4",
-        "service/valory/trader_omen_gnosis/0.1.0": "bafybeiei7wb5jvrn7e7fss2t6ajnkjakgf7uaz42fvvlkolhpnez2dlfsy"
+        "skill/valory/trader_abci/0.1.0": "bafybeietewrf35mcpiza52lcybolh4czedxphkmwesg4kawce4f6hmgq7i",
+        "skill/valory/tx_settlement_multiplexer_abci/0.1.0": "bafybeicm7jbix6qnptanwg34agi4kndaazywzzwr3httv6xtlfgcn47rcy",
+        "skill/valory/staking_abci/0.1.0": "bafybeidt4bcu257zb4nge357j3llbodajeaeo4atapaadki2qiznvnvlni",
+        "skill/valory/check_stop_trading_abci/0.1.0": "bafybeiebravnf2aqk2rhxkala5auws3t5bhdmzjfm2drgrorcurt3pznfa",
+        "agent/valory/trader/0.1.0": "bafybeiahhjwk4chbeenr77uzr7ryrgxjhtkkpdb3htwo6y3fmz6fpgop6u",
+        "service/valory/trader/0.1.0": "bafybeicmfj4dxknm6gueod5perbtunz6ypalr74v5bv3q5c3nrb2ymclsm",
+        "service/valory/trader_omen_gnosis/0.1.0": "bafybeifjtoqigilzka5kxqegdvcswji246a67536qfovhswdqterfxnw2q"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeihv62fim3wl2bayavfcg3u5e5cxu3b7brtu4cn5xoxd6lqwachasi",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -16,13 +16,13 @@
         "contract/valory/relayer/0.1.0": "bafybeiaabvxim4blp5fxb6qjlzjivtvkme3fk24h5jte7w6vr6rsx72j6u",
         "skill/valory/market_manager_abci/0.1.0": "bafybeicbvxvjkoksbknujaid5hx7krjlgm6barcjcwo33tdccanrcp674a",
         "skill/valory/decision_maker_abci/0.1.0": "bafybeihvaze22cfs7djtbduficbtmbcv4n5nc3g45irnczhwuqzzcvkr6y",
-        "skill/valory/trader_abci/0.1.0": "bafybeif2ssppwfdm7kbabw3xe2336apxpafzia3dszd7b6ecb63we6csh4",
-        "skill/valory/tx_settlement_multiplexer_abci/0.1.0": "bafybeietfxfo5k3inw6s35e7ovqv7aklkjwaby2ienauud4kri33qoztwa",
-        "skill/valory/staking_abci/0.1.0": "bafybeidpc3vvcri7tzx2cuxgtoabaunux5jjc7sa3mibsqho2agiv64pim",
-        "skill/valory/check_stop_trading_abci/0.1.0": "bafybeig4xbc4izvanftxjvmhhuzuolqdx5fb3xtmnsvmhoghg7lrgn6rmq",
-        "agent/valory/trader/0.1.0": "bafybeic7qgdwowkeffq56g44wg5h7otfhcvgbigdxstryxc3lw35vtfofa",
-        "service/valory/trader/0.1.0": "bafybeiagay3wff3ieso2rlzbtypi6657bu5yep5eshcogo2habfkjg3xy4",
-        "service/valory/trader_omen_gnosis/0.1.0": "bafybeihv3nyh43rim6kcxdscdgsiojhbqfwndhwcrtxhi3gkxbnasdc7ui"
+        "skill/valory/trader_abci/0.1.0": "bafybeib5t4rbvoybx6qv4fjdxhjd72rrz3jdcko4uksgim2gedldeoij5a",
+        "skill/valory/tx_settlement_multiplexer_abci/0.1.0": "bafybeialmq3grz5eurvoad7gjl4hpvqapnqtlehy2qj5isxtx43s2e5zlq",
+        "skill/valory/staking_abci/0.1.0": "bafybeihmqmf37cyik5naiiofsrwsw27ey3qm4tq7bgjp5gghvrbcb4nati",
+        "skill/valory/check_stop_trading_abci/0.1.0": "bafybeignyejmijrwpdwubkolchqliz323faheeywol6xlqcll2e55a7gly",
+        "agent/valory/trader/0.1.0": "bafybeida4fgx2k33fr27kulnl3y2e7z5zkrsq6w5sb7a6tfu43oeonrzui",
+        "service/valory/trader/0.1.0": "bafybeigrgjinmacqzd6v6jzdkukv7gwk4v2b2ufyajfc7yfgjuso3avun4",
+        "service/valory/trader_omen_gnosis/0.1.0": "bafybeiei7wb5jvrn7e7fss2t6ajnkjakgf7uaz42fvvlkolhpnez2dlfsy"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeihv62fim3wl2bayavfcg3u5e5cxu3b7brtu4cn5xoxd6lqwachasi",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -20,9 +20,9 @@
         "skill/valory/tx_settlement_multiplexer_abci/0.1.0": "bafybeietfxfo5k3inw6s35e7ovqv7aklkjwaby2ienauud4kri33qoztwa",
         "skill/valory/staking_abci/0.1.0": "bafybeidpc3vvcri7tzx2cuxgtoabaunux5jjc7sa3mibsqho2agiv64pim",
         "skill/valory/check_stop_trading_abci/0.1.0": "bafybeig4xbc4izvanftxjvmhhuzuolqdx5fb3xtmnsvmhoghg7lrgn6rmq",
-        "agent/valory/trader/0.1.0": "bafybeiajgc36fmbvxrflj4mgkdpesjykjelajutttkiqqnfcb6ycvwn5o4",
-        "service/valory/trader/0.1.0": "bafybeih7horukvnp7dq2iumxznhjyustpxvimiseusyx4muvpgb7tdt3vu",
-        "service/valory/trader_omen_gnosis/0.1.0": "bafybeih5woeemgmz2dgez6t335eydw2sftse2alsbkvkxormt55ef7o7e4"
+        "agent/valory/trader/0.1.0": "bafybeic7qgdwowkeffq56g44wg5h7otfhcvgbigdxstryxc3lw35vtfofa",
+        "service/valory/trader/0.1.0": "bafybeiagay3wff3ieso2rlzbtypi6657bu5yep5eshcogo2habfkjg3xy4",
+        "service/valory/trader_omen_gnosis/0.1.0": "bafybeibcel7tvcc3yhqobiro7klrmuv7ues3goaesozybhq6jlrxkjpw3u"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeihv62fim3wl2bayavfcg3u5e5cxu3b7brtu4cn5xoxd6lqwachasi",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -21,8 +21,8 @@
         "skill/valory/staking_abci/0.1.0": "bafybeidpc3vvcri7tzx2cuxgtoabaunux5jjc7sa3mibsqho2agiv64pim",
         "skill/valory/check_stop_trading_abci/0.1.0": "bafybeig4xbc4izvanftxjvmhhuzuolqdx5fb3xtmnsvmhoghg7lrgn6rmq",
         "agent/valory/trader/0.1.0": "bafybeiajgc36fmbvxrflj4mgkdpesjykjelajutttkiqqnfcb6ycvwn5o4",
-        "service/valory/trader/0.1.0": "bafybeidftggpk4qfsgxock7wt2pou4e227s6odjuoupsufytyw2mkujyay",
-        "service/valory/trader_omen_gnosis/0.1.0": "bafybeibbloa4w33vj4bvdkso7pzk6tr3duvxjpecbx4mur4ix6ehnwb5uu"
+        "service/valory/trader/0.1.0": "bafybeih7horukvnp7dq2iumxznhjyustpxvimiseusyx4muvpgb7tdt3vu",
+        "service/valory/trader_omen_gnosis/0.1.0": "bafybeih5woeemgmz2dgez6t335eydw2sftse2alsbkvkxormt55ef7o7e4"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeihv62fim3wl2bayavfcg3u5e5cxu3b7brtu4cn5xoxd6lqwachasi",

--- a/packages/valory/agents/trader/aea-config.yaml
+++ b/packages/valory/agents/trader/aea-config.yaml
@@ -47,12 +47,12 @@ skills:
 - valory/reset_pause_abci:0.1.0:bafybeiameewywqigpupy3u2iwnkfczeiiucue74x2l5lbge74rmw6bgaie
 - valory/termination_abci:0.1.0:bafybeif2zim2de356eo3sipkmoev5emwadpqqzk3huwqarywh4tmqt3vzq
 - valory/transaction_settlement_abci:0.1.0:bafybeic3tccdjypuge2lewtlgprwkbb53lhgsgn7oiwzyrcrrptrbeyote
-- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeialmq3grz5eurvoad7gjl4hpvqapnqtlehy2qj5isxtx43s2e5zlq
+- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeicm7jbix6qnptanwg34agi4kndaazywzzwr3httv6xtlfgcn47rcy
 - valory/market_manager_abci:0.1.0:bafybeicbvxvjkoksbknujaid5hx7krjlgm6barcjcwo33tdccanrcp674a
 - valory/decision_maker_abci:0.1.0:bafybeihvaze22cfs7djtbduficbtmbcv4n5nc3g45irnczhwuqzzcvkr6y
-- valory/trader_abci:0.1.0:bafybeib5t4rbvoybx6qv4fjdxhjd72rrz3jdcko4uksgim2gedldeoij5a
-- valory/staking_abci:0.1.0:bafybeihmqmf37cyik5naiiofsrwsw27ey3qm4tq7bgjp5gghvrbcb4nati
-- valory/check_stop_trading_abci:0.1.0:bafybeignyejmijrwpdwubkolchqliz323faheeywol6xlqcll2e55a7gly
+- valory/trader_abci:0.1.0:bafybeietewrf35mcpiza52lcybolh4czedxphkmwesg4kawce4f6hmgq7i
+- valory/staking_abci:0.1.0:bafybeidt4bcu257zb4nge357j3llbodajeaeo4atapaadki2qiznvnvlni
+- valory/check_stop_trading_abci:0.1.0:bafybeiebravnf2aqk2rhxkala5auws3t5bhdmzjfm2drgrorcurt3pznfa
 - valory/mech_interact_abci:0.1.0:bafybeih2cck5xu6yaibomwtm5zbcp6llghr3ighdnk56fzwu3ihu5xx35e
 customs:
 - valory/mike_strat:0.1.0:bafybeihjiol7f4ch4piwfikurdtfwzsh6qydkbsztpbwbwb2yrqdqf726m

--- a/packages/valory/agents/trader/aea-config.yaml
+++ b/packages/valory/agents/trader/aea-config.yaml
@@ -47,12 +47,12 @@ skills:
 - valory/reset_pause_abci:0.1.0:bafybeiameewywqigpupy3u2iwnkfczeiiucue74x2l5lbge74rmw6bgaie
 - valory/termination_abci:0.1.0:bafybeif2zim2de356eo3sipkmoev5emwadpqqzk3huwqarywh4tmqt3vzq
 - valory/transaction_settlement_abci:0.1.0:bafybeic3tccdjypuge2lewtlgprwkbb53lhgsgn7oiwzyrcrrptrbeyote
-- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeicm7jbix6qnptanwg34agi4kndaazywzzwr3httv6xtlfgcn47rcy
+- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeif6yp475vtskwp7jk3lbrtgkzmbim5o74rlrhp6fwy65dfhzuazgi
 - valory/market_manager_abci:0.1.0:bafybeicbvxvjkoksbknujaid5hx7krjlgm6barcjcwo33tdccanrcp674a
 - valory/decision_maker_abci:0.1.0:bafybeihvaze22cfs7djtbduficbtmbcv4n5nc3g45irnczhwuqzzcvkr6y
-- valory/trader_abci:0.1.0:bafybeietewrf35mcpiza52lcybolh4czedxphkmwesg4kawce4f6hmgq7i
-- valory/staking_abci:0.1.0:bafybeidt4bcu257zb4nge357j3llbodajeaeo4atapaadki2qiznvnvlni
-- valory/check_stop_trading_abci:0.1.0:bafybeiebravnf2aqk2rhxkala5auws3t5bhdmzjfm2drgrorcurt3pznfa
+- valory/trader_abci:0.1.0:bafybeic5stbbd6q2vgtweb4ifnjgjb3mobehuijhn6pbaa7hmzn7om4h4q
+- valory/staking_abci:0.1.0:bafybeicbzbfyngqjllkpfvwo62zewotebebstdlpykmmhlzezknkaphdni
+- valory/check_stop_trading_abci:0.1.0:bafybeigiavk6dwd5clx32paza7qsmkkmhc4tvgy5tteazmdkhj7v32p6fq
 - valory/mech_interact_abci:0.1.0:bafybeih2cck5xu6yaibomwtm5zbcp6llghr3ighdnk56fzwu3ihu5xx35e
 customs:
 - valory/mike_strat:0.1.0:bafybeihjiol7f4ch4piwfikurdtfwzsh6qydkbsztpbwbwb2yrqdqf726m

--- a/packages/valory/agents/trader/aea-config.yaml
+++ b/packages/valory/agents/trader/aea-config.yaml
@@ -285,4 +285,5 @@ public_id: valory/http_server:0.22.0:bafybeicblltx7ha3ulthg7bzfccuqqyjmihhrvfezt
 type: connection
 config:
   host: ${str:0.0.0.0}
+  port: ${int:8000}
   target_skill_id: valory/trader_abci:0.1.0

--- a/packages/valory/agents/trader/aea-config.yaml
+++ b/packages/valory/agents/trader/aea-config.yaml
@@ -47,12 +47,12 @@ skills:
 - valory/reset_pause_abci:0.1.0:bafybeiameewywqigpupy3u2iwnkfczeiiucue74x2l5lbge74rmw6bgaie
 - valory/termination_abci:0.1.0:bafybeif2zim2de356eo3sipkmoev5emwadpqqzk3huwqarywh4tmqt3vzq
 - valory/transaction_settlement_abci:0.1.0:bafybeic3tccdjypuge2lewtlgprwkbb53lhgsgn7oiwzyrcrrptrbeyote
-- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeietfxfo5k3inw6s35e7ovqv7aklkjwaby2ienauud4kri33qoztwa
+- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeialmq3grz5eurvoad7gjl4hpvqapnqtlehy2qj5isxtx43s2e5zlq
 - valory/market_manager_abci:0.1.0:bafybeicbvxvjkoksbknujaid5hx7krjlgm6barcjcwo33tdccanrcp674a
 - valory/decision_maker_abci:0.1.0:bafybeihvaze22cfs7djtbduficbtmbcv4n5nc3g45irnczhwuqzzcvkr6y
-- valory/trader_abci:0.1.0:bafybeif2ssppwfdm7kbabw3xe2336apxpafzia3dszd7b6ecb63we6csh4
-- valory/staking_abci:0.1.0:bafybeidpc3vvcri7tzx2cuxgtoabaunux5jjc7sa3mibsqho2agiv64pim
-- valory/check_stop_trading_abci:0.1.0:bafybeig4xbc4izvanftxjvmhhuzuolqdx5fb3xtmnsvmhoghg7lrgn6rmq
+- valory/trader_abci:0.1.0:bafybeib5t4rbvoybx6qv4fjdxhjd72rrz3jdcko4uksgim2gedldeoij5a
+- valory/staking_abci:0.1.0:bafybeihmqmf37cyik5naiiofsrwsw27ey3qm4tq7bgjp5gghvrbcb4nati
+- valory/check_stop_trading_abci:0.1.0:bafybeignyejmijrwpdwubkolchqliz323faheeywol6xlqcll2e55a7gly
 - valory/mech_interact_abci:0.1.0:bafybeih2cck5xu6yaibomwtm5zbcp6llghr3ighdnk56fzwu3ihu5xx35e
 customs:
 - valory/mike_strat:0.1.0:bafybeihjiol7f4ch4piwfikurdtfwzsh6qydkbsztpbwbwb2yrqdqf726m

--- a/packages/valory/services/trader/service.yaml
+++ b/packages/valory/services/trader/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeigtuothskwyvrhfosps2bu6suauycolj67dpuxqvnicdrdu7yhtvq
 fingerprint_ignore_patterns: []
-agent: valory/trader:0.1.0:bafybeiajgc36fmbvxrflj4mgkdpesjykjelajutttkiqqnfcb6ycvwn5o4
+agent: valory/trader:0.1.0:bafybeic7qgdwowkeffq56g44wg5h7otfhcvgbigdxstryxc3lw35vtfofa
 number_of_agents: 4
 deployment:
   agent:

--- a/packages/valory/services/trader/service.yaml
+++ b/packages/valory/services/trader/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeigtuothskwyvrhfosps2bu6suauycolj67dpuxqvnicdrdu7yhtvq
 fingerprint_ignore_patterns: []
-agent: valory/trader:0.1.0:bafybeida4fgx2k33fr27kulnl3y2e7z5zkrsq6w5sb7a6tfu43oeonrzui
+agent: valory/trader:0.1.0:bafybeiahhjwk4chbeenr77uzr7ryrgxjhtkkpdb3htwo6y3fmz6fpgop6u
 number_of_agents: 4
 deployment:
   agent:

--- a/packages/valory/services/trader/service.yaml
+++ b/packages/valory/services/trader/service.yaml
@@ -247,7 +247,6 @@ type: skill
         redeem_round_timeout: ${REDEEM_ROUND_TIMEOUT:float:3600.0}
         contract_timeout: ${CONTRACT_TIMEOUT:float:300.0}
         file_hash_to_strategies_json: ${FILE_HASH_TO_STRATEGIES_JSON:list:[["bafybeihufqu2ra7vud4h6g2nwahx7mvdido7ff6prwnib2tdlc4np7dw24",["bet_amount_per_threshold"]],["bafybeif55cu7cf6znyma7kxus4wxa2doarhau2xmndo57iegshxorivwmq",["kelly_criterion"]]]}
-        strategies_kwargs: ${STRATEGIES_KWARGS:list:[["bet_kelly_fraction",0.5],["floor_balance",500000000000000000],["bet_amount_per_threshold",{"0.0":0,"0.1":0,"0.2":0,"0.3":0,"0.4":0,"0.5":0,"0.6":60000000000000000,"0.7":90000000000000000,"0.8":100000000000000000,"0.9":1000000000000000000,"1.0":10000000000000000000}]]}
         use_subgraph_for_redeeming: ${USE_SUBGRAPH_FOR_REDEEMING:bool:true}
         use_nevermined: ${USE_NEVERMINED:bool:false}
         mech_to_subscription_params: ${SUBSCRIPTION_PARAMS:list:[["base_url", "https://marketplace-api.gnosis.nevermined.app/api/v1/metadata/assets/ddo"],

--- a/packages/valory/services/trader/service.yaml
+++ b/packages/valory/services/trader/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeigtuothskwyvrhfosps2bu6suauycolj67dpuxqvnicdrdu7yhtvq
 fingerprint_ignore_patterns: []
-agent: valory/trader:0.1.0:bafybeic7qgdwowkeffq56g44wg5h7otfhcvgbigdxstryxc3lw35vtfofa
+agent: valory/trader:0.1.0:bafybeida4fgx2k33fr27kulnl3y2e7z5zkrsq6w5sb7a6tfu43oeonrzui
 number_of_agents: 4
 deployment:
   agent:

--- a/packages/valory/services/trader/service.yaml
+++ b/packages/valory/services/trader/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeigtuothskwyvrhfosps2bu6suauycolj67dpuxqvnicdrdu7yhtvq
 fingerprint_ignore_patterns: []
-agent: valory/trader:0.1.0:bafybeiahhjwk4chbeenr77uzr7ryrgxjhtkkpdb3htwo6y3fmz6fpgop6u
+agent: valory/trader:0.1.0:bafybeif2sjvwqa7dzz4ieajtffl3eftscc4xfnruxnrg5dlrrwe53b5bgu
 number_of_agents: 4
 deployment:
   agent:

--- a/packages/valory/services/trader/service.yaml
+++ b/packages/valory/services/trader/service.yaml
@@ -247,6 +247,7 @@ type: skill
         redeem_round_timeout: ${REDEEM_ROUND_TIMEOUT:float:3600.0}
         contract_timeout: ${CONTRACT_TIMEOUT:float:300.0}
         file_hash_to_strategies_json: ${FILE_HASH_TO_STRATEGIES_JSON:list:[["bafybeihufqu2ra7vud4h6g2nwahx7mvdido7ff6prwnib2tdlc4np7dw24",["bet_amount_per_threshold"]],["bafybeif55cu7cf6znyma7kxus4wxa2doarhau2xmndo57iegshxorivwmq",["kelly_criterion"]]]}
+        strategies_kwargs: ${STRATEGIES_KWARGS:list:[["bet_kelly_fraction",0.5],["floor_balance",500000000000000000],["bet_amount_per_threshold",{"0.0":0,"0.1":0,"0.2":0,"0.3":0,"0.4":0,"0.5":0,"0.6":60000000000000000,"0.7":90000000000000000,"0.8":100000000000000000,"0.9":1000000000000000000,"1.0":10000000000000000000}]]}
         use_subgraph_for_redeeming: ${USE_SUBGRAPH_FOR_REDEEMING:bool:true}
         use_nevermined: ${USE_NEVERMINED:bool:false}
         mech_to_subscription_params: ${SUBSCRIPTION_PARAMS:list:[["base_url", "https://marketplace-api.gnosis.nevermined.app/api/v1/metadata/assets/ddo"],

--- a/packages/valory/services/trader_omen_gnosis/service.yaml
+++ b/packages/valory/services/trader_omen_gnosis/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeibg7bdqpioh4lmvknw3ygnllfku32oca4eq5pqtvdrdsgw6buko7e
 fingerprint_ignore_patterns: []
-agent: valory/trader:0.1.0:bafybeic7qgdwowkeffq56g44wg5h7otfhcvgbigdxstryxc3lw35vtfofa
+agent: valory/trader:0.1.0:bafybeida4fgx2k33fr27kulnl3y2e7z5zkrsq6w5sb7a6tfu43oeonrzui
 number_of_agents: 1
 deployment:
   agent:

--- a/packages/valory/services/trader_omen_gnosis/service.yaml
+++ b/packages/valory/services/trader_omen_gnosis/service.yaml
@@ -70,7 +70,7 @@ models:
       store_path: ./data
       policy_epsilon: 0.1
       irrelevant_tools: ${IRRELEVANT_TOOLS:list:["prediction-request-rag","prediction-request-reasoning-claude","prediction-url-cot-claude","claude-prediction-offline","claude-prediction-online","prediction-offline-sme","deepmind-optimization","deepmind-optimization-strong","openai-gpt-3.5-turbo","openai-gpt-3.5-turbo-instruct","openai-gpt-4","openai-text-davinci-002","openai-text-davinci-003","prediction-online-sum-url-content","prediction-online-summarized-info","stabilityai-stable-diffusion-512-v2-1","stabilityai-stable-diffusion-768-v2-1","stabilityai-stable-diffusion-v1-5","stabilityai-stable-diffusion-xl-beta-v2-2-2"]}
-      staking_contract_address: '0x2Ef503950Be67a98746F484DA0bBAdA339DF3326'
+      staking_contract_address: '0xEE9F19b5DF06c7E8Bfc7B28745dcf944C504198A'
       disable_trading: false
       stop_trading_if_staking_kpi_met: true
       agent_balance_threshold: 10000000000000000

--- a/packages/valory/services/trader_omen_gnosis/service.yaml
+++ b/packages/valory/services/trader_omen_gnosis/service.yaml
@@ -79,7 +79,6 @@ models:
       redeem_round_timeout: 3600.0
       contract_timeout: 300.0
       file_hash_to_strategies_json: ${FILE_HASH_TO_STRATEGIES_JSON:list:[["bafybeihufqu2ra7vud4h6g2nwahx7mvdido7ff6prwnib2tdlc4np7dw24",["bet_amount_per_threshold"]],["bafybeif55cu7cf6znyma7kxus4wxa2doarhau2xmndo57iegshxorivwmq",["kelly_criterion"]]]}
-      strategies_kwargs: ${STRATEGIES_KWARGS:list:[["bet_kelly_fraction",1],["floor_balance",500000000000000000],["bet_amount_per_threshold",{"0.0":0,"0.1":0,"0.2":0,"0.3":0,"0.4":0,"0.5":0,"0.6":60000000000000000,"0.7":80000000000000000,"0.8":160000000000000000,"0.9":1000000000000000000,"1.0":1000000000000000000}]]}
       mech_to_subscription_params: ${SUBSCRIPTION_PARAMS:list:[["base_url", "https://marketplace-api.gnosis.nevermined.app/api/v1/metadata/assets/ddo"],
         ["did", "did:nv:0ea01d5de3b34e3792db825f2a5f5595c393c68b19fd5efdacd00fcc63a53483"],
         ["escrow_payment_condition_address", "0x9dDC4F1Ea5b94C138A23b60EC48c0d01d172629a"],

--- a/packages/valory/services/trader_omen_gnosis/service.yaml
+++ b/packages/valory/services/trader_omen_gnosis/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeibg7bdqpioh4lmvknw3ygnllfku32oca4eq5pqtvdrdsgw6buko7e
 fingerprint_ignore_patterns: []
-agent: valory/trader:0.1.0:bafybeida4fgx2k33fr27kulnl3y2e7z5zkrsq6w5sb7a6tfu43oeonrzui
+agent: valory/trader:0.1.0:bafybeiahhjwk4chbeenr77uzr7ryrgxjhtkkpdb3htwo6y3fmz6fpgop6u
 number_of_agents: 1
 deployment:
   agent:

--- a/packages/valory/services/trader_omen_gnosis/service.yaml
+++ b/packages/valory/services/trader_omen_gnosis/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeibg7bdqpioh4lmvknw3ygnllfku32oca4eq5pqtvdrdsgw6buko7e
 fingerprint_ignore_patterns: []
-agent: valory/trader:0.1.0:bafybeiajgc36fmbvxrflj4mgkdpesjykjelajutttkiqqnfcb6ycvwn5o4
+agent: valory/trader:0.1.0:bafybeic7qgdwowkeffq56g44wg5h7otfhcvgbigdxstryxc3lw35vtfofa
 number_of_agents: 1
 deployment:
   agent:
@@ -119,3 +119,9 @@ cert_requests:
   public_key: 02d3a830c9d6ea1ae91936951430dee11f4662f33118b02190693be835359a9d77
   save_path: .certs/acn_cosmos_11000.txt
 is_abstract: false
+---
+public_id: valory/http_server:0.22.0
+type: connection
+config:
+  host: ${HTTP_SERVER_HOST:str:0.0.0.0}
+  port: ${HTTP_SERVER_PORT:int:8001}

--- a/packages/valory/services/trader_omen_gnosis/service.yaml
+++ b/packages/valory/services/trader_omen_gnosis/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeibg7bdqpioh4lmvknw3ygnllfku32oca4eq5pqtvdrdsgw6buko7e
 fingerprint_ignore_patterns: []
-agent: valory/trader:0.1.0:bafybeiahhjwk4chbeenr77uzr7ryrgxjhtkkpdb3htwo6y3fmz6fpgop6u
+agent: valory/trader:0.1.0:bafybeif2sjvwqa7dzz4ieajtffl3eftscc4xfnruxnrg5dlrrwe53b5bgu
 number_of_agents: 1
 deployment:
   agent:

--- a/packages/valory/skills/check_stop_trading_abci/behaviours.py
+++ b/packages/valory/skills/check_stop_trading_abci/behaviours.py
@@ -149,7 +149,7 @@ class CheckStopTradingBehaviour(StakingInteractBaseBehaviour):
             return True
 
         stop_trading_conditions = []
-        self.context.logger.info(f"{self.params.stop_trading_if_staking_kpi_met=}")
+        self.context.logger.debug(f"{self.params.stop_trading_if_staking_kpi_met=}")
         if self.params.stop_trading_if_staking_kpi_met:
             staking_kpi_met = yield from self.is_staking_kpi_met()
             self.context.logger.debug(f"{staking_kpi_met=}")

--- a/packages/valory/skills/check_stop_trading_abci/behaviours.py
+++ b/packages/valory/skills/check_stop_trading_abci/behaviours.py
@@ -121,22 +121,11 @@ class CheckStopTradingBehaviour(StakingInteractBaseBehaviour):
         current_timestamp = self.synced_timestamp
         self.context.logger.debug(f"{current_timestamp=}")
 
-        # kpi calculation if v2 staking is used
-        if self.use_v2:
-            eligibility_margin = (
-                liveness_period * liveness_ratio + REQUIRED_MECH_REQUESTS_SAFETY_MARGIN
-            )
-            is_kpi_met = mech_requests_since_last_cp >= eligibility_margin
-            return is_kpi_met
-
         required_mech_requests = (
             math.ceil(
-                max(
-                    (current_timestamp - last_ts_checkpoint)
-                    * liveness_ratio
-                    / LIVENESS_RATIO_SCALE_FACTOR,
-                    liveness_period * liveness_ratio / LIVENESS_RATIO_SCALE_FACTOR,
-                )
+                max(liveness_period, (current_timestamp - last_ts_checkpoint))
+                * liveness_ratio
+                / LIVENESS_RATIO_SCALE_FACTOR
             )
             + REQUIRED_MECH_REQUESTS_SAFETY_MARGIN
         )
@@ -145,10 +134,6 @@ class CheckStopTradingBehaviour(StakingInteractBaseBehaviour):
         if mech_requests_since_last_cp >= required_mech_requests:
             return True
         return False
-
-    def _v1_kpi_met(self) -> bool:
-        """Return whether the KPI is met."""
-        return self.mech_request_count >= self.params.stop_trading_kpi
 
     def _compute_stop_trading(self) -> Generator:
         # This is a "hacky" way of getting required data initialized on
@@ -164,7 +149,7 @@ class CheckStopTradingBehaviour(StakingInteractBaseBehaviour):
             return True
 
         stop_trading_conditions = []
-        self.context.logger.debug(f"{self.params.stop_trading_if_staking_kpi_met=}")
+        self.context.logger.info(f"{self.params.stop_trading_if_staking_kpi_met=}")
         if self.params.stop_trading_if_staking_kpi_met:
             staking_kpi_met = yield from self.is_staking_kpi_met()
             self.context.logger.debug(f"{staking_kpi_met=}")

--- a/packages/valory/skills/check_stop_trading_abci/skill.yaml
+++ b/packages/valory/skills/check_stop_trading_abci/skill.yaml
@@ -23,7 +23,7 @@ contracts:
 protocols: []
 skills:
 - valory/abstract_round_abci:0.1.0:bafybeiar2yhzxacfe3qqamqhaihtlcimquwedffctw55sowx6rac3cm3ui
-- valory/staking_abci:0.1.0:bafybeidpc3vvcri7tzx2cuxgtoabaunux5jjc7sa3mibsqho2agiv64pim
+- valory/staking_abci:0.1.0:bafybeihmqmf37cyik5naiiofsrwsw27ey3qm4tq7bgjp5gghvrbcb4nati
 behaviours:
   main:
     args: {}

--- a/packages/valory/skills/check_stop_trading_abci/skill.yaml
+++ b/packages/valory/skills/check_stop_trading_abci/skill.yaml
@@ -8,7 +8,7 @@ aea_version: '>=1.0.0, <2.0.0'
 fingerprint:
   README.md: bafybeif2pq7fg5upl6vmfgfzpiwsh4nbk4zaeyz6upyucqi5tasrxgq4ee
   __init__.py: bafybeifc23rlw2hzhplp3wfceixnmwq5ztnixhh7jp4dd5av3crwp3x22a
-  behaviours.py: bafybeibfccisavdgagkzd7apnl5eisgu5jitwoqyqzqxq3p3qmmzatoeua
+  behaviours.py: bafybeia2sp2iszftv6pm3auea4ux3j5nn72dhxyhtio7sis544gks2oi6m
   dialogues.py: bafybeictrrnwcijiejczy23dfvbx5kujgef3dulzqhs3etl2juvz5spm2e
   fsm_specification.yaml: bafybeihhau35a5xclncjpxh5lg7qiw34xs4d5qlez7dnjpkf45d3gc57ai
   handlers.py: bafybeiard64fwxib3rtyp67ymhf222uongcyqhfhdyttpsyqkmyh5ajipu
@@ -23,7 +23,7 @@ contracts:
 protocols: []
 skills:
 - valory/abstract_round_abci:0.1.0:bafybeiar2yhzxacfe3qqamqhaihtlcimquwedffctw55sowx6rac3cm3ui
-- valory/staking_abci:0.1.0:bafybeidt4bcu257zb4nge357j3llbodajeaeo4atapaadki2qiznvnvlni
+- valory/staking_abci:0.1.0:bafybeicbzbfyngqjllkpfvwo62zewotebebstdlpykmmhlzezknkaphdni
 behaviours:
   main:
     args: {}

--- a/packages/valory/skills/check_stop_trading_abci/skill.yaml
+++ b/packages/valory/skills/check_stop_trading_abci/skill.yaml
@@ -8,7 +8,7 @@ aea_version: '>=1.0.0, <2.0.0'
 fingerprint:
   README.md: bafybeif2pq7fg5upl6vmfgfzpiwsh4nbk4zaeyz6upyucqi5tasrxgq4ee
   __init__.py: bafybeifc23rlw2hzhplp3wfceixnmwq5ztnixhh7jp4dd5av3crwp3x22a
-  behaviours.py: bafybeiaun2btspmgetucfaem73hyjww2caf76qo3xsrtfastmonl2ug4yi
+  behaviours.py: bafybeibfccisavdgagkzd7apnl5eisgu5jitwoqyqzqxq3p3qmmzatoeua
   dialogues.py: bafybeictrrnwcijiejczy23dfvbx5kujgef3dulzqhs3etl2juvz5spm2e
   fsm_specification.yaml: bafybeihhau35a5xclncjpxh5lg7qiw34xs4d5qlez7dnjpkf45d3gc57ai
   handlers.py: bafybeiard64fwxib3rtyp67ymhf222uongcyqhfhdyttpsyqkmyh5ajipu
@@ -23,7 +23,7 @@ contracts:
 protocols: []
 skills:
 - valory/abstract_round_abci:0.1.0:bafybeiar2yhzxacfe3qqamqhaihtlcimquwedffctw55sowx6rac3cm3ui
-- valory/staking_abci:0.1.0:bafybeihmqmf37cyik5naiiofsrwsw27ey3qm4tq7bgjp5gghvrbcb4nati
+- valory/staking_abci:0.1.0:bafybeidt4bcu257zb4nge357j3llbodajeaeo4atapaadki2qiznvnvlni
 behaviours:
   main:
     args: {}

--- a/packages/valory/skills/staking_abci/behaviours.py
+++ b/packages/valory/skills/staking_abci/behaviours.py
@@ -322,12 +322,7 @@ class StakingInteractBaseBehaviour(BaseBehaviour, ABC):
 
     def _get_liveness_period(self) -> WaitableConditionType:
         """Get the liveness period."""
-        contract_interact = (
-            self._mech_activity_checker_contract_interact
-            if self.use_v2
-            else self._staking_contract_interact
-        )
-        status = yield from contract_interact(
+        status = yield from self._staking_contract_interact(
             contract_callable="get_liveness_period",
             placeholder=get_name(CallCheckpointBehaviour.liveness_period),
         )
@@ -335,8 +330,12 @@ class StakingInteractBaseBehaviour(BaseBehaviour, ABC):
 
     def _get_liveness_ratio(self) -> WaitableConditionType:
         """Get the liveness ratio."""
-
-        status = yield from self._staking_contract_interact(
+        contract_interact = (
+            self._mech_activity_checker_contract_interact
+            if self.use_v2
+            else self._staking_contract_interact
+        )
+        status = yield from contract_interact(
             contract_callable="liveness_ratio",
             placeholder=get_name(CallCheckpointBehaviour.liveness_ratio),
         )

--- a/packages/valory/skills/staking_abci/behaviours.py
+++ b/packages/valory/skills/staking_abci/behaviours.py
@@ -31,9 +31,6 @@ from packages.valory.contracts.service_staking_token.contract import (
     ServiceStakingTokenContract,
     StakingState,
 )
-from packages.valory.contracts.staking_token.contract import (
-    StakingState as StakingTokenStakingState,
-)
 from packages.valory.contracts.staking_token.contract import StakingTokenContract
 from packages.valory.protocols.contract_api import ContractApiMessage
 from packages.valory.skills.abstract_round_abci.base import get_name
@@ -100,11 +97,6 @@ class StakingInteractBaseBehaviour(BaseBehaviour, ABC):
         """Get the staking contract address."""
         return self.params.mech_activity_checker_contract
 
-    @staking_contract_address.setter
-    def staking_contract_address(self, staking_contract_address: str) -> None:
-        """Set the staking contract address."""
-        self.params.staking_contract_address = staking_contract_address
-
     @property
     def service_staking_state(self) -> StakingState:
         """Get the service's staking state."""
@@ -116,7 +108,7 @@ class StakingInteractBaseBehaviour(BaseBehaviour, ABC):
 
         # The class StakingState is redefined in several packages.
         # This conversion is required to use a single representation.
-        if isinstance(state, StakingTokenStakingState):
+        if not isinstance(state, StakingState):
             state = StakingState(state.value)
 
         self._service_staking_state = state

--- a/packages/valory/skills/staking_abci/behaviours.py
+++ b/packages/valory/skills/staking_abci/behaviours.py
@@ -31,6 +31,9 @@ from packages.valory.contracts.service_staking_token.contract import (
     ServiceStakingTokenContract,
     StakingState,
 )
+from packages.valory.contracts.staking_token.contract import (
+    StakingState as StakingTokenStakingState,
+)
 from packages.valory.contracts.staking_token.contract import StakingTokenContract
 from packages.valory.protocols.contract_api import ContractApiMessage
 from packages.valory.skills.abstract_round_abci.base import get_name
@@ -110,6 +113,12 @@ class StakingInteractBaseBehaviour(BaseBehaviour, ABC):
     @service_staking_state.setter
     def service_staking_state(self, state: StakingState) -> None:
         """Set the service's staking state."""
+
+        # The class StakingState is redefined in several packages.
+        # This conversion is required to use a single representation.
+        if isinstance(state, StakingTokenStakingState):
+            state = StakingState(state.value)
+
         self._service_staking_state = state
 
     @property

--- a/packages/valory/skills/staking_abci/skill.yaml
+++ b/packages/valory/skills/staking_abci/skill.yaml
@@ -8,7 +8,7 @@ aea_version: '>=1.0.0, <2.0.0'
 fingerprint:
   README.md: bafybeifrpl36fddmgvniwvghqtxdzc44ry6l2zvqy37vu3y2xvwyd23ugy
   __init__.py: bafybeiageyes36ujnvvodqd5vlnihgz44rupysrk2ebbhskjkueetj6dai
-  behaviours.py: bafybeifcxwxg6tiwbdw3zwo7pkh2nap3ipmjkgydtajfoze7osfh5xcyei
+  behaviours.py: bafybeiemyah5wqletzntd475trhnxxykqzmnsx2t4uz4a43xv6kk5cbmwq
   dialogues.py: bafybeiebofyykseqp3fmif36cqmmyf3k7d2zbocpl6t6wnlpv4szghrxbm
   fsm_specification.yaml: bafybeicuoejmaks3ndwhbflp64kkfdkrdyn74a2fplarg4l3gxlonfmeoq
   handlers.py: bafybeichsi2y5zvzffupj2vhgagocwvnm7cbzr6jmavp656mfrzsdvkfnu

--- a/packages/valory/skills/staking_abci/skill.yaml
+++ b/packages/valory/skills/staking_abci/skill.yaml
@@ -8,7 +8,7 @@ aea_version: '>=1.0.0, <2.0.0'
 fingerprint:
   README.md: bafybeifrpl36fddmgvniwvghqtxdzc44ry6l2zvqy37vu3y2xvwyd23ugy
   __init__.py: bafybeiageyes36ujnvvodqd5vlnihgz44rupysrk2ebbhskjkueetj6dai
-  behaviours.py: bafybeiemyah5wqletzntd475trhnxxykqzmnsx2t4uz4a43xv6kk5cbmwq
+  behaviours.py: bafybeibysxpflj6fhlafrsgqxylgwrfgsmegb7mxk67jtycs3jjddewcsi
   dialogues.py: bafybeiebofyykseqp3fmif36cqmmyf3k7d2zbocpl6t6wnlpv4szghrxbm
   fsm_specification.yaml: bafybeicuoejmaks3ndwhbflp64kkfdkrdyn74a2fplarg4l3gxlonfmeoq
   handlers.py: bafybeichsi2y5zvzffupj2vhgagocwvnm7cbzr6jmavp656mfrzsdvkfnu

--- a/packages/valory/skills/staking_abci/skill.yaml
+++ b/packages/valory/skills/staking_abci/skill.yaml
@@ -8,7 +8,7 @@ aea_version: '>=1.0.0, <2.0.0'
 fingerprint:
   README.md: bafybeifrpl36fddmgvniwvghqtxdzc44ry6l2zvqy37vu3y2xvwyd23ugy
   __init__.py: bafybeiageyes36ujnvvodqd5vlnihgz44rupysrk2ebbhskjkueetj6dai
-  behaviours.py: bafybeibysxpflj6fhlafrsgqxylgwrfgsmegb7mxk67jtycs3jjddewcsi
+  behaviours.py: bafybeif3gquhfz7igfujdhs4usx7zjuwwmga4funlm6x6pfvegujrjy2zm
   dialogues.py: bafybeiebofyykseqp3fmif36cqmmyf3k7d2zbocpl6t6wnlpv4szghrxbm
   fsm_specification.yaml: bafybeicuoejmaks3ndwhbflp64kkfdkrdyn74a2fplarg4l3gxlonfmeoq
   handlers.py: bafybeichsi2y5zvzffupj2vhgagocwvnm7cbzr6jmavp656mfrzsdvkfnu

--- a/packages/valory/skills/trader_abci/skill.yaml
+++ b/packages/valory/skills/trader_abci/skill.yaml
@@ -26,9 +26,9 @@ skills:
 - valory/termination_abci:0.1.0:bafybeif2zim2de356eo3sipkmoev5emwadpqqzk3huwqarywh4tmqt3vzq
 - valory/market_manager_abci:0.1.0:bafybeicbvxvjkoksbknujaid5hx7krjlgm6barcjcwo33tdccanrcp674a
 - valory/decision_maker_abci:0.1.0:bafybeihvaze22cfs7djtbduficbtmbcv4n5nc3g45irnczhwuqzzcvkr6y
-- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeietfxfo5k3inw6s35e7ovqv7aklkjwaby2ienauud4kri33qoztwa
-- valory/staking_abci:0.1.0:bafybeidpc3vvcri7tzx2cuxgtoabaunux5jjc7sa3mibsqho2agiv64pim
-- valory/check_stop_trading_abci:0.1.0:bafybeig4xbc4izvanftxjvmhhuzuolqdx5fb3xtmnsvmhoghg7lrgn6rmq
+- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeialmq3grz5eurvoad7gjl4hpvqapnqtlehy2qj5isxtx43s2e5zlq
+- valory/staking_abci:0.1.0:bafybeihmqmf37cyik5naiiofsrwsw27ey3qm4tq7bgjp5gghvrbcb4nati
+- valory/check_stop_trading_abci:0.1.0:bafybeignyejmijrwpdwubkolchqliz323faheeywol6xlqcll2e55a7gly
 - valory/mech_interact_abci:0.1.0:bafybeih2cck5xu6yaibomwtm5zbcp6llghr3ighdnk56fzwu3ihu5xx35e
 behaviours:
   main:

--- a/packages/valory/skills/trader_abci/skill.yaml
+++ b/packages/valory/skills/trader_abci/skill.yaml
@@ -26,9 +26,9 @@ skills:
 - valory/termination_abci:0.1.0:bafybeif2zim2de356eo3sipkmoev5emwadpqqzk3huwqarywh4tmqt3vzq
 - valory/market_manager_abci:0.1.0:bafybeicbvxvjkoksbknujaid5hx7krjlgm6barcjcwo33tdccanrcp674a
 - valory/decision_maker_abci:0.1.0:bafybeihvaze22cfs7djtbduficbtmbcv4n5nc3g45irnczhwuqzzcvkr6y
-- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeicm7jbix6qnptanwg34agi4kndaazywzzwr3httv6xtlfgcn47rcy
-- valory/staking_abci:0.1.0:bafybeidt4bcu257zb4nge357j3llbodajeaeo4atapaadki2qiznvnvlni
-- valory/check_stop_trading_abci:0.1.0:bafybeiebravnf2aqk2rhxkala5auws3t5bhdmzjfm2drgrorcurt3pznfa
+- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeif6yp475vtskwp7jk3lbrtgkzmbim5o74rlrhp6fwy65dfhzuazgi
+- valory/staking_abci:0.1.0:bafybeicbzbfyngqjllkpfvwo62zewotebebstdlpykmmhlzezknkaphdni
+- valory/check_stop_trading_abci:0.1.0:bafybeigiavk6dwd5clx32paza7qsmkkmhc4tvgy5tteazmdkhj7v32p6fq
 - valory/mech_interact_abci:0.1.0:bafybeih2cck5xu6yaibomwtm5zbcp6llghr3ighdnk56fzwu3ihu5xx35e
 behaviours:
   main:

--- a/packages/valory/skills/trader_abci/skill.yaml
+++ b/packages/valory/skills/trader_abci/skill.yaml
@@ -26,9 +26,9 @@ skills:
 - valory/termination_abci:0.1.0:bafybeif2zim2de356eo3sipkmoev5emwadpqqzk3huwqarywh4tmqt3vzq
 - valory/market_manager_abci:0.1.0:bafybeicbvxvjkoksbknujaid5hx7krjlgm6barcjcwo33tdccanrcp674a
 - valory/decision_maker_abci:0.1.0:bafybeihvaze22cfs7djtbduficbtmbcv4n5nc3g45irnczhwuqzzcvkr6y
-- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeialmq3grz5eurvoad7gjl4hpvqapnqtlehy2qj5isxtx43s2e5zlq
-- valory/staking_abci:0.1.0:bafybeihmqmf37cyik5naiiofsrwsw27ey3qm4tq7bgjp5gghvrbcb4nati
-- valory/check_stop_trading_abci:0.1.0:bafybeignyejmijrwpdwubkolchqliz323faheeywol6xlqcll2e55a7gly
+- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeicm7jbix6qnptanwg34agi4kndaazywzzwr3httv6xtlfgcn47rcy
+- valory/staking_abci:0.1.0:bafybeidt4bcu257zb4nge357j3llbodajeaeo4atapaadki2qiznvnvlni
+- valory/check_stop_trading_abci:0.1.0:bafybeiebravnf2aqk2rhxkala5auws3t5bhdmzjfm2drgrorcurt3pznfa
 - valory/mech_interact_abci:0.1.0:bafybeih2cck5xu6yaibomwtm5zbcp6llghr3ighdnk56fzwu3ihu5xx35e
 behaviours:
   main:

--- a/packages/valory/skills/tx_settlement_multiplexer_abci/skill.yaml
+++ b/packages/valory/skills/tx_settlement_multiplexer_abci/skill.yaml
@@ -22,7 +22,7 @@ protocols:
 skills:
 - valory/abstract_round_abci:0.1.0:bafybeiar2yhzxacfe3qqamqhaihtlcimquwedffctw55sowx6rac3cm3ui
 - valory/decision_maker_abci:0.1.0:bafybeihvaze22cfs7djtbduficbtmbcv4n5nc3g45irnczhwuqzzcvkr6y
-- valory/staking_abci:0.1.0:bafybeidt4bcu257zb4nge357j3llbodajeaeo4atapaadki2qiznvnvlni
+- valory/staking_abci:0.1.0:bafybeicbzbfyngqjllkpfvwo62zewotebebstdlpykmmhlzezknkaphdni
 - valory/mech_interact_abci:0.1.0:bafybeih2cck5xu6yaibomwtm5zbcp6llghr3ighdnk56fzwu3ihu5xx35e
 behaviours:
   main:

--- a/packages/valory/skills/tx_settlement_multiplexer_abci/skill.yaml
+++ b/packages/valory/skills/tx_settlement_multiplexer_abci/skill.yaml
@@ -22,7 +22,7 @@ protocols:
 skills:
 - valory/abstract_round_abci:0.1.0:bafybeiar2yhzxacfe3qqamqhaihtlcimquwedffctw55sowx6rac3cm3ui
 - valory/decision_maker_abci:0.1.0:bafybeihvaze22cfs7djtbduficbtmbcv4n5nc3g45irnczhwuqzzcvkr6y
-- valory/staking_abci:0.1.0:bafybeihmqmf37cyik5naiiofsrwsw27ey3qm4tq7bgjp5gghvrbcb4nati
+- valory/staking_abci:0.1.0:bafybeidt4bcu257zb4nge357j3llbodajeaeo4atapaadki2qiznvnvlni
 - valory/mech_interact_abci:0.1.0:bafybeih2cck5xu6yaibomwtm5zbcp6llghr3ighdnk56fzwu3ihu5xx35e
 behaviours:
   main:

--- a/packages/valory/skills/tx_settlement_multiplexer_abci/skill.yaml
+++ b/packages/valory/skills/tx_settlement_multiplexer_abci/skill.yaml
@@ -22,7 +22,7 @@ protocols:
 skills:
 - valory/abstract_round_abci:0.1.0:bafybeiar2yhzxacfe3qqamqhaihtlcimquwedffctw55sowx6rac3cm3ui
 - valory/decision_maker_abci:0.1.0:bafybeihvaze22cfs7djtbduficbtmbcv4n5nc3g45irnczhwuqzzcvkr6y
-- valory/staking_abci:0.1.0:bafybeidpc3vvcri7tzx2cuxgtoabaunux5jjc7sa3mibsqho2agiv64pim
+- valory/staking_abci:0.1.0:bafybeihmqmf37cyik5naiiofsrwsw27ey3qm4tq7bgjp5gghvrbcb4nati
 - valory/mech_interact_abci:0.1.0:bafybeih2cck5xu6yaibomwtm5zbcp6llghr3ighdnk56fzwu3ihu5xx35e
 behaviours:
   main:

--- a/tox.ini
+++ b/tox.ini
@@ -168,7 +168,7 @@ skipsdist = True
 skip_install = True
 deps =
     tomte[safety]==0.2.17
-commands = safety check -i 37524 -i 38038 -i 37776 -i 38039 -i 39621 -i 40291 -i 39706 -i 41002 -i 51358 -i 51499 -i 67599
+commands = safety check -i 37524 -i 38038 -i 37776 -i 38039 -i 39621 -i 40291 -i 39706 -i 41002 -i 51358 -i 51499 -i 67599 -i 70612
 
 [testenv:darglint]
 skipsdist = True


### PR DESCRIPTION
This PR fixes several issues that prevent the Pearl agent starting normally.

* Several fixes to the staking interaction.
  * Wrong contracts being called
  * Wrong computation of minimum number of mech requests
  * Issue with StakingState: duplicate class name in different packages

* Remove override from service.yaml in trader_omen_gnosis (used in Perl)
  
  The reason for this change is that the environment exports of strategies_kwargs is causing issues in the definition of export variables on Perl; it is producing variables with a period, which is not a valid variable name in bash.
  
  ```
      "SKILL_TRADER_ABCI_MODELS_PARAMS_ARGS_STRATEGIES_KWARGS_0": "[\"bet_kelly_fraction\",1]",
      "SKILL_TRADER_ABCI_MODELS_PARAMS_ARGS_STRATEGIES_KWARGS_1": "[\"floor_balance\",500000000000000000]",
      "SKILL_TRADER_ABCI_MODELS_PARAMS_ARGS_STRATEGIES_KWARGS_2_0": "bet_amount_per_threshold",
      "SKILL_TRADER_ABCI_MODELS_PARAMS_ARGS_STRATEGIES_KWARGS_2_1_0.0": "0",
      "SKILL_TRADER_ABCI_MODELS_PARAMS_ARGS_STRATEGIES_KWARGS_2_1_0.1": "0",
      "SKILL_TRADER_ABCI_MODELS_PARAMS_ARGS_STRATEGIES_KWARGS_2_1_0.2": "0",
      "SKILL_TRADER_ABCI_MODELS_PARAMS_ARGS_STRATEGIES_KWARGS_2_1_0.3": "0",
      "SKILL_TRADER_ABCI_MODELS_PARAMS_ARGS_STRATEGIES_KWARGS_2_1_0.4": "0",
      "SKILL_TRADER_ABCI_MODELS_PARAMS_ARGS_STRATEGIES_KWARGS_2_1_0.5": "0",
      "SKILL_TRADER_ABCI_MODELS_PARAMS_ARGS_STRATEGIES_KWARGS_2_1_0.6": "60000000000000000",
      "SKILL_TRADER_ABCI_MODELS_PARAMS_ARGS_STRATEGIES_KWARGS_2_1_0.7": "80000000000000000",
      "SKILL_TRADER_ABCI_MODELS_PARAMS_ARGS_STRATEGIES_KWARGS_2_1_0.8": "160000000000000000",
      "SKILL_TRADER_ABCI_MODELS_PARAMS_ARGS_STRATEGIES_KWARGS_2_1_0.9": "1000000000000000000",
      "SKILL_TRADER_ABCI_MODELS_PARAMS_ARGS_STRATEGIES_KWARGS_2_1_1.0": "1000000000000000000",
  ```