### PR TITLE
Skip buy amount calculation on first failure

### DIFF
--- a/packages/packages.json
+++ b/packages/packages.json
@@ -16,14 +16,14 @@
         "contract/valory/staking_token/0.1.0": "bafybeiabkkhjpybqpzdfc4vcbiz4vefctfpvwetbmo7pqpiuxprmpvnti4",
         "contract/valory/relayer/0.1.0": "bafybeibvqc3lwxtcnu6dgfkf7mzefdgtfyosyq2dow7ogyxsl25vkxjwea",
         "skill/valory/market_manager_abci/0.1.0": "bafybeihmyqkzl3bm5zvjnc4auj32qjf3pk73scyq7mntmpsudqnisb4gey",
-        "skill/valory/decision_maker_abci/0.1.0": "bafybeigddrgyys4rqu3x6gwig7cpylesbpy6ioocmngremad373w54nlky",
-        "skill/valory/trader_abci/0.1.0": "bafybeidvi2fa26sbs3ig56rzfsewzcr2htgwkpxcdxzauyoys27byynoze",
-        "skill/valory/tx_settlement_multiplexer_abci/0.1.0": "bafybeicffb2hc2efvr33tvbbd5dp5sbj25fkar4fhgmqfbpy4fzxnzolsy",
+        "skill/valory/decision_maker_abci/0.1.0": "bafybeidlc7ed2lnrre3yyugqu35vlydbd6bzjgi7z6ormlguwjn5fpriku",
+        "skill/valory/trader_abci/0.1.0": "bafybeienif666scmx4zyn55u27pupgex4xw4ifwhoctskeoxj72devyu54",
+        "skill/valory/tx_settlement_multiplexer_abci/0.1.0": "bafybeiaonsd6obcnmhhrmkbejna6xeohpmzpalrsiwkvtk7yxu5vetqqqu",
         "skill/valory/staking_abci/0.1.0": "bafybeial5xtgzf37e2khvdrc2q2wa2xhirjwioi2szwvcgtupidjxhg7tq",
         "skill/valory/check_stop_trading_abci/0.1.0": "bafybeid7l74lmjnkeerkbvwhoo2l4cawb7c545rhcx3mjpsjux4zwy5wpm",
-        "agent/valory/trader/0.1.0": "bafybeif4vgpi37dspburfa4nltd6rzi7muqgqx3ojliutibwpahln3wxbe",
-        "service/valory/trader/0.1.0": "bafybeigzal6ikcehpsitpi7g3qgv6vhigcp2uqwlqgs3askdzaknk5bcy4",
-        "service/valory/trader_pearl/0.1.0": "bafybeihgmbbjtkrlu62bkm3e4j2ehqipv5huqpifjiyttvjrk4sikwsfzu"
+        "agent/valory/trader/0.1.0": "bafybeic625e3kale47ug35txqmkue74edbnype6oc5uijydqfwoetc24fu",
+        "service/valory/trader/0.1.0": "bafybeiffqhv2waa355pnbbpmhpkn3a35gho3ey5o5fbartvd535df62vai",
+        "service/valory/trader_pearl/0.1.0": "bafybeif5dmcya5vimxqecypr6rndmdv7xa2tidnygieinajqci7s25yjc4"
     },
     "third_party": {
         "protocol/valory/acn_data_share/0.1.0": "bafybeih5ydonnvrwvy2ygfqgfabkr47s4yw3uqxztmwyfprulwfsoe7ipq",

--- a/packages/valory/agents/trader/aea-config.yaml
+++ b/packages/valory/agents/trader/aea-config.yaml
@@ -50,10 +50,10 @@ skills:
 - valory/reset_pause_abci:0.1.0:bafybeigebq46oqz2mx2iajupr6p5pgm6z5pvfye5w6zypsseuqtvta7b4a
 - valory/termination_abci:0.1.0:bafybeieurwmfernodqyczj5ertsgfbjtjnrlgvte7sli4sajnbopty7inu
 - valory/transaction_settlement_abci:0.1.0:bafybeifkftgkyzrxwxjdyqixpp7vk6aqmufikalmwx3kydtlg74tonu47u
-- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeicffb2hc2efvr33tvbbd5dp5sbj25fkar4fhgmqfbpy4fzxnzolsy
+- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeiaonsd6obcnmhhrmkbejna6xeohpmzpalrsiwkvtk7yxu5vetqqqu
 - valory/market_manager_abci:0.1.0:bafybeihmyqkzl3bm5zvjnc4auj32qjf3pk73scyq7mntmpsudqnisb4gey
-- valory/decision_maker_abci:0.1.0:bafybeigddrgyys4rqu3x6gwig7cpylesbpy6ioocmngremad373w54nlky
-- valory/trader_abci:0.1.0:bafybeidvi2fa26sbs3ig56rzfsewzcr2htgwkpxcdxzauyoys27byynoze
+- valory/decision_maker_abci:0.1.0:bafybeidlc7ed2lnrre3yyugqu35vlydbd6bzjgi7z6ormlguwjn5fpriku
+- valory/trader_abci:0.1.0:bafybeienif666scmx4zyn55u27pupgex4xw4ifwhoctskeoxj72devyu54
 - valory/staking_abci:0.1.0:bafybeial5xtgzf37e2khvdrc2q2wa2xhirjwioi2szwvcgtupidjxhg7tq
 - valory/check_stop_trading_abci:0.1.0:bafybeid7l74lmjnkeerkbvwhoo2l4cawb7c545rhcx3mjpsjux4zwy5wpm
 - valory/mech_interact_abci:0.1.0:bafybeif2tpz2zet6p4z4vi3b254oxzyyzoe5tehj3me3znzt7h7otkpd54

--- a/packages/valory/services/trader/service.yaml
+++ b/packages/valory/services/trader/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeigtuothskwyvrhfosps2bu6suauycolj67dpuxqvnicdrdu7yhtvq
 fingerprint_ignore_patterns: []
-agent: valory/trader:0.1.0:bafybeif4vgpi37dspburfa4nltd6rzi7muqgqx3ojliutibwpahln3wxbe
+agent: valory/trader:0.1.0:bafybeic625e3kale47ug35txqmkue74edbnype6oc5uijydqfwoetc24fu
 number_of_agents: 4
 deployment:
   agent:

--- a/packages/valory/services/trader_pearl/service.yaml
+++ b/packages/valory/services/trader_pearl/service.yaml
@@ -8,7 +8,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeibg7bdqpioh4lmvknw3ygnllfku32oca4eq5pqtvdrdsgw6buko7e
 fingerprint_ignore_patterns: []
-agent: valory/trader:0.1.0:bafybeif4vgpi37dspburfa4nltd6rzi7muqgqx3ojliutibwpahln3wxbe
+agent: valory/trader:0.1.0:bafybeic625e3kale47ug35txqmkue74edbnype6oc5uijydqfwoetc24fu
 number_of_agents: 1
 deployment:
   agent:

--- a/packages/valory/skills/decision_maker_abci/behaviours/bet_placement.py
+++ b/packages/valory/skills/decision_maker_abci/behaviours/bet_placement.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # ------------------------------------------------------------------------------
 #
-#   Copyright 2023-2024 Valory AG
+#   Copyright 2023-2025 Valory AG
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.

--- a/packages/valory/skills/decision_maker_abci/behaviours/bet_placement.py
+++ b/packages/valory/skills/decision_maker_abci/behaviours/bet_placement.py
@@ -187,9 +187,15 @@ class BetPlacementBehaviour(DecisionMakerBaseBehaviour):
 
     def _prepare_safe_tx(self) -> Generator[None, None, Optional[str]]:
         """Prepare the safe transaction for placing a bet and return the hex for the tx settlement skill."""
+        yield from self.wait_for_condition_with_sleep(self._build_approval_tx)
+
+        # based on past observations, the buy amount calculation usually fails because of the RPC misbehaving
+        # if this happens, we do not want to retry as it won't get resolved soon. Instead, we exit this round.
+        calculation_succeeded = yield from self._calc_buy_amount()
+        if not calculation_succeeded:
+            return None
+
         for step in (
-            self._build_approval_tx,
-            self._calc_buy_amount,
             self._build_buy_tx,
             self._build_multisend_data,
             self._build_multisend_safe_tx_hash,

--- a/packages/valory/skills/decision_maker_abci/fsm_specification.yaml
+++ b/packages/valory/skills/decision_maker_abci/fsm_specification.yaml
@@ -3,6 +3,7 @@ alphabet_in:
 - BENCHMARKING_ENABLED
 - BENCHMARKING_FINISHED
 - BLACKLIST
+- CALC_BUY_AMOUNT_FAILED
 - DONE
 - FETCH_ERROR
 - INSUFFICIENT_BALANCE
@@ -68,6 +69,7 @@ transition_func:
     (BenchmarkingRandomnessRound, NONE): ImpossibleRound
     (BenchmarkingRandomnessRound, NO_MAJORITY): BenchmarkingRandomnessRound
     (BenchmarkingRandomnessRound, ROUND_TIMEOUT): BenchmarkingRandomnessRound
+    (BetPlacementRound, CALC_BUY_AMOUNT_FAILED): HandleFailedTxRound
     (BetPlacementRound, DONE): FinishedDecisionMakerRound
     (BetPlacementRound, INSUFFICIENT_BALANCE): RefillRequiredRound
     (BetPlacementRound, MOCK_TX): RedeemRound

--- a/packages/valory/skills/decision_maker_abci/rounds.py
+++ b/packages/valory/skills/decision_maker_abci/rounds.py
@@ -293,6 +293,7 @@ class DecisionMakerAbciApp(AbciApp[Event]):
             Event.MOCK_TX: RedeemRound,
             # degenerate round on purpose, owner must refill the safe
             Event.INSUFFICIENT_BALANCE: RefillRequiredRound,
+            Event.CALC_BUY_AMOUNT_FAILED: HandleFailedTxRound,
             Event.NO_MAJORITY: BetPlacementRound,
             Event.ROUND_TIMEOUT: BetPlacementRound,
             # this is here because of `autonomy analyse fsm-specs`

--- a/packages/valory/skills/decision_maker_abci/rounds.py
+++ b/packages/valory/skills/decision_maker_abci/rounds.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # ------------------------------------------------------------------------------
 #
-#   Copyright 2023-2024 Valory AG
+#   Copyright 2023-2025 Valory AG
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
@@ -157,6 +157,7 @@ class DecisionMakerAbciApp(AbciApp[Event]):
             - done: 13.
             - mock tx: 11.
             - insufficient balance: 19.
+            - calc buy amount failed: 12.
             - no majority: 10.
             - round timeout: 10.
             - none: 20.

--- a/packages/valory/skills/decision_maker_abci/skill.yaml
+++ b/packages/valory/skills/decision_maker_abci/skill.yaml
@@ -13,7 +13,7 @@ fingerprint:
   __init__.py: bafybeih563ujnigeci2ldzh7hakbau6a222vsed7leg3b7lq32vcn3nm4a
   behaviours/__init__.py: bafybeih6ddz2ocvm6x6ytvlbcz6oi4snb5ee5xh5h65nq4w2qf7fd7zfky
   behaviours/base.py: bafybeifyuhycdirvw4k5np6spfmvinzvisb5rley5xjl7nodhxjtee34oa
-  behaviours/bet_placement.py: bafybeibiezagww5dsbpptgvtzgch3yjrq3343gw5cyfpckegxkfzo67vru
+  behaviours/bet_placement.py: bafybeibflvlyvmd7que4y6eb7egbixx3hvlwdu764zesi6dnwyusvryhba
   behaviours/blacklisting.py: bafybeieuqoup2vrmrtvjfqnr5mzrvkegc7afb2oeujzq2itsbhcsham2se
   behaviours/check_benchmarking.py: bafybeiao2lyj7apezkqrpgsyzb3dwvrdgsrgtprf6iuhsmlsufvxfl5bci
   behaviours/claim_subscription.py: bafybeigbqkhc6mb73rbwaks32tfiqx6u2xza43uiy6rvbtrnqd6m4fru3e
@@ -28,7 +28,7 @@ fingerprint:
   behaviours/storage_manager.py: bafybeic6wca37fkwonbsrwme55xnklfbqtheknroudayzfxdge4pxdbm7y
   behaviours/tool_selection.py: bafybeienlxcgjs3ogyofli3d7q3p5rst3mcxxcnwqf7qolqjeefjtixeke
   dialogues.py: bafybeigpwuzku3we7axmxeamg7vn656maww6emuztau5pg3ebsoquyfdqm
-  fsm_specification.yaml: bafybeifvu7n6sjmrerogkzsftjrw2l6w5ppuq3f43ouj2rwbomdr5glp2e
+  fsm_specification.yaml: bafybeib3oecxsixxzf3fsai5f7jlqpqqm23jcuvqn5fgp54shdj3temz2y
   handlers.py: bafybeiherm5a2kjmf46ffjoyvhh3tsja5au5i677oasiutdxdojwdtwqla
   io_/__init__.py: bafybeifxgmmwjqzezzn3e6keh2bfo4cyo7y5dq2ept3stfmgglbrzfl5rq
   io_/loader.py: bafybeih3sdsx5dhe4kzhtoafexjgkutsujwqy3zcdrlrkhtdks45bc7exa
@@ -36,11 +36,11 @@ fingerprint:
   payloads.py: bafybeieygushjlrzwzpnhagjgpbs3goot3pnfheh6yawuwctrk3uoeesfm
   policy.py: bafybeidofgwvk6sudz75tvuduskuphtn3amtib2irzw5hr3qcfn5pdwuc4
   redeem_info.py: bafybeifiiix4gihfo4avraxt34sfw35v6dqq45do2drrssei2shbps63mm
-  rounds.py: bafybeiftrpaxyyly3d36kvfg2c2m5fmzchm6n4vv5losu3jr2b7s5ces6a
+  rounds.py: bafybeiedbmmy7jnqvtcdfnd222yyr3r4d7m7bhhwccla4nsqautmavwgrq
   rounds_info.py: bafybeihg6i3h7a7ahfxzhow7gcuszcilq5krfpchze2szjdu7dtem2tnwa
   states/__init__.py: bafybeid23llnyp6j257dluxmrnztugo5llsrog7kua53hllyktz4dqhqoy
-  states/base.py: bafybeiglqvym3ri6hurx4k7hrnykzbmslxe3vuj23djt6hai4czii4vbqq
-  states/bet_placement.py: bafybeih5eopyxubczys5u5t3bdxbxpc7mmfdyqrpqsbm2uha5jc2phza4i
+  states/base.py: bafybeictnvwzj2m7uk4n3uwuh5yhfx2uqn5klgs3afog2tet33mp5hnxmi
+  states/bet_placement.py: bafybeidd3k6bbnjkznwbv43l44wexaci7k7axz6mfrgca76mjljp5o2344
   states/blacklisting.py: bafybeiapelgjhbjjn4uq4z5gspyirqzwzgccg5anktrp5kxdwamfnfw5mi
   states/check_benchmarking.py: bafybeiagrgeopuluwqkvoqbst2hjymte5rju2pecvkoeleklnqca5andeu
   states/claim_subscription.py: bafybeicjsjkvv2ftfv2gquvp7fyvuqia6acs44d3smwebgaic7lhkbaym4

--- a/packages/valory/skills/decision_maker_abci/states/base.py
+++ b/packages/valory/skills/decision_maker_abci/states/base.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # ------------------------------------------------------------------------------
 #
-#   Copyright 2023-2024 Valory AG
+#   Copyright 2023-2025 Valory AG
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.

--- a/packages/valory/skills/decision_maker_abci/states/base.py
+++ b/packages/valory/skills/decision_maker_abci/states/base.py
@@ -59,6 +59,7 @@ class Event(Enum):
     TIE = "tie"
     UNPROFITABLE = "unprofitable"
     INSUFFICIENT_BALANCE = "insufficient_balance"
+    CALC_BUY_AMOUNT_FAILED = "calc_buy_amount_failed"
     NO_REDEEMING = "no_redeeming"
     BLACKLIST = "blacklist"
     NO_OP = "no_op"

--- a/packages/valory/skills/decision_maker_abci/states/bet_placement.py
+++ b/packages/valory/skills/decision_maker_abci/states/bet_placement.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # ------------------------------------------------------------------------------
 #
-#   Copyright 2024 Valory AG
+#   Copyright 2024-2025 Valory AG
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.

--- a/packages/valory/skills/decision_maker_abci/states/bet_placement.py
+++ b/packages/valory/skills/decision_maker_abci/states/bet_placement.py
@@ -19,7 +19,7 @@
 
 """This module contains the sampling state of the decision-making abci app."""
 from enum import Enum
-from typing import Optional, Tuple, Type
+from typing import Optional, Tuple, Type, cast
 
 from packages.valory.skills.abstract_round_abci.base import BaseSynchronizedData
 from packages.valory.skills.decision_maker_abci.payloads import (
@@ -28,6 +28,7 @@ from packages.valory.skills.decision_maker_abci.payloads import (
 )
 from packages.valory.skills.decision_maker_abci.states.base import (
     Event,
+    SynchronizedData,
     TxPreparationRound,
 )
 
@@ -36,16 +37,19 @@ class BetPlacementRound(TxPreparationRound):
     """A round for placing a bet."""
 
     payload_class: Type[MultisigTxPayload] = BetPlacementPayload
-
     none_event = Event.INSUFFICIENT_BALANCE
 
     def end_block(self) -> Optional[Tuple[BaseSynchronizedData, Enum]]:
         """Process the end of the block."""
-        update = super().end_block()
-        if update is None:
+        res = super().end_block()
+        if res is None:
             return None
 
-        sync_data, event = update
+        synced_data, event = cast(Tuple[SynchronizedData, Enum], res)
         wallet_balance = self.most_voted_payload_values[-1]
-        sync_data = sync_data.update(wallet_balance=wallet_balance)
-        return sync_data, event
+        synced_data.update(wallet_balance=wallet_balance)
+
+        if event == Event.DONE and not synced_data.most_voted_tx_hash:
+            event = Event.CALC_BUY_AMOUNT_FAILED
+
+        return synced_data, event

--- a/packages/valory/skills/trader_abci/fsm_specification.yaml
+++ b/packages/valory/skills/trader_abci/fsm_specification.yaml
@@ -4,6 +4,7 @@ alphabet_in:
 - BENCHMARKING_FINISHED
 - BET_PLACEMENT_DONE
 - BLACKLIST
+- CALC_BUY_AMOUNT_FAILED
 - CHECKS_PASSED
 - CHECK_HISTORY
 - CHECK_LATE_ARRIVING_MESSAGE
@@ -98,6 +99,7 @@ transition_func:
     (BenchmarkingRandomnessRound, NONE): ImpossibleRound
     (BenchmarkingRandomnessRound, NO_MAJORITY): BenchmarkingRandomnessRound
     (BenchmarkingRandomnessRound, ROUND_TIMEOUT): BenchmarkingRandomnessRound
+    (BetPlacementRound, CALC_BUY_AMOUNT_FAILED): HandleFailedTxRound
     (BetPlacementRound, DONE): PreTxSettlementRound
     (BetPlacementRound, INSUFFICIENT_BALANCE): ResetAndPauseRound
     (BetPlacementRound, MOCK_TX): RedeemRound

--- a/packages/valory/skills/trader_abci/skill.yaml
+++ b/packages/valory/skills/trader_abci/skill.yaml
@@ -11,7 +11,7 @@ fingerprint:
   behaviours.py: bafybeigc6hszbu66ccajny5eh7thfgsrlr36je4mzziwp4mupgvtaeu6aa
   composition.py: bafybeievziz7cajszkw3ugfd3xn6ycktms463kefxjk2qlcyyh73couqg4
   dialogues.py: bafybeihouxm2nl2r6h3vlymmtrge43tcnwphtzhc2q3vludpgytigggguy
-  fsm_specification.yaml: bafybeid6u6esbfsahu3xqcgkpbsfhffghc3jgizgmzqbc4ww7wtjbkhuay
+  fsm_specification.yaml: bafybeia4bg3ws7xea2etcodkcgk6q5hgw4mtytrbovchfncul6h27jxnvm
   handlers.py: bafybeigrqsgqupy6kds2vqieacsymx3eucntwl52rlgi4cu4lrb6bglhti
   models.py: bafybeie342ympii4zkf6cp5n7tfnwql2ftdodfwlwzgiivi43iyqia37vy
   tests/__init__.py: bafybeiadatapyjh3e7ucg2ehz77oms3ihrbutwb2cs2tkjehy54utwvuyi
@@ -27,8 +27,8 @@ skills:
 - valory/transaction_settlement_abci:0.1.0:bafybeifkftgkyzrxwxjdyqixpp7vk6aqmufikalmwx3kydtlg74tonu47u
 - valory/termination_abci:0.1.0:bafybeieurwmfernodqyczj5ertsgfbjtjnrlgvte7sli4sajnbopty7inu
 - valory/market_manager_abci:0.1.0:bafybeihmyqkzl3bm5zvjnc4auj32qjf3pk73scyq7mntmpsudqnisb4gey
-- valory/decision_maker_abci:0.1.0:bafybeigddrgyys4rqu3x6gwig7cpylesbpy6ioocmngremad373w54nlky
-- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeicffb2hc2efvr33tvbbd5dp5sbj25fkar4fhgmqfbpy4fzxnzolsy
+- valory/decision_maker_abci:0.1.0:bafybeidlc7ed2lnrre3yyugqu35vlydbd6bzjgi7z6ormlguwjn5fpriku
+- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeiaonsd6obcnmhhrmkbejna6xeohpmzpalrsiwkvtk7yxu5vetqqqu
 - valory/staking_abci:0.1.0:bafybeial5xtgzf37e2khvdrc2q2wa2xhirjwioi2szwvcgtupidjxhg7tq
 - valory/check_stop_trading_abci:0.1.0:bafybeid7l74lmjnkeerkbvwhoo2l4cawb7c545rhcx3mjpsjux4zwy5wpm
 - valory/mech_interact_abci:0.1.0:bafybeif2tpz2zet6p4z4vi3b254oxzyyzoe5tehj3me3znzt7h7otkpd54

--- a/packages/valory/skills/tx_settlement_multiplexer_abci/skill.yaml
+++ b/packages/valory/skills/tx_settlement_multiplexer_abci/skill.yaml
@@ -23,7 +23,7 @@ protocols:
 - valory/ledger_api:1.0.0:bafybeihmqzcbj6t7vxz2aehd5726ofnzsfjs5cwlf42ro4tn6i34cbfrc4
 skills:
 - valory/abstract_round_abci:0.1.0:bafybeia27qmw6w5ds5fcrpj2475brnz742aampe3sgochloijs2l7jovai
-- valory/decision_maker_abci:0.1.0:bafybeigddrgyys4rqu3x6gwig7cpylesbpy6ioocmngremad373w54nlky
+- valory/decision_maker_abci:0.1.0:bafybeidlc7ed2lnrre3yyugqu35vlydbd6bzjgi7z6ormlguwjn5fpriku
 - valory/staking_abci:0.1.0:bafybeial5xtgzf37e2khvdrc2q2wa2xhirjwioi2szwvcgtupidjxhg7tq
 - valory/mech_interact_abci:0.1.0:bafybeif2tpz2zet6p4z4vi3b254oxzyyzoe5tehj3me3znzt7h7otkpd54
 behaviours:

--- a/poetry.lock
+++ b/poetry.lock
@@ -1445,13 +1445,13 @@ files = [
 
 [[package]]
 name = "googleapis-common-protos"
-version = "1.67.0"
+version = "1.68.0"
 description = "Common protobufs used in Google APIs"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "googleapis_common_protos-1.67.0-py2.py3-none-any.whl", hash = "sha256:579de760800d13616f51cf8be00c876f00a9f146d3e6510e19d1f4111758b741"},
-    {file = "googleapis_common_protos-1.67.0.tar.gz", hash = "sha256:21398025365f138be356d5923e9168737d94d46a72aefee4a6110a1f23463c86"},
+    {file = "googleapis_common_protos-1.68.0-py2.py3-none-any.whl", hash = "sha256:aaf179b2f81df26dfadac95def3b16a95064c76a5f45f07e4c68a21bb371c4ac"},
+    {file = "googleapis_common_protos-1.68.0.tar.gz", hash = "sha256:95d38161f4f9af0d9423eed8fb7b64ffd2568c3464eb542ff02c5bfa1953ab3c"},
 ]
 
 [package.dependencies]


### PR DESCRIPTION
Based on past observations, the buy amount calculation usually fails because of the RPC misbehaving. If this happens, we do not want to retry as it usually does not get resolved soon. Instead, we now exit this round.