### PR TITLE
fix: update runner to use ubuntu-latest for package publishing 🔄

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,7 +8,7 @@ on:
 jobs:
   publish-packages:
     name: Push Packages
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         os: [ubuntu-latest]


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow configuration to use the latest Ubuntu version for the runner environment.

* [`.github/workflows/release.yaml`](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaL11-R11): Changed the `runs-on` parameter from `ubuntu-20.04` to `ubuntu-latest` in the `publish-packages` job to ensure the workflow uses the most up-to-date Ubuntu environment.