### PR TITLE
Temporarily hardcode the mech's hash

### DIFF
--- a/packages/packages.json
+++ b/packages/packages.json
@@ -16,14 +16,14 @@
         "contract/valory/relayer/0.1.0": "bafybeihypuljybkocl6iiacy52py7i5iqxdli3ily66q7b3nego4qajvne",
         "contract/valory/market_maker/0.1.0": "bafybeiepwclhyg7oo7wcffmben42wmwrxgb4ovoomw2zbjqljcy7b2neke",
         "skill/valory/market_manager_abci/0.1.0": "bafybeidblnaypi5fbci6zyk4ekngxq5zf2jiptssfhfiodzg7rilq24cz4",
-        "skill/valory/decision_maker_abci/0.1.0": "bafybeigwwk26gnxagplsn5opbefevntpzoyclnebl2gxetbil665zqiv64",
-        "skill/valory/trader_abci/0.1.0": "bafybeievvi5nmvmlxtzghqxu2nepefg5wn5fudhbk3znzec2tvxnyyxmsa",
-        "skill/valory/tx_settlement_multiplexer_abci/0.1.0": "bafybeicjjos5c2oc35rbknddzz563hk2axzwpimqeyk52t6g2glcuxmrwm",
+        "skill/valory/decision_maker_abci/0.1.0": "bafybeiequ53nozctyki67yv6o7px55rxhk6shuwdp4idxb4bnlturxs2ge",
+        "skill/valory/trader_abci/0.1.0": "bafybeicwl4j46jlslwisg6uusbvpfq335nuxuolhm7dsrngwzrnfmetxri",
+        "skill/valory/tx_settlement_multiplexer_abci/0.1.0": "bafybeihcissp2uqahoo4zf3jeosvwvkw5tlqucby3zhs3a3z3pmzu44zxm",
         "skill/valory/staking_abci/0.1.0": "bafybeifupwkfbxa4c4jogpudvzwt5rkgfuedgd65sj2bf2z5ver4phq64m",
         "skill/valory/check_stop_trading_abci/0.1.0": "bafybeibtp73af35klgofghueuyrsasslndb7iuidm2p2pk4qmkq6qwt774",
