### PR TITLE
chore: Add helper script to run agent more easily

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,6 @@ trader/
 /trader_service/
 /.coverage
 .dmypy.json
+logs/
+data/
+benchmarks/

--- a/Makefile
+++ b/Makefile
@@ -162,3 +162,13 @@ build-agent-runner-mac:
 	--codesign-identity "${SIGN_ID}" \
 	--name agent_runner_bin
 	./dist/agent_runner_bin 1>/dev/null
+
+
+.PHONY: run-agent
+run-agent:
+	mkdir -p ./logs && \
+	bash -c 'TIMESTAMP=$$(date +%d-%m-%y_%H-%M); \
+	LOG_FILE="./logs/agent_log_$$TIMESTAMP.log"; \
+	LATEST_LOG_FILE="./logs/agent_log_latest.log"; \
+	echo "Running agent and logging to $$LOG_FILE"; \
+	bash run_agent.sh 2>&1 | tee $$LOG_FILE $$LATEST_LOG_FILE'

--- a/run_agent.sh
+++ b/run_agent.sh
@@ -1,8 +1,52 @@
-rm -r trader
-find . -empty -type d -delete  # remove empty directories to avoid wrong hashes
+cleanup() {
+    echo "Terminating tendermint..."
+    if kill -0 "$tm_subprocess_pid" 2>/dev/null; then
+        kill "$tm_subprocess_pid"
+        wait "$tm_subprocess_pid" 2>/dev/null
+    fi
+    echo "Tendermint terminated"
+}
+
+# Link cleanup to the exit signal
+trap cleanup EXIT
+
+# Remove previous agent if exists
+if test -d trader; then
+  echo "Removing previous agent build"
+  sudo rm -r trader
+fi
+
+# Remove empty directories to avoid wrong hashes
+find . -empty -type d -delete
+make clean
+
+# Ensure that third party packages are correctly synced  # TODO: temporarily disabled until Open-Autonomy hashes fix
+# AUTONOMY_VERSION=v$(autonomy --version | grep -oP '(?<=version\s)\S+')
+# AEA_VERSION=v$(aea --version | grep -oP '(?<=version\s)\S+')
+# autonomy packages sync --source valory-xyz/open-aea:$AEA_VERSION --source valory-xyz/open-autonomy:$AUTONOMY_VERSION --update-packages
+
+# Ensure hashes are updated
 autonomy packages lock
-autonomy fetch --local --agent valory/trader && cd trader
+
+# Fetch the agent
+autonomy fetch --local --agent valory/trader
+
+# Replace params with env vars
+source .env
+python scripts/aea-config-replace.py
+
+# Copy and add the keys and issue certificates
+cd trader
 cp $PWD/../ethereum_private_key.txt .
 autonomy add-key ethereum ethereum_private_key.txt
 autonomy issue-certificates
+
+# Run tendermint
+rm -r ~/.tendermint
+tendermint init > /dev/null 2>&1
+echo "Starting Tendermint..."
+tendermint node --proxy_app=tcp://127.0.0.1:26658 --rpc.laddr=tcp://127.0.0.1:26657 --p2p.laddr=tcp://0.0.0.0:26656 --p2p.seeds= --consensus.create_empty_blocks=true > /dev/null 2>&1 &
+tm_subprocess_pid=$!
+
+# Run the agent
 aea -s run

--- a/scripts/aea-config-replace.py
+++ b/scripts/aea-config-replace.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# ------------------------------------------------------------------------------
+#
+#   Copyright 2021-2025 Valory AG
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ------------------------------------------------------------------------------
+
+
+"""Updates fetched agent with correct config"""
+import os
+import re
+from pathlib import Path
+
+import yaml
+from dotenv import load_dotenv
+
+
+AGENT_NAME = "trader"
+
+PATH_TO_VAR = {
+    # Chains
+    "config/ledger_apis/gnosis/address": "RPC_0",
+    # Params
+    "models/params/args/setup/all_participants": "ALL_PARTICIPANTS",
+    "models/params/args/setup/safe_contract_address": "SAFE_CONTRACT_ADDRESS",
+    "models/omen_subgraph/args/url": "OMEN_SUBGRAPH_URL",
+    "models/params/args/prompt_template": "PROMPT_TEMPLATE",
+    "models/params/args/store_path": "STORE_PATH",
+    "models/benchmark_tool/args/log_dir": "BENCHMARKS_DIR",
+    "models/params/args/strategies_kwargs": "STRATEGIES_KWARGS",
+    "config/genai_api_key": "GENAI_API_KEY",
+}
+
+CONFIG_REGEX = r"\${.*?:(.*)}"
+
+
+def find_and_replace(config, path, new_value):
+    """Find and replace a variable"""
+
+    # Find the correct section where this variable fits
+    section_indexes = []
+    for i, section in enumerate(config):
+        value = section
+        try:
+            for part in path:
+                value = value[part]
+            section_indexes.append(i)
+        except KeyError:
+            continue
+
+    if not section_indexes:
+        raise ValueError(f"Could not update {path}")
+
+    # To persist the changes in the config variable,
+    # access iterating the path parts but the last part
+    for section_index in section_indexes:
+        sub_dic = config[section_index]
+        for part in path[:-1]:
+            sub_dic = sub_dic[part]
+
+        # Now, get the whole string value
+        old_str_value = sub_dic[path[-1]]
+
+        # Extract the old variable value
+        match = re.match(CONFIG_REGEX, old_str_value)
+        old_var_value = match.groups()[0]
+
+        # Replace the old variable with the secret value in the complete string
+        new_str_value = old_str_value.replace(old_var_value, new_value)
+        sub_dic[path[-1]] = new_str_value
+
+    return config
+
+
+def main() -> None:
+    """Main"""
+    load_dotenv()
+
+    # Load the aea config
+    with open(Path(AGENT_NAME, "aea-config.yaml"), "r", encoding="utf-8") as file:
+        config = list(yaml.safe_load_all(file))
+
+    # Search and replace all the secrets
+    for path, var in PATH_TO_VAR.items():
+        try:
+            new_value = os.getenv(var)
+            if new_value is None:
+                print(f"Env var {var} is not set")
+                continue
+            config = find_and_replace(config, path.split("/"), new_value)
+        except Exception as e:
+            raise ValueError(f"Could not update {path}") from e
+
+    # Dump the updated config
+    with open(Path(AGENT_NAME, "aea-config.yaml"), "w", encoding="utf-8") as file:
+        yaml.dump_all(config, file, sort_keys=False)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Ported over from @dvilelaf's script in [meme-ooorr](https://github.com/dvilelaf/meme-ooorr)

No need to test out changes in vendor folder each time. Can edit actual packages directly
Stores logs for each run to seperate folder
Recreates local agent directory on each run with proper values picked from .env file
Runs tendermint process each time
use make run-agent to run the agent