### PR TITLE
Hotfix: no default value for sample bet index

### DIFF
--- a/packages/packages.json
+++ b/packages/packages.json
@@ -16,14 +16,14 @@
         "contract/valory/staking_token/0.1.0": "bafybeigwsffbzx62d3ikz5kyjsewcvknrrnq3bcqgktnbrcpz4g6lyu3eq",
         "contract/valory/relayer/0.1.0": "bafybeicawmds6czx7db2lcktvexwrp245jpekgulndtos5s5zdid3ilvq4",
         "skill/valory/market_manager_abci/0.1.0": "bafybeicia7itulcrxlwbmhfzxppgo5i33tb2nmcycwizftw7gps4dareka",
-        "skill/valory/decision_maker_abci/0.1.0": "bafybeiaiqddhwawt7u6stg6ujmzmnn3my7dtqa7tur5jbjfswnsasfoila",
-        "skill/valory/trader_abci/0.1.0": "bafybeidq5fxitj26rcy37pyrksoyks65zusndh6sor6ct5qv26kz3eupl4",
-        "skill/valory/tx_settlement_multiplexer_abci/0.1.0": "bafybeidw5cedygh25jtxdv35zb4223kbhtwv6enfxtkkdkuhuayvply5gq",
+        "skill/valory/decision_maker_abci/0.1.0": "bafybeie3ku2ms5xb3brkma7ilvareli4smcfd7kzmuacdyor7pmykfdyau",
+        "skill/valory/trader_abci/0.1.0": "bafybeidldmbcgwh4ndvvipmvpa6uhgkj4hi4jhdmyjlvunwdme7cchpqry",
+        "skill/valory/tx_settlement_multiplexer_abci/0.1.0": "bafybeihhwaxdphul2zukucjzezabiwkpidqc7wvelf7kconq6hjeu2sdxa",
         "skill/valory/staking_abci/0.1.0": "bafybeifyqszbiccxwwfldrl6lz5dspuaxbqd5qnniyecusddwvxpfwiyr4",
         "skill/valory/check_stop_trading_abci/0.1.0": "bafybeicsrrxjs6bup267jiek3r7eutd42ssfyjthyvxfku6qozw3xebxta",
-        "agent/valory/trader/0.1.0": "bafybeief2fkdv5pvryo6kyzguqhyfrvsxvb2sqnt4ptriairagjvuonttq",
-        "service/valory/trader/0.1.0": "bafybeig4b4v62lkebjacfstiizb3cr6ir6vtj6qhrfcpvry7vltikyqyyq",
-        "service/valory/trader_pearl/0.1.0": "bafybeicioq4b7o7ajmwigl66lvy2yiaprdagmrvz34awq55nxsoupr6ooe"
+        "agent/valory/trader/0.1.0": "bafybeidu3cbxgeayxyezxfgreppt4ipbkb4a5zavum73lywahyveunfyhq",
+        "service/valory/trader/0.1.0": "bafybeidvv656xcz7vijqy3n26dway5sliemwfn5rgxrsw4ujniehn5jouy",
+        "service/valory/trader_pearl/0.1.0": "bafybeib3vz5jits34modzrvm55m2oxz22g3jizztqrv6vwqezc3265gidu"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeihv62fim3wl2bayavfcg3u5e5cxu3b7brtu4cn5xoxd6lqwachasi",

--- a/packages/valory/agents/trader/aea-config.yaml
+++ b/packages/valory/agents/trader/aea-config.yaml
@@ -45,10 +45,10 @@ skills:
 - valory/reset_pause_abci:0.1.0:bafybeigrdlxed3xlsnxtjhnsbl3cojruihxcqx4jxhgivkd5i2fkjncgba
 - valory/termination_abci:0.1.0:bafybeib5l7jhew5ic6iq24dd23nidcoimzqkrk556gqywhoziatj33zvwm
 - valory/transaction_settlement_abci:0.1.0:bafybeic7q7recyka272udwcupblwbkc3jkodgp74fvcdxb7urametg5dae
-- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeidw5cedygh25jtxdv35zb4223kbhtwv6enfxtkkdkuhuayvply5gq
+- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeihhwaxdphul2zukucjzezabiwkpidqc7wvelf7kconq6hjeu2sdxa
 - valory/market_manager_abci:0.1.0:bafybeicia7itulcrxlwbmhfzxppgo5i33tb2nmcycwizftw7gps4dareka
-- valory/decision_maker_abci:0.1.0:bafybeiaiqddhwawt7u6stg6ujmzmnn3my7dtqa7tur5jbjfswnsasfoila
-- valory/trader_abci:0.1.0:bafybeidq5fxitj26rcy37pyrksoyks65zusndh6sor6ct5qv26kz3eupl4
+- valory/decision_maker_abci:0.1.0:bafybeie3ku2ms5xb3brkma7ilvareli4smcfd7kzmuacdyor7pmykfdyau
+- valory/trader_abci:0.1.0:bafybeidldmbcgwh4ndvvipmvpa6uhgkj4hi4jhdmyjlvunwdme7cchpqry
 - valory/staking_abci:0.1.0:bafybeifyqszbiccxwwfldrl6lz5dspuaxbqd5qnniyecusddwvxpfwiyr4
 - valory/check_stop_trading_abci:0.1.0:bafybeicsrrxjs6bup267jiek3r7eutd42ssfyjthyvxfku6qozw3xebxta
 - valory/mech_interact_abci:0.1.0:bafybeid6m3i5ofq7vuogqapdnoshhq7mswmudhvfcr2craw25fdwtoe3lm

--- a/packages/valory/services/trader/service.yaml
+++ b/packages/valory/services/trader/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeigtuothskwyvrhfosps2bu6suauycolj67dpuxqvnicdrdu7yhtvq
 fingerprint_ignore_patterns: []
-agent: valory/trader:0.1.0:bafybeief2fkdv5pvryo6kyzguqhyfrvsxvb2sqnt4ptriairagjvuonttq
+agent: valory/trader:0.1.0:bafybeidu3cbxgeayxyezxfgreppt4ipbkb4a5zavum73lywahyveunfyhq
 number_of_agents: 4
 deployment:
   agent:

--- a/packages/valory/services/trader_pearl/service.yaml
+++ b/packages/valory/services/trader_pearl/service.yaml
@@ -8,7 +8,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeibg7bdqpioh4lmvknw3ygnllfku32oca4eq5pqtvdrdsgw6buko7e
 fingerprint_ignore_patterns: []
-agent: valory/trader:0.1.0:bafybeief2fkdv5pvryo6kyzguqhyfrvsxvb2sqnt4ptriairagjvuonttq
+agent: valory/trader:0.1.0:bafybeidu3cbxgeayxyezxfgreppt4ipbkb4a5zavum73lywahyveunfyhq
 number_of_agents: 1
 deployment:
   agent:

--- a/packages/valory/skills/decision_maker_abci/behaviours/base.py
+++ b/packages/valory/skills/decision_maker_abci/behaviours/base.py
@@ -269,7 +269,13 @@ class DecisionMakerBaseBehaviour(BetsManagerBehaviour, ABC):
     def sampled_bet(self) -> Bet:
         """Get the sampled bet."""
         self.read_bets()
-        return self.bets[self.synchronized_data.sampled_bet_index]
+        # default value
+        try:
+            bet_index = self.synchronized_data.sampled_bet_index
+        except ValueError:
+            # default value
+            bet_index = 0
+        return self.bets[bet_index]
 
     @property
     def collateral_token(self) -> str:

--- a/packages/valory/skills/decision_maker_abci/skill.yaml
+++ b/packages/valory/skills/decision_maker_abci/skill.yaml
@@ -12,7 +12,7 @@ fingerprint:
   README.md: bafybeia367zzdwndvlhw27rvnwodytjo3ms7gbc3q7mhrrjqjgfasnk47i
   __init__.py: bafybeih563ujnigeci2ldzh7hakbau6a222vsed7leg3b7lq32vcn3nm4a
   behaviours/__init__.py: bafybeih6ddz2ocvm6x6ytvlbcz6oi4snb5ee5xh5h65nq4w2qf7fd7zfky
