### PR TITLE
restoring claude and rag tools in pearl agents

### DIFF
--- a/packages/packages.json
+++ b/packages/packages.json
@@ -22,7 +22,7 @@
         "skill/valory/check_stop_trading_abci/0.1.0": "bafybeiharjs3rkmtk7fczhobfvgoikdun6cgdplprz4u6wo2efukul6n7q",
         "agent/valory/trader/0.1.0": "bafybeigab5vw47o5tulu4qofr3eyl7xahj3clkfwx2k6fz67rydxj6bw6u",
         "service/valory/trader/0.1.0": "bafybeigbu55tvgoljuxdyiwtqthhsaswk2xii4bl3tlwpqhzo2ddhw4suq",
-        "service/valory/trader_pearl/0.1.0": "bafybeicjed5gnkrplpdofkvqrglupdgg7b7jxufi5piaaxhxb2uqy4zvzq"
+        "service/valory/trader_pearl/0.1.0": "bafybeicib5qkdst2u7xfjqdsy7qxvfirn4chleltmk42e5drgmxbrq3hka"
     },
     "third_party": {
         "protocol/valory/acn_data_share/0.1.0": "bafybeih5ydonnvrwvy2ygfqgfabkr47s4yw3uqxztmwyfprulwfsoe7ipq",

--- a/packages/valory/services/trader_pearl/service.yaml
+++ b/packages/valory/services/trader_pearl/service.yaml
@@ -114,7 +114,7 @@ models:
       slippage: ${SLIPPAGE:float:0.01}
       policy_epsilon: ${POLICY_EPSILON:float:0.25}
       store_path: ${STORE_PATH:str:/data/}
-      irrelevant_tools: ${IRRELEVANT_TOOLS:list:["native-transfer","prediction-online-lite","claude-prediction-online-lite","prediction-online-sme-lite","prediction-request-reasoning-lite","prediction-request-reasoning-claude-lite","prediction-request-rag","prediction-request-reasoning-claude","prediction-url-cot-claude","claude-prediction-offline","claude-prediction-online","prediction-offline-sme","deepmind-optimization",
+      irrelevant_tools: ${IRRELEVANT_TOOLS:list:["native-transfer","prediction-online-lite","claude-prediction-online-lite","prediction-online-sme-lite","prediction-request-reasoning-lite","prediction-request-reasoning-claude-lite","prediction-offline-sme","deepmind-optimization",
         "deepmind-optimization-strong", "openai-gpt-3.5-turbo", "openai-gpt-3.5-turbo-instruct",
         "openai-gpt-4", "openai-text-davinci-002", "openai-text-davinci-003", "prediction-online-sum-url-content",
         "prediction-online-summarized-info", "stabilityai-stable-diffusion-512-v2-1",


### PR DESCRIPTION
After some investigation we discovered that Claude tools and prediction-request-rag were removed from the list of available tools for the pearl agents so we want to bring them back so that trader agents can choose again these tools to make predictions.