### PR TITLE
Improve the healthcheck

### DIFF
--- a/packages/packages.json
+++ b/packages/packages.json
@@ -16,14 +16,14 @@
         "contract/valory/staking_token/0.1.0": "bafybeiabkkhjpybqpzdfc4vcbiz4vefctfpvwetbmo7pqpiuxprmpvnti4",
         "contract/valory/relayer/0.1.0": "bafybeibvqc3lwxtcnu6dgfkf7mzefdgtfyosyq2dow7ogyxsl25vkxjwea",
         "skill/valory/market_manager_abci/0.1.0": "bafybeihmyqkzl3bm5zvjnc4auj32qjf3pk73scyq7mntmpsudqnisb4gey",
-        "skill/valory/decision_maker_abci/0.1.0": "bafybeigehrtalp3ppnog25yuvfcdt3gmrgvxb2zm2zyngxxfcvps2s3tza",
-        "skill/valory/trader_abci/0.1.0": "bafybeideek7oe3rbcnaymd4bnwsm2kull75wfdvljv5prvcsok5sgti7bq",
-        "skill/valory/tx_settlement_multiplexer_abci/0.1.0": "bafybeih2s2dwnyxm7xhd3knc3wlaejzyvfulxkipwnidmzxgx7t3ofqbpq",
+        "skill/valory/decision_maker_abci/0.1.0": "bafybeifbu5ufyxout25e5qo4m4eh55ie52qsw6ejzx7vfbqenbqjzsejl4",
+        "skill/valory/trader_abci/0.1.0": "bafybeianhvowfav2hceteyru6smi6gfblih7ji7qqqoplapem2vgdgngk4",
+        "skill/valory/tx_settlement_multiplexer_abci/0.1.0": "bafybeifie37a5g5qf2w2b5zcbaq5z75mkhmq6b7l26xiuf46dg2ztmebme",
         "skill/valory/staking_abci/0.1.0": "bafybeial5xtgzf37e2khvdrc2q2wa2xhirjwioi2szwvcgtupidjxhg7tq",
         "skill/valory/check_stop_trading_abci/0.1.0": "bafybeid7l74lmjnkeerkbvwhoo2l4cawb7c545rhcx3mjpsjux4zwy5wpm",
-        "agent/valory/trader/0.1.0": "bafybeicy63hsvgcui5p6vwjdgfwrm7ldvjxui4nyy7zykm675xjfnmdbza",
-        "service/valory/trader/0.1.0": "bafybeiawu46p7whmf6aiywqyechsolmhb56ew7c7pjphmrhzen7umk6lc4",
-        "service/valory/trader_pearl/0.1.0": "bafybeia3eztsz325jy2sbtilulfnl6pngz3bltkvogowx6xym3kr5re4ei"
+        "agent/valory/trader/0.1.0": "bafybeibwwzx3spt3wi22jb3joejrywncbad32oatrrrfb6fprp63rssy64",
+        "service/valory/trader/0.1.0": "bafybeieiukh6zokn7bjgnyywmnb32n7gmvhngzjjiusxjsh72yfksw24bu",
+        "service/valory/trader_pearl/0.1.0": "bafybeidpwx2lx5he6l3lft2er7laaboxy5j6qcrginr3v7mimzyr5hu4jq"
     },
     "third_party": {
         "protocol/valory/acn_data_share/0.1.0": "bafybeih5ydonnvrwvy2ygfqgfabkr47s4yw3uqxztmwyfprulwfsoe7ipq",

--- a/packages/valory/agents/trader/aea-config.yaml
+++ b/packages/valory/agents/trader/aea-config.yaml
@@ -50,10 +50,10 @@ skills:
 - valory/reset_pause_abci:0.1.0:bafybeigebq46oqz2mx2iajupr6p5pgm6z5pvfye5w6zypsseuqtvta7b4a
 - valory/termination_abci:0.1.0:bafybeieurwmfernodqyczj5ertsgfbjtjnrlgvte7sli4sajnbopty7inu
 - valory/transaction_settlement_abci:0.1.0:bafybeifkftgkyzrxwxjdyqixpp7vk6aqmufikalmwx3kydtlg74tonu47u
-- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeih2s2dwnyxm7xhd3knc3wlaejzyvfulxkipwnidmzxgx7t3ofqbpq
+- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeifie37a5g5qf2w2b5zcbaq5z75mkhmq6b7l26xiuf46dg2ztmebme
 - valory/market_manager_abci:0.1.0:bafybeihmyqkzl3bm5zvjnc4auj32qjf3pk73scyq7mntmpsudqnisb4gey
-- valory/decision_maker_abci:0.1.0:bafybeigehrtalp3ppnog25yuvfcdt3gmrgvxb2zm2zyngxxfcvps2s3tza
-- valory/trader_abci:0.1.0:bafybeideek7oe3rbcnaymd4bnwsm2kull75wfdvljv5prvcsok5sgti7bq
+- valory/decision_maker_abci:0.1.0:bafybeifbu5ufyxout25e5qo4m4eh55ie52qsw6ejzx7vfbqenbqjzsejl4
+- valory/trader_abci:0.1.0:bafybeianhvowfav2hceteyru6smi6gfblih7ji7qqqoplapem2vgdgngk4
 - valory/staking_abci:0.1.0:bafybeial5xtgzf37e2khvdrc2q2wa2xhirjwioi2szwvcgtupidjxhg7tq
 - valory/check_stop_trading_abci:0.1.0:bafybeid7l74lmjnkeerkbvwhoo2l4cawb7c545rhcx3mjpsjux4zwy5wpm
 - valory/mech_interact_abci:0.1.0:bafybeif2tpz2zet6p4z4vi3b254oxzyyzoe5tehj3me3znzt7h7otkpd54

--- a/packages/valory/services/trader/service.yaml
+++ b/packages/valory/services/trader/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeigtuothskwyvrhfosps2bu6suauycolj67dpuxqvnicdrdu7yhtvq
 fingerprint_ignore_patterns: []
-agent: valory/trader:0.1.0:bafybeicy63hsvgcui5p6vwjdgfwrm7ldvjxui4nyy7zykm675xjfnmdbza
+agent: valory/trader:0.1.0:bafybeibwwzx3spt3wi22jb3joejrywncbad32oatrrrfb6fprp63rssy64
 number_of_agents: 4
 deployment:
   agent:

--- a/packages/valory/services/trader_pearl/service.yaml
+++ b/packages/valory/services/trader_pearl/service.yaml
@@ -8,7 +8,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeibg7bdqpioh4lmvknw3ygnllfku32oca4eq5pqtvdrdsgw6buko7e
 fingerprint_ignore_patterns: []
-agent: valory/trader:0.1.0:bafybeicy63hsvgcui5p6vwjdgfwrm7ldvjxui4nyy7zykm675xjfnmdbza
+agent: valory/trader:0.1.0:bafybeibwwzx3spt3wi22jb3joejrywncbad32oatrrrfb6fprp63rssy64
 number_of_agents: 1
 deployment:
   agent:

--- a/packages/valory/skills/decision_maker_abci/handlers.py
+++ b/packages/valory/skills/decision_maker_abci/handlers.py
@@ -168,9 +168,7 @@ class HttpHandler(BaseHttpHandler):
     @property
     def synchronized_data(self) -> SynchronizedData:
         """Return the synchronized data."""
-        return SynchronizedData(
-            db=self.context.state.round_sequence.latest_synchronized_data.db
-        )
+        return SynchronizedData(db=self.round_sequence.latest_synchronized_data.db)
 
     def _get_handler(self, url: str, method: str) -> Tuple[Optional[Callable], Dict]:
         """Check if an url is meant to be handled in this handler

--- a/packages/valory/skills/decision_maker_abci/handlers.py
+++ b/packages/valory/skills/decision_maker_abci/handlers.py
@@ -387,6 +387,6 @@ class HttpHandler(BaseHttpHandler):
         # (an on chain transaction)
         return (
             self.synchronized_data.decision_receive_timestamp
-            < int(datetime.utcnow().timestamp())
+            < int(datetime.now(timezone.utc).timestamp())
             - self.context.params.expected_mech_response_time
         )

--- a/packages/valory/skills/decision_maker_abci/handlers.py
+++ b/packages/valory/skills/decision_maker_abci/handlers.py
@@ -183,7 +183,7 @@ class HttpHandler(BaseHttpHandler):
         # Check base url
         if not re.match(self.handler_url_regex, url):
             self.context.logger.info(
-                f"The url {url} does not match the DynamicNFT HttpHandler's pattern"
+                f"The url {url} does not match the HttpHandler's pattern"
             )
             return None, {}
 
@@ -200,7 +200,7 @@ class HttpHandler(BaseHttpHandler):
 
         # No route found
         self.context.logger.info(
-            f"The message [{method}] {url} is intended for the DynamicNFT HttpHandler but did not match any valid pattern"
+            f"The message [{method}] {url} is intended for the HttpHandler but did not match any valid pattern"
         )
         return self._handle_bad_request, {}
 

--- a/packages/valory/skills/decision_maker_abci/skill.yaml
+++ b/packages/valory/skills/decision_maker_abci/skill.yaml
@@ -29,7 +29,7 @@ fingerprint:
   behaviours/tool_selection.py: bafybeienlxcgjs3ogyofli3d7q3p5rst3mcxxcnwqf7qolqjeefjtixeke
   dialogues.py: bafybeigpwuzku3we7axmxeamg7vn656maww6emuztau5pg3ebsoquyfdqm
   fsm_specification.yaml: bafybeifvu7n6sjmrerogkzsftjrw2l6w5ppuq3f43ouj2rwbomdr5glp2e
-  handlers.py: bafybeieggvt2rh654s2jt2ablqtyzaycb7wlgrrdbsccf5652nptv45hie
+  handlers.py: bafybeidnrhmpngeobpv76nuyg7vdjstostrez3jiu4d4vqgk2467t6gq4i
   io_/__init__.py: bafybeifxgmmwjqzezzn3e6keh2bfo4cyo7y5dq2ept3stfmgglbrzfl5rq
   io_/loader.py: bafybeih3sdsx5dhe4kzhtoafexjgkutsujwqy3zcdrlrkhtdks45bc7exa
   models.py: bafybeiasqxrhudkisjohjdgbkmmj6esyw52sh66xflwkatd5dyradxb37q

--- a/packages/valory/skills/trader_abci/skill.yaml
+++ b/packages/valory/skills/trader_abci/skill.yaml
@@ -27,8 +27,8 @@ skills:
 - valory/transaction_settlement_abci:0.1.0:bafybeifkftgkyzrxwxjdyqixpp7vk6aqmufikalmwx3kydtlg74tonu47u
 - valory/termination_abci:0.1.0:bafybeieurwmfernodqyczj5ertsgfbjtjnrlgvte7sli4sajnbopty7inu
 - valory/market_manager_abci:0.1.0:bafybeihmyqkzl3bm5zvjnc4auj32qjf3pk73scyq7mntmpsudqnisb4gey
-- valory/decision_maker_abci:0.1.0:bafybeigehrtalp3ppnog25yuvfcdt3gmrgvxb2zm2zyngxxfcvps2s3tza
-- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeih2s2dwnyxm7xhd3knc3wlaejzyvfulxkipwnidmzxgx7t3ofqbpq
+- valory/decision_maker_abci:0.1.0:bafybeifbu5ufyxout25e5qo4m4eh55ie52qsw6ejzx7vfbqenbqjzsejl4
+- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeifie37a5g5qf2w2b5zcbaq5z75mkhmq6b7l26xiuf46dg2ztmebme
 - valory/staking_abci:0.1.0:bafybeial5xtgzf37e2khvdrc2q2wa2xhirjwioi2szwvcgtupidjxhg7tq
 - valory/check_stop_trading_abci:0.1.0:bafybeid7l74lmjnkeerkbvwhoo2l4cawb7c545rhcx3mjpsjux4zwy5wpm
 - valory/mech_interact_abci:0.1.0:bafybeif2tpz2zet6p4z4vi3b254oxzyyzoe5tehj3me3znzt7h7otkpd54

--- a/packages/valory/skills/tx_settlement_multiplexer_abci/skill.yaml
+++ b/packages/valory/skills/tx_settlement_multiplexer_abci/skill.yaml
@@ -23,7 +23,7 @@ protocols:
 - valory/ledger_api:1.0.0:bafybeihmqzcbj6t7vxz2aehd5726ofnzsfjs5cwlf42ro4tn6i34cbfrc4
 skills:
 - valory/abstract_round_abci:0.1.0:bafybeia27qmw6w5ds5fcrpj2475brnz742aampe3sgochloijs2l7jovai
-- valory/decision_maker_abci:0.1.0:bafybeigehrtalp3ppnog25yuvfcdt3gmrgvxb2zm2zyngxxfcvps2s3tza
+- valory/decision_maker_abci:0.1.0:bafybeifbu5ufyxout25e5qo4m4eh55ie52qsw6ejzx7vfbqenbqjzsejl4
 - valory/staking_abci:0.1.0:bafybeial5xtgzf37e2khvdrc2q2wa2xhirjwioi2szwvcgtupidjxhg7tq
 - valory/mech_interact_abci:0.1.0:bafybeif2tpz2zet6p4z4vi3b254oxzyyzoe5tehj3me3znzt7h7otkpd54
 behaviours:

--- a/poetry.lock
+++ b/poetry.lock
@@ -3539,13 +3539,13 @@ watchmedo = ["PyYAML (>=3.10)"]
 
 [[package]]
 name = "web3"
-version = "6.20.3"
+version = "6.20.4"
 description = "web3.py"
 optional = false
 python-versions = ">=3.7.2"
 files = [
-    {file = "web3-6.20.3-py3-none-any.whl", hash = "sha256:529fbb33f2476ce8185f7a2ed7e2e07c4c28621b0e89b845fbfdcaea9571286d"},
-    {file = "web3-6.20.3.tar.gz", hash = "sha256:c69dbf1a61ace172741d06990e60afc7f55f303eac087e7235f382df3047d017"},
+    {file = "web3-6.20.4-py3-none-any.whl", hash = "sha256:a6e1c428a54bf0fd398fbf006d00235898aed794476177ce73f7db177d2ad16c"},
+    {file = "web3-6.20.4.tar.gz", hash = "sha256:7f3cdceca369be3eb959ce3905783cd021a0786f40c60b01e40ae2ba538e6e3f"},
 ]
 
 [package.dependencies]
@@ -3564,11 +3564,11 @@ pyunormalize = ">=15.0.0"
 pywin32 = {version = ">=223", markers = "platform_system == \"Windows\""}
 requests = ">=2.16.0"
 typing-extensions = ">=4.0.1"
-websockets = ">=10.0.0"
+websockets = ">=10.0.0,<14.0.0"
 
 [package.extras]
-dev = ["build (>=0.9.0)", "bumpversion", "eth-tester[py-evm] (>=0.11.0b1,<0.12.0b1)", "eth-tester[py-evm] (>=0.9.0b1,<0.10.0b1)", "flaky (>=3.7.0)", "hypothesis (>=3.31.2)", "importlib-metadata (<5.0)", "ipfshttpclient (==0.8.0a2)", "pre-commit (>=2.21.0)", "py-geth (>=3.14.0,<4)", "pytest (>=7.0.0)", "pytest-asyncio (>=0.21.2,<0.23)", "pytest-mock (>=1.10)", "pytest-watch (>=4.2)", "pytest-xdist (>=1.29)", "setuptools (>=38.6.0)", "sphinx (>=5.3.0)", "sphinx-rtd-theme (>=1.0.0)", "towncrier (>=21,<22)", "tox (>=3.18.0)", "tqdm (>4.32)", "twine (>=1.13)", "when-changed (>=0.3.0)"]
-docs = ["sphinx (>=5.3.0)", "sphinx-rtd-theme (>=1.0.0)", "towncrier (>=21,<22)"]
+dev = ["build (>=0.9.0)", "bumpversion", "eth-tester[py-evm] (>=0.11.0b1,<0.12.0b1)", "eth-tester[py-evm] (>=0.9.0b1,<0.10.0b1)", "flaky (>=3.7.0)", "hypothesis (>=3.31.2)", "importlib-metadata (<5.0)", "ipfshttpclient (==0.8.0a2)", "pre-commit (>=2.21.0)", "py-geth (>=3.14.0,<4)", "pytest (>=7.0.0)", "pytest-asyncio (>=0.21.2,<0.23)", "pytest-mock (>=1.10)", "pytest-watch (>=4.2)", "pytest-xdist (>=1.29)", "setuptools (>=38.6.0)", "sphinx (>=5.3.0)", "sphinx_rtd_theme (>=1.0.0)", "towncrier (>=21,<22)", "tox (>=3.18.0)", "tqdm (>4.32)", "twine (>=1.13)", "when-changed (>=0.3.0)"]
+docs = ["sphinx (>=5.3.0)", "sphinx_rtd_theme (>=1.0.0)", "towncrier (>=21,<22)"]
 ipfs = ["ipfshttpclient (==0.8.0a2)"]
 tester = ["eth-tester[py-evm] (>=0.11.0b1,<0.12.0b1)", "eth-tester[py-evm] (>=0.9.0b1,<0.10.0b1)", "py-geth (>=3.14.0,<4)"]
 


### PR DESCRIPTION
The healthcheck's `is_transitioning_fast` flag should be calculated by the current round's max timeout, not the default reset pause duration.