-  behaviours/base.py: bafybeidjmsljdaw7y5chzzkub63mzf5ydpauch5ugojds5jwpeyvovkq3y
+  behaviours/base.py: bafybeibkytexgxr2xddm342uk66he6tdhi2qm4ipx4w62uabybafsyqgha
   behaviours/bet_placement.py: bafybeihmia64t2payxfqcnfdqg675ui2yp3hnyfwb2xhj2hn7wl237b4re
   behaviours/blacklisting.py: bafybeicqwj7o4l7qcym5xjqwq45jngqkhyf44mn6qise2ysyfnlnwz7pdy
   behaviours/check_benchmarking.py: bafybeiao2lyj7apezkqrpgsyzb3dwvrdgsrgtprf6iuhsmlsufvxfl5bci

--- a/packages/valory/skills/trader_abci/skill.yaml
+++ b/packages/valory/skills/trader_abci/skill.yaml
@@ -27,8 +27,8 @@ skills:
 - valory/transaction_settlement_abci:0.1.0:bafybeic7q7recyka272udwcupblwbkc3jkodgp74fvcdxb7urametg5dae
 - valory/termination_abci:0.1.0:bafybeib5l7jhew5ic6iq24dd23nidcoimzqkrk556gqywhoziatj33zvwm
 - valory/market_manager_abci:0.1.0:bafybeicia7itulcrxlwbmhfzxppgo5i33tb2nmcycwizftw7gps4dareka
-- valory/decision_maker_abci:0.1.0:bafybeiaiqddhwawt7u6stg6ujmzmnn3my7dtqa7tur5jbjfswnsasfoila
-- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeidw5cedygh25jtxdv35zb4223kbhtwv6enfxtkkdkuhuayvply5gq
+- valory/decision_maker_abci:0.1.0:bafybeie3ku2ms5xb3brkma7ilvareli4smcfd7kzmuacdyor7pmykfdyau
+- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeihhwaxdphul2zukucjzezabiwkpidqc7wvelf7kconq6hjeu2sdxa
 - valory/staking_abci:0.1.0:bafybeifyqszbiccxwwfldrl6lz5dspuaxbqd5qnniyecusddwvxpfwiyr4
 - valory/check_stop_trading_abci:0.1.0:bafybeicsrrxjs6bup267jiek3r7eutd42ssfyjthyvxfku6qozw3xebxta
 - valory/mech_interact_abci:0.1.0:bafybeid6m3i5ofq7vuogqapdnoshhq7mswmudhvfcr2craw25fdwtoe3lm

--- a/packages/valory/skills/tx_settlement_multiplexer_abci/skill.yaml
+++ b/packages/valory/skills/tx_settlement_multiplexer_abci/skill.yaml
@@ -23,7 +23,7 @@ protocols:
 - valory/ledger_api:1.0.0:bafybeihdk6psr4guxmbcrc26jr2cbgzpd5aljkqvpwo64bvaz7tdti2oni
 skills:
 - valory/abstract_round_abci:0.1.0:bafybeib733xfbndtpvkf44mtk7oyodnficgloo6xhn7xmqxxeos33es65u
-- valory/decision_maker_abci:0.1.0:bafybeiaiqddhwawt7u6stg6ujmzmnn3my7dtqa7tur5jbjfswnsasfoila
+- valory/decision_maker_abci:0.1.0:bafybeie3ku2ms5xb3brkma7ilvareli4smcfd7kzmuacdyor7pmykfdyau
 - valory/staking_abci:0.1.0:bafybeifyqszbiccxwwfldrl6lz5dspuaxbqd5qnniyecusddwvxpfwiyr4
 - valory/mech_interact_abci:0.1.0:bafybeid6m3i5ofq7vuogqapdnoshhq7mswmudhvfcr2craw25fdwtoe3lm
 behaviours:


### PR DESCRIPTION
When running the latest trader version with the Benchmarking mode active, an error was found because there was no default value for the index at the synchronized data

self.synchronized_data.sampled_bet_index

In order to have the Benchmarking running again we need to introduce a default value.