-        "agent/valory/trader/0.1.0": "bafybeidlsdofn3g65n237im5elxlmhkvqugl6ftzymbbawletbz4s5amky",
-        "service/valory/trader/0.1.0": "bafybeicq5w557pbehlmt43oad2fqsnykwmkyfkgnoi76xdllkpcr7avrna",
-        "service/valory/trader_pearl/0.1.0": "bafybeighlbdwqp5q2qxuan4dx6j7a4yo6ygjoyym6pta6yus6q2v5xeide"
+        "agent/valory/trader/0.1.0": "bafybeigf6o6bebvdtqlzup7cjqcunpum7npzdygtumjr5w2enq6lyadpti",
+        "service/valory/trader/0.1.0": "bafybeihksvwcli5zjs3umptgepscxerixzq33qyh65e3adgmej4cjx2r6q",
+        "service/valory/trader_pearl/0.1.0": "bafybeievvf3663md525u2khoxjlufgp6hsf6vf6kah4xqckksj5nmtkg5q"
     },
     "third_party": {
         "protocol/valory/acn_data_share/0.1.0": "bafybeih5ydonnvrwvy2ygfqgfabkr47s4yw3uqxztmwyfprulwfsoe7ipq",

--- a/packages/valory/agents/trader/aea-config.yaml
+++ b/packages/valory/agents/trader/aea-config.yaml
@@ -52,10 +52,10 @@ skills:
 - valory/reset_pause_abci:0.1.0:bafybeiachgo6reit2q4jw75mefw2acj4ldedeqmn3rewjm4dbzts2l7oxe
 - valory/termination_abci:0.1.0:bafybeibtbboau3q5fxfviwm7lbeix4z55uptfqqiyiu6siivxwkp3o5pju
 - valory/transaction_settlement_abci:0.1.0:bafybeic2ywzpwkyeqbzsvkbvurhsptemam4xtceihax2tmxmlxtgd3xpya
-- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeicjjos5c2oc35rbknddzz563hk2axzwpimqeyk52t6g2glcuxmrwm
+- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeihcissp2uqahoo4zf3jeosvwvkw5tlqucby3zhs3a3z3pmzu44zxm
 - valory/market_manager_abci:0.1.0:bafybeidblnaypi5fbci6zyk4ekngxq5zf2jiptssfhfiodzg7rilq24cz4
-- valory/decision_maker_abci:0.1.0:bafybeigwwk26gnxagplsn5opbefevntpzoyclnebl2gxetbil665zqiv64
-- valory/trader_abci:0.1.0:bafybeievvi5nmvmlxtzghqxu2nepefg5wn5fudhbk3znzec2tvxnyyxmsa
+- valory/decision_maker_abci:0.1.0:bafybeiequ53nozctyki67yv6o7px55rxhk6shuwdp4idxb4bnlturxs2ge
+- valory/trader_abci:0.1.0:bafybeicwl4j46jlslwisg6uusbvpfq335nuxuolhm7dsrngwzrnfmetxri
 - valory/staking_abci:0.1.0:bafybeifupwkfbxa4c4jogpudvzwt5rkgfuedgd65sj2bf2z5ver4phq64m
 - valory/check_stop_trading_abci:0.1.0:bafybeibtp73af35klgofghueuyrsasslndb7iuidm2p2pk4qmkq6qwt774
 - valory/mech_interact_abci:0.1.0:bafybeiedcaz6tmjg2irpntcco7ny2vwyqvffxl3mpji7qi6esdjr6qv3za

--- a/packages/valory/services/trader/service.yaml
+++ b/packages/valory/services/trader/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeigtuothskwyvrhfosps2bu6suauycolj67dpuxqvnicdrdu7yhtvq
 fingerprint_ignore_patterns: []
-agent: valory/trader:0.1.0:bafybeidlsdofn3g65n237im5elxlmhkvqugl6ftzymbbawletbz4s5amky
+agent: valory/trader:0.1.0:bafybeigf6o6bebvdtqlzup7cjqcunpum7npzdygtumjr5w2enq6lyadpti
 number_of_agents: 4
 deployment:
   agent:

--- a/packages/valory/services/trader_pearl/service.yaml
+++ b/packages/valory/services/trader_pearl/service.yaml
@@ -8,7 +8,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeibg7bdqpioh4lmvknw3ygnllfku32oca4eq5pqtvdrdsgw6buko7e
 fingerprint_ignore_patterns: []
-agent: valory/trader:0.1.0:bafybeidlsdofn3g65n237im5elxlmhkvqugl6ftzymbbawletbz4s5amky
+agent: valory/trader:0.1.0:bafybeigf6o6bebvdtqlzup7cjqcunpum7npzdygtumjr5w2enq6lyadpti
 number_of_agents: 1
 deployment:
   agent:

--- a/packages/valory/skills/decision_maker_abci/behaviours/storage_manager.py
+++ b/packages/valory/skills/decision_maker_abci/behaviours/storage_manager.py
@@ -55,7 +55,9 @@ class StorageManagerBehaviour(DecisionMakerBaseBehaviour, ABC):
         """Initialize Behaviour."""
         super().__init__(**kwargs)
         self._mech_id: int = 0
-        self._mech_hash: str = ""
+        self._mech_hash: str = (
+            "d26821719fcdb05d3683d8091ca31183ccdb02b792abe9e69bd62e3886abe835"
+        )
         self._utilized_tools: Dict[str, str] = {}
         self._mech_tools: Optional[List[str]] = None
         self._remote_accuracy_information: StringIO = StringIO()
@@ -220,12 +222,7 @@ class StorageManagerBehaviour(DecisionMakerBaseBehaviour, ABC):
             self._get_tools_from_benchmark_file()
             return
 
-        for step in (
-            self._get_mech_id,
-            self._get_mech_hash,
-            self._get_mech_tools,
-        ):
-            yield from self.wait_for_condition_with_sleep(step)
+        yield from self.wait_for_condition_with_sleep(self._get_mech_tools)
 
     def _try_recover_policy(self) -> Optional[EGreedyPolicy]:
         """Try to recover the policy from the policy store."""

--- a/packages/valory/skills/decision_maker_abci/skill.yaml
+++ b/packages/valory/skills/decision_maker_abci/skill.yaml
@@ -25,7 +25,7 @@ fingerprint:
   behaviours/reedem.py: bafybeiajxsz34iy24muw4avq4vbevluhsabjcyqaadssnrs2zrfdapbnqq
   behaviours/round_behaviour.py: bafybeih63hpia2bwwzu563hxs5yd3t5ycvxvkfnhvxbzghbyy3mw3xjl3i
   behaviours/sampling.py: bafybeiet37e4o4s5kdf4u4denls7iaqm6b2a2mqa5eu576waiwmuwozhmi
-  behaviours/storage_manager.py: bafybeihgwuxrbn7hjznvwedzrmnqkx735vh45lev55clokgdvdqufm37u4
+  behaviours/storage_manager.py: bafybeiginbllxqnupheqczdpvuwbug7he7sivs4tebjq3eaehyh3ns4vpi
   behaviours/tool_selection.py: bafybeienlxcgjs3ogyofli3d7q3p5rst3mcxxcnwqf7qolqjeefjtixeke
   dialogues.py: bafybeigpwuzku3we7axmxeamg7vn656maww6emuztau5pg3ebsoquyfdqm
   fsm_specification.yaml: bafybeib3oecxsixxzf3fsai5f7jlqpqqm23jcuvqn5fgp54shdj3temz2y

--- a/packages/valory/skills/trader_abci/skill.yaml
+++ b/packages/valory/skills/trader_abci/skill.yaml
@@ -35,8 +35,8 @@ skills:
 - valory/transaction_settlement_abci:0.1.0:bafybeic2ywzpwkyeqbzsvkbvurhsptemam4xtceihax2tmxmlxtgd3xpya
 - valory/termination_abci:0.1.0:bafybeibtbboau3q5fxfviwm7lbeix4z55uptfqqiyiu6siivxwkp3o5pju
 - valory/market_manager_abci:0.1.0:bafybeidblnaypi5fbci6zyk4ekngxq5zf2jiptssfhfiodzg7rilq24cz4
-- valory/decision_maker_abci:0.1.0:bafybeigwwk26gnxagplsn5opbefevntpzoyclnebl2gxetbil665zqiv64
-- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeicjjos5c2oc35rbknddzz563hk2axzwpimqeyk52t6g2glcuxmrwm
+- valory/decision_maker_abci:0.1.0:bafybeiequ53nozctyki67yv6o7px55rxhk6shuwdp4idxb4bnlturxs2ge
+- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeihcissp2uqahoo4zf3jeosvwvkw5tlqucby3zhs3a3z3pmzu44zxm
 - valory/staking_abci:0.1.0:bafybeifupwkfbxa4c4jogpudvzwt5rkgfuedgd65sj2bf2z5ver4phq64m
 - valory/check_stop_trading_abci:0.1.0:bafybeibtp73af35klgofghueuyrsasslndb7iuidm2p2pk4qmkq6qwt774
 - valory/mech_interact_abci:0.1.0:bafybeiedcaz6tmjg2irpntcco7ny2vwyqvffxl3mpji7qi6esdjr6qv3za

--- a/packages/valory/skills/tx_settlement_multiplexer_abci/skill.yaml
+++ b/packages/valory/skills/tx_settlement_multiplexer_abci/skill.yaml
@@ -23,7 +23,7 @@ protocols:
 - valory/ledger_api:1.0.0:bafybeihmqzcbj6t7vxz2aehd5726ofnzsfjs5cwlf42ro4tn6i34cbfrc4
 skills:
 - valory/abstract_round_abci:0.1.0:bafybeiey45kkbniukmtpdjduwazpyygaiayeo7mh3tu6wfbau2bxvuljmy
-- valory/decision_maker_abci:0.1.0:bafybeigwwk26gnxagplsn5opbefevntpzoyclnebl2gxetbil665zqiv64
+- valory/decision_maker_abci:0.1.0:bafybeiequ53nozctyki67yv6o7px55rxhk6shuwdp4idxb4bnlturxs2ge
 - valory/staking_abci:0.1.0:bafybeifupwkfbxa4c4jogpudvzwt5rkgfuedgd65sj2bf2z5ver4phq64m
 - valory/mech_interact_abci:0.1.0:bafybeiedcaz6tmjg2irpntcco7ny2vwyqvffxl3mpji7qi6esdjr6qv3za
 behaviours:


### PR DESCRIPTION
The mech marketplace does not support fetching the mech's hash from the registry.

A new contract will be deployed for the marketplace soon, in order to fetch mech's metadata given their service ids.

Until then, we hardcode a mech hash as a temporary quick and dirty fix.