### PR TITLE
Update the utilized tools when adjusting the policy's tools

### DIFF
--- a/packages/packages.json
+++ b/packages/packages.json
@@ -13,13 +13,13 @@
         "contract/valory/transfer_nft_condition/0.1.0": "bafybeihnict3irtvnyxtkwyg6wphe44wz3dogijiha45xrkcrh5ktq2lsi",
         "contract/valory/relayer/0.1.0": "bafybeiaabvxim4blp5fxb6qjlzjivtvkme3fk24h5jte7w6vr6rsx72j6u",
         "skill/valory/market_manager_abci/0.1.0": "bafybeicbvxvjkoksbknujaid5hx7krjlgm6barcjcwo33tdccanrcp674a",
-        "skill/valory/decision_maker_abci/0.1.0": "bafybeiaw5kilhtdu7fcmk5553l3m6v366myaflekvipe4qa2vp4arbzlva",
-        "skill/valory/trader_abci/0.1.0": "bafybeibvlfhotlobiuemgra677qrmb5juumhpg4wz5uayi42sa6asxlona",
-        "skill/valory/tx_settlement_multiplexer_abci/0.1.0": "bafybeidkr6vthdixhjxe423bur7deeynzfwqmqc2gyylhxadfsbzo22faa",
+        "skill/valory/decision_maker_abci/0.1.0": "bafybeibb2qs73ug56hazdmuirwa2avbbdmenuhbmmwcp7zn4fdgztd6sjy",
+        "skill/valory/trader_abci/0.1.0": "bafybeietcp2q726jgo3wwoautzkxuwjoa4jdv2bllcx4o44plsh5gqt7fu",
+        "skill/valory/tx_settlement_multiplexer_abci/0.1.0": "bafybeiaybhcckjudnmelw3vc4mhw7fmydisyguanvlb2h6kdbhke3kjsvi",
         "skill/valory/staking_abci/0.1.0": "bafybeigo7bicej5t2rbki37cmcwkzgwpcnopokn7ijhylmkihsbqw47xr4",
         "skill/valory/check_stop_trading_abci/0.1.0": "bafybeickfeuqlpmryegnfvfu2duk2v4ycowwloohu3xxrafd5md6xl5swi",
-        "agent/valory/trader/0.1.0": "bafybeidt6cy3vo33dcue5ocyi7j2y6gxomzdotlgjq7hresembhdam533i",
-        "service/valory/trader/0.1.0": "bafybeid6wzptaugaeyf3mfgjop2buxjawnuignycbdod46dh2kazja6eim"
+        "agent/valory/trader/0.1.0": "bafybeiczhuenxymwnoankdarwogerydxmzkjeefe6anokksaok25dto6nu",
+        "service/valory/trader/0.1.0": "bafybeih3l6tcadclvaumuvgyle3jgt52d6o7s5rb4r34tfmzsic25bmwje"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeihv62fim3wl2bayavfcg3u5e5cxu3b7brtu4cn5xoxd6lqwachasi",

--- a/packages/valory/agents/trader/aea-config.yaml
+++ b/packages/valory/agents/trader/aea-config.yaml
@@ -45,10 +45,10 @@ skills:
 - valory/reset_pause_abci:0.1.0:bafybeiameewywqigpupy3u2iwnkfczeiiucue74x2l5lbge74rmw6bgaie
 - valory/termination_abci:0.1.0:bafybeif2zim2de356eo3sipkmoev5emwadpqqzk3huwqarywh4tmqt3vzq
 - valory/transaction_settlement_abci:0.1.0:bafybeic3tccdjypuge2lewtlgprwkbb53lhgsgn7oiwzyrcrrptrbeyote
-- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeidkr6vthdixhjxe423bur7deeynzfwqmqc2gyylhxadfsbzo22faa
+- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeiaybhcckjudnmelw3vc4mhw7fmydisyguanvlb2h6kdbhke3kjsvi
 - valory/market_manager_abci:0.1.0:bafybeicbvxvjkoksbknujaid5hx7krjlgm6barcjcwo33tdccanrcp674a
-- valory/decision_maker_abci:0.1.0:bafybeiaw5kilhtdu7fcmk5553l3m6v366myaflekvipe4qa2vp4arbzlva
-- valory/trader_abci:0.1.0:bafybeibvlfhotlobiuemgra677qrmb5juumhpg4wz5uayi42sa6asxlona
+- valory/decision_maker_abci:0.1.0:bafybeibb2qs73ug56hazdmuirwa2avbbdmenuhbmmwcp7zn4fdgztd6sjy
+- valory/trader_abci:0.1.0:bafybeietcp2q726jgo3wwoautzkxuwjoa4jdv2bllcx4o44plsh5gqt7fu
 - valory/staking_abci:0.1.0:bafybeigo7bicej5t2rbki37cmcwkzgwpcnopokn7ijhylmkihsbqw47xr4
 - valory/check_stop_trading_abci:0.1.0:bafybeickfeuqlpmryegnfvfu2duk2v4ycowwloohu3xxrafd5md6xl5swi
 - valory/mech_interact_abci:0.1.0:bafybeih2cck5xu6yaibomwtm5zbcp6llghr3ighdnk56fzwu3ihu5xx35e

--- a/packages/valory/services/trader/service.yaml
+++ b/packages/valory/services/trader/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeigtuothskwyvrhfosps2bu6suauycolj67dpuxqvnicdrdu7yhtvq
 fingerprint_ignore_patterns: []
-agent: valory/trader:0.1.0:bafybeidt6cy3vo33dcue5ocyi7j2y6gxomzdotlgjq7hresembhdam533i
+agent: valory/trader:0.1.0:bafybeiczhuenxymwnoankdarwogerydxmzkjeefe6anokksaok25dto6nu
 number_of_agents: 4
 deployment:
   agent:

--- a/packages/valory/skills/decision_maker_abci/skill.yaml
+++ b/packages/valory/skills/decision_maker_abci/skill.yaml
@@ -25,7 +25,7 @@ fingerprint:
   behaviours/reedem.py: bafybeieyqb2w7bvvl4wkgpqwryyyb4lex4wmwoykylehr2zljz3a7tkeja
   behaviours/round_behaviour.py: bafybeibvhobpvzzd37ecleuyp2jrbed6nontcw7urtsilbbzvqsmmupx64
   behaviours/sampling.py: bafybeibtkli72qsvotkrsepkgpiumtr5sershtkpb427oygnszs3dpgxry
-  behaviours/tool_selection.py: bafybeie7xhopohfoct7jggerk6nu3vkhlx7uhcowo3dfktoqmr7227j4ke
+  behaviours/tool_selection.py: bafybeicjfo5pqaupv4bpupvkccfffg65sygcgzlg4cieoiktjfilzf5l3a
   dialogues.py: bafybeigpwuzku3we7axmxeamg7vn656maww6emuztau5pg3ebsoquyfdqm
   fsm_specification.yaml: bafybeif2kas4eho4aielucf3ihjzjsog32icccbxrvje6kkw7aw4m4zg6q
   handlers.py: bafybeielhwnfm2blt6clmwr557g2g3gddnt5bpb4cqul6p3wiwsfoksvlu

--- a/packages/valory/skills/trader_abci/skill.yaml
+++ b/packages/valory/skills/trader_abci/skill.yaml
@@ -25,8 +25,8 @@ skills:
 - valory/transaction_settlement_abci:0.1.0:bafybeic3tccdjypuge2lewtlgprwkbb53lhgsgn7oiwzyrcrrptrbeyote
 - valory/termination_abci:0.1.0:bafybeif2zim2de356eo3sipkmoev5emwadpqqzk3huwqarywh4tmqt3vzq
 - valory/market_manager_abci:0.1.0:bafybeicbvxvjkoksbknujaid5hx7krjlgm6barcjcwo33tdccanrcp674a
-- valory/decision_maker_abci:0.1.0:bafybeiaw5kilhtdu7fcmk5553l3m6v366myaflekvipe4qa2vp4arbzlva
-- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeidkr6vthdixhjxe423bur7deeynzfwqmqc2gyylhxadfsbzo22faa
+- valory/decision_maker_abci:0.1.0:bafybeibb2qs73ug56hazdmuirwa2avbbdmenuhbmmwcp7zn4fdgztd6sjy
+- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeiaybhcckjudnmelw3vc4mhw7fmydisyguanvlb2h6kdbhke3kjsvi
 - valory/staking_abci:0.1.0:bafybeigo7bicej5t2rbki37cmcwkzgwpcnopokn7ijhylmkihsbqw47xr4
 - valory/check_stop_trading_abci:0.1.0:bafybeickfeuqlpmryegnfvfu2duk2v4ycowwloohu3xxrafd5md6xl5swi
 - valory/mech_interact_abci:0.1.0:bafybeih2cck5xu6yaibomwtm5zbcp6llghr3ighdnk56fzwu3ihu5xx35e

--- a/packages/valory/skills/tx_settlement_multiplexer_abci/skill.yaml
+++ b/packages/valory/skills/tx_settlement_multiplexer_abci/skill.yaml
@@ -21,7 +21,7 @@ protocols:
 - valory/ledger_api:1.0.0:bafybeihdk6psr4guxmbcrc26jr2cbgzpd5aljkqvpwo64bvaz7tdti2oni
 skills:
 - valory/abstract_round_abci:0.1.0:bafybeiar2yhzxacfe3qqamqhaihtlcimquwedffctw55sowx6rac3cm3ui
-- valory/decision_maker_abci:0.1.0:bafybeiaw5kilhtdu7fcmk5553l3m6v366myaflekvipe4qa2vp4arbzlva
+- valory/decision_maker_abci:0.1.0:bafybeibb2qs73ug56hazdmuirwa2avbbdmenuhbmmwcp7zn4fdgztd6sjy
 - valory/staking_abci:0.1.0:bafybeigo7bicej5t2rbki37cmcwkzgwpcnopokn7ijhylmkihsbqw47xr4
 - valory/mech_interact_abci:0.1.0:bafybeih2cck5xu6yaibomwtm5zbcp6llghr3ighdnk56fzwu3ihu5xx35e
 behaviours:


### PR DESCRIPTION
Introduces a change to the tool selection behaviour to update the utilized tools when adjusting the policy's tools. Otherwise, an edge case might occur if both statements below hold true:
1. The mech's metadata get updated while the trader is running.
2. The agent has already placed some bets and the indexes conflict with the updated ones.

Therefore, after redeeming, and during the policy update, the service will break with an index error while updating the rewards.