### PR TITLE
Fix the path for obtaining the metadata

### DIFF
--- a/packages/packages.json
+++ b/packages/packages.json
@@ -16,14 +16,14 @@
         "contract/valory/relayer/0.1.0": "bafybeihypuljybkocl6iiacy52py7i5iqxdli3ily66q7b3nego4qajvne",
         "contract/valory/market_maker/0.1.0": "bafybeiepwclhyg7oo7wcffmben42wmwrxgb4ovoomw2zbjqljcy7b2neke",
         "skill/valory/market_manager_abci/0.1.0": "bafybeidblnaypi5fbci6zyk4ekngxq5zf2jiptssfhfiodzg7rilq24cz4",
-        "skill/valory/decision_maker_abci/0.1.0": "bafybeigkg5xgdyp6pngqw2jdqgaxuiwhaunnygvdp27b2hcnitpanhikha",
-        "skill/valory/trader_abci/0.1.0": "bafybeihn4jwmlosgcgo4z4ldhasiogllu7ccw54oirhfrwmlq3xbizyulq",
-        "skill/valory/tx_settlement_multiplexer_abci/0.1.0": "bafybeiehnn6bzszzilzfk6vzuvxq2g5cibkiafxzyzjxem7be4v7qrtxem",
+        "skill/valory/decision_maker_abci/0.1.0": "bafybeid36vyxqkje3hymlyqxjjdxkwqkc2nimn2njhz7qxm46lhtqmytyi",
+        "skill/valory/trader_abci/0.1.0": "bafybeifjevfpkkpiheomggdbagrjf2cablt36k7ge56zgxyxun3ddbtppq",
+        "skill/valory/tx_settlement_multiplexer_abci/0.1.0": "bafybeifiofckl77nnq6xbbf2v3lamsh5lgcxhhmgxje6m3nfegycbhj37m",
         "skill/valory/staking_abci/0.1.0": "bafybeifupwkfbxa4c4jogpudvzwt5rkgfuedgd65sj2bf2z5ver4phq64m",
         "skill/valory/check_stop_trading_abci/0.1.0": "bafybeie3f4o3ddygddyqqpeydguxvrcqvtcjaw5wjecngbjbrv5oizbzmu",
-        "agent/valory/trader/0.1.0": "bafybeib7l6f2jmvp5bpokj3dbk2fsmqsfjumln6kein37o3tmq5254mify",
-        "service/valory/trader/0.1.0": "bafybeihq54dbdhdgcbdrwdh2sxhiefdnoktqacskkb6downzqtnh3kcitu",
-        "service/valory/trader_pearl/0.1.0": "bafybeidiprm5pik5mkmmnyj7skxziqmjn6u2t77476rqostwep3lxp7dqq"
+        "agent/valory/trader/0.1.0": "bafybeicp7ve2jiy2n65nz3ounkehxl4w2zvhz4kztvzm3rl26r6746ctiu",
+        "service/valory/trader/0.1.0": "bafybeiakpk2lzxh7gceo6lliydnx52kdf5bzbl57rjegaxdusjjflu6g24",
+        "service/valory/trader_pearl/0.1.0": "bafybeidatmzo4m65sjdfha2aurz4mvsdxeu7coom2zcnfbnwpeyfsn4mza"
     },
     "third_party": {
         "protocol/valory/acn_data_share/0.1.0": "bafybeih5ydonnvrwvy2ygfqgfabkr47s4yw3uqxztmwyfprulwfsoe7ipq",

--- a/packages/valory/agents/trader/aea-config.yaml
+++ b/packages/valory/agents/trader/aea-config.yaml
@@ -53,10 +53,10 @@ skills:
 - valory/reset_pause_abci:0.1.0:bafybeiachgo6reit2q4jw75mefw2acj4ldedeqmn3rewjm4dbzts2l7oxe
 - valory/termination_abci:0.1.0:bafybeibtbboau3q5fxfviwm7lbeix4z55uptfqqiyiu6siivxwkp3o5pju
 - valory/transaction_settlement_abci:0.1.0:bafybeic2ywzpwkyeqbzsvkbvurhsptemam4xtceihax2tmxmlxtgd3xpya
-- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeiehnn6bzszzilzfk6vzuvxq2g5cibkiafxzyzjxem7be4v7qrtxem
+- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeifiofckl77nnq6xbbf2v3lamsh5lgcxhhmgxje6m3nfegycbhj37m
 - valory/market_manager_abci:0.1.0:bafybeidblnaypi5fbci6zyk4ekngxq5zf2jiptssfhfiodzg7rilq24cz4
-- valory/decision_maker_abci:0.1.0:bafybeigkg5xgdyp6pngqw2jdqgaxuiwhaunnygvdp27b2hcnitpanhikha
-- valory/trader_abci:0.1.0:bafybeihn4jwmlosgcgo4z4ldhasiogllu7ccw54oirhfrwmlq3xbizyulq
+- valory/decision_maker_abci:0.1.0:bafybeid36vyxqkje3hymlyqxjjdxkwqkc2nimn2njhz7qxm46lhtqmytyi
+- valory/trader_abci:0.1.0:bafybeifjevfpkkpiheomggdbagrjf2cablt36k7ge56zgxyxun3ddbtppq
 - valory/staking_abci:0.1.0:bafybeifupwkfbxa4c4jogpudvzwt5rkgfuedgd65sj2bf2z5ver4phq64m
 - valory/check_stop_trading_abci:0.1.0:bafybeie3f4o3ddygddyqqpeydguxvrcqvtcjaw5wjecngbjbrv5oizbzmu
 - valory/mech_interact_abci:0.1.0:bafybeigkizx3ecohtyshr6tq55zvp4sl5cou344a2t6nvwfgund4xnrj4a

--- a/packages/valory/services/trader/service.yaml
+++ b/packages/valory/services/trader/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeigtuothskwyvrhfosps2bu6suauycolj67dpuxqvnicdrdu7yhtvq
 fingerprint_ignore_patterns: []
-agent: valory/trader:0.1.0:bafybeib7l6f2jmvp5bpokj3dbk2fsmqsfjumln6kein37o3tmq5254mify
+agent: valory/trader:0.1.0:bafybeicp7ve2jiy2n65nz3ounkehxl4w2zvhz4kztvzm3rl26r6746ctiu
 number_of_agents: 4
 deployment:
   agent:

--- a/packages/valory/services/trader_pearl/service.yaml
+++ b/packages/valory/services/trader_pearl/service.yaml
@@ -8,7 +8,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeibg7bdqpioh4lmvknw3ygnllfku32oca4eq5pqtvdrdsgw6buko7e
 fingerprint_ignore_patterns: []
-agent: valory/trader:0.1.0:bafybeib7l6f2jmvp5bpokj3dbk2fsmqsfjumln6kein37o3tmq5254mify
+agent: valory/trader:0.1.0:bafybeicp7ve2jiy2n65nz3ounkehxl4w2zvhz4kztvzm3rl26r6746ctiu
 number_of_agents: 1
 deployment:
   agent:

--- a/packages/valory/skills/decision_maker_abci/behaviours/storage_manager.py
+++ b/packages/valory/skills/decision_maker_abci/behaviours/storage_manager.py
@@ -50,6 +50,7 @@ AVAILABLE_TOOLS_STORE = "available_tools_store.json"
 UTILIZED_TOOLS_STORE = "utilized_tools.json"
 GET = "GET"
 OK_CODE = 200
+NO_METADATA_HASH = "0" * 64
 
 
 class StorageManagerBehaviour(DecisionMakerBaseBehaviour, ABC):
@@ -270,8 +271,17 @@ class StorageManagerBehaviour(DecisionMakerBaseBehaviour, ABC):
         )
         return result
 
+    def _check_hash(self) -> None:
+        """Check the validity of the obtained mech hash."""
+        if self.mech_hash.endswith(NO_METADATA_HASH):
+            self.context.logger.error(
+                f"No metadata hash was found for the mech with address {self.params.mech_contract_address} "
+                f"and id {self.mech_id}!"
+            )
+
     def _get_mech_tools(self) -> WaitableConditionType:
         """Get the mech agent's tools from IPFS."""
+        self._check_hash()
         yield from self.set_mech_agent_specs()
         specs = self.mech_tools_api.get_spec()
         res_raw = yield from self.get_http_response(**specs)

--- a/packages/valory/skills/decision_maker_abci/behaviours/storage_manager.py
+++ b/packages/valory/skills/decision_maker_abci/behaviours/storage_manager.py
@@ -42,6 +42,7 @@ from packages.valory.skills.decision_maker_abci.policy import (
     AccuracyInfo,
     EGreedyPolicy,
 )
+from packages.valory.skills.decision_maker_abci.utils.general import suppress_logs
 
 
 POLICY_STORE = "policy_store_multi_bet_failure_adjusting.json"
@@ -130,11 +131,72 @@ class StorageManagerBehaviour(DecisionMakerBaseBehaviour, ABC):
             if self.utilized_tools is None:
                 self.utilized_tools = self._try_recover_utilized_tools()
 
-    def set_mech_agent_specs(self) -> None:
+    def detect_new_mm(self) -> WaitableConditionType:
+        """Detect whether the new mech marketplace is being used."""
+        # suppressing logs: contract method may not exist, but failure is expected during MM version detection
+        with suppress_logs():
+            # the `get_payment_type` is only available in mechs on the new marketplace
+            is_new_mm = yield from self._mech_mm_contract_interact(
+                contract_callable="get_payment_type",
+                data_key="payment_type",
+                placeholder="_",
+            )
+
+        if is_new_mm:
+            self.context.logger.info(
+                f"Mech with address {self.params.mech_contract_address} is on the latest mech marketplace."
+            )
+            self.shared_state.new_mm_detected = is_new_mm
+
+        return is_new_mm
+
+    def detect_legacy_mm(self) -> Generator:
+        """Detect whether the legacy mech marketplace is being used."""
+        # suppressing logs: contract method may not exist, but failure is expected during MM version detection
+        with suppress_logs():
+            # the `get_price` is only available in mechs on the legacy marketplace
+            is_legacy_mm = yield from self._mech_contract_interact(
+                contract_callable="get_price",
+                data_key="price",
+                placeholder="_",
+            )
+
+        if is_legacy_mm:
+            self.context.logger.info(
+                f"Mech with address {self.params.mech_contract_address} is on the legacy mech marketplace."
+            )
+            self.shared_state.new_mm_detected = False
+        else:
+            # we do not set the flag in the shared state in this case, so that the check is performed again next time
+            self.context.logger.error(
+                f"Could not verify the mech's version for address {self.params.mech_contract_address}! "
+                "Assuming legacy mech marketplace."
+            )
+
+    def detect_mm_version(self) -> WaitableConditionType:
+        """Detect the mech marketplace version in which the utilized mech belongs to."""
+        is_new_mm = yield from self.detect_new_mm()
+        if is_new_mm:
+            return True
+        yield from self.detect_legacy_mm()
+        return False
+
+    def using_new_mm(self) -> WaitableConditionType:
+        """Whether the new mech marketplace is being used."""
+        if self.shared_state.new_mm_detected is not None:
+            return self.shared_state.new_mm_detected
+
+        if not self.params.use_mech_marketplace:
+            self.shared_state.new_mm_detected = False
+            return False
+
+        return (yield from self.detect_mm_version())
+
+    def set_mech_agent_specs(self) -> Generator:
         """Set the mech's agent specs."""
         ipfs_link = (
             self.mech_hash
-            if self.params.use_mech_marketplace
+            if (yield from self.using_new_mm())
             else self.params.ipfs_address + CID_PREFIX + self.mech_hash
         )
 
@@ -210,7 +272,7 @@ class StorageManagerBehaviour(DecisionMakerBaseBehaviour, ABC):
 
     def _get_mech_tools(self) -> WaitableConditionType:
         """Get the mech agent's tools from IPFS."""
-        self.set_mech_agent_specs()
+        yield from self.set_mech_agent_specs()
         specs = self.mech_tools_api.get_spec()
         res_raw = yield from self.get_http_response(**specs)
         res = self.mech_tools_api.process_response(res_raw)
@@ -255,7 +317,7 @@ class StorageManagerBehaviour(DecisionMakerBaseBehaviour, ABC):
                 self._get_mech_service_id,
                 self._get_metadata_uri,
             )
-            if self.params.use_mech_marketplace
+            if (yield from self.using_new_mm())
             else (
                 self._get_mech_id,
                 self._get_mech_hash,

--- a/packages/valory/skills/decision_maker_abci/models.py
+++ b/packages/valory/skills/decision_maker_abci/models.py
@@ -210,13 +210,13 @@ class SharedState(BaseSharedState):
         self.liquidity_prices: Dict[str, List[float]] = {}
         # whether this is the last run of the benchmarking mode
         self.last_benchmarking_has_run: bool = False
-
         # the mapping from bet id to the row number in the dataset
         # the key is the market id/question_id
         self.bet_id_row_manager: Dict[str, List[int]] = {}
-
         # mech call counter for benchmarking behaviour
         self.benchmarking_mech_calls: int = 0
+        # whether the code has detected the new mech marketplace being used
+        self.new_mm_detected: Optional[bool] = None
 
     @property
     def mock_question_id(self) -> Any:

--- a/packages/valory/skills/decision_maker_abci/skill.yaml
+++ b/packages/valory/skills/decision_maker_abci/skill.yaml
@@ -25,14 +25,14 @@ fingerprint:
   behaviours/reedem.py: bafybeiajxsz34iy24muw4avq4vbevluhsabjcyqaadssnrs2zrfdapbnqq
   behaviours/round_behaviour.py: bafybeih63hpia2bwwzu563hxs5yd3t5ycvxvkfnhvxbzghbyy3mw3xjl3i
   behaviours/sampling.py: bafybeiet37e4o4s5kdf4u4denls7iaqm6b2a2mqa5eu576waiwmuwozhmi
-  behaviours/storage_manager.py: bafybeif3lyu3sbzeu3ouv3ed667uvoqmknk6jxs4adic6onhvd6ngzm3ry
+  behaviours/storage_manager.py: bafybeidmcwsyfz6s3cf2wvnjrls2pbizbixrvn2tkfxdcqknec27syjvau
   behaviours/tool_selection.py: bafybeienlxcgjs3ogyofli3d7q3p5rst3mcxxcnwqf7qolqjeefjtixeke
   dialogues.py: bafybeigpwuzku3we7axmxeamg7vn656maww6emuztau5pg3ebsoquyfdqm
   fsm_specification.yaml: bafybeib3oecxsixxzf3fsai5f7jlqpqqm23jcuvqn5fgp54shdj3temz2y
   handlers.py: bafybeiherm5a2kjmf46ffjoyvhh3tsja5au5i677oasiutdxdojwdtwqla
   io_/__init__.py: bafybeifxgmmwjqzezzn3e6keh2bfo4cyo7y5dq2ept3stfmgglbrzfl5rq
   io_/loader.py: bafybeih3sdsx5dhe4kzhtoafexjgkutsujwqy3zcdrlrkhtdks45bc7exa
-  models.py: bafybeibpvd37pnswgqjpuio2l7j7rij44cz5yoyiojjt7cx6nvuetlfkg4
+  models.py: bafybeidhqp4d5cwhchqgghwivzsunp75k4b64fik4c4nzy6yqeotagvlga
   payloads.py: bafybeieygushjlrzwzpnhagjgpbs3goot3pnfheh6yawuwctrk3uoeesfm
   policy.py: bafybeigmstzp26no6lg2hcsusaybpdidzqgek4wc6hzay4zg4ybjjbij44
   redeem_info.py: bafybeifiiix4gihfo4avraxt34sfw35v6dqq45do2drrssei2shbps63mm
@@ -79,6 +79,7 @@ fingerprint:
   tests/test_payloads.py: bafybeiggbcppj4j54r23qvg423elsnd7dcxl3sfo534ek5sd3g65ua57nq
   tests/test_rounds.py: bafybeigifftusd4ew42tyvyrr55o2uehhcik2gdq3atkpjwwlqdeskedty
   utils/__init__.py: bafybeiazrfg3kwfdl5q45azwz6b6mobqxngxpf4hazmrnkhinpk4qhbbf4
+  utils/general.py: bafybeidklil35bhvew7556zv3rohbruwkxe7d7n2qnbrohunfalw2okigm
   utils/nevermined.py: bafybeigallaqxhqopznhjhefr6bukh4ojkz5vdtqyzod5dksshrf24fjgi
   utils/scaling.py: bafybeialr3z4zogp4k3l2bzcjfi4igvxzjexmlpgze2bai2ufc3plaow4y
 fingerprint_ignore_patterns: []

--- a/packages/valory/skills/decision_maker_abci/utils/general.py
+++ b/packages/valory/skills/decision_maker_abci/utils/general.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+# ------------------------------------------------------------------------------
+#
+#   Copyright 2025 Valory AG
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ------------------------------------------------------------------------------
+
+"""This module contains general utils for the decision maker skill."""
+
+
+import logging
+from contextlib import contextmanager
+from typing import Generator
+
+
+@contextmanager
+def suppress_logs(level: int = logging.CRITICAL) -> Generator:
+    """Context manager to suppress the logs for a specific code block."""
+    previous_level = logging.root.manager.disable
+    logging.disable(level)
+    try:
+        yield
+    finally:
+        logging.disable(previous_level)

--- a/packages/valory/skills/trader_abci/skill.yaml
+++ b/packages/valory/skills/trader_abci/skill.yaml
@@ -36,8 +36,8 @@ skills:
 - valory/transaction_settlement_abci:0.1.0:bafybeic2ywzpwkyeqbzsvkbvurhsptemam4xtceihax2tmxmlxtgd3xpya
 - valory/termination_abci:0.1.0:bafybeibtbboau3q5fxfviwm7lbeix4z55uptfqqiyiu6siivxwkp3o5pju
 - valory/market_manager_abci:0.1.0:bafybeidblnaypi5fbci6zyk4ekngxq5zf2jiptssfhfiodzg7rilq24cz4
-- valory/decision_maker_abci:0.1.0:bafybeigkg5xgdyp6pngqw2jdqgaxuiwhaunnygvdp27b2hcnitpanhikha
-- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeiehnn6bzszzilzfk6vzuvxq2g5cibkiafxzyzjxem7be4v7qrtxem
+- valory/decision_maker_abci:0.1.0:bafybeid36vyxqkje3hymlyqxjjdxkwqkc2nimn2njhz7qxm46lhtqmytyi
+- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeifiofckl77nnq6xbbf2v3lamsh5lgcxhhmgxje6m3nfegycbhj37m
 - valory/staking_abci:0.1.0:bafybeifupwkfbxa4c4jogpudvzwt5rkgfuedgd65sj2bf2z5ver4phq64m
 - valory/check_stop_trading_abci:0.1.0:bafybeie3f4o3ddygddyqqpeydguxvrcqvtcjaw5wjecngbjbrv5oizbzmu
 - valory/mech_interact_abci:0.1.0:bafybeigkizx3ecohtyshr6tq55zvp4sl5cou344a2t6nvwfgund4xnrj4a

--- a/packages/valory/skills/tx_settlement_multiplexer_abci/skill.yaml
+++ b/packages/valory/skills/tx_settlement_multiplexer_abci/skill.yaml
@@ -23,7 +23,7 @@ protocols:
 - valory/ledger_api:1.0.0:bafybeihmqzcbj6t7vxz2aehd5726ofnzsfjs5cwlf42ro4tn6i34cbfrc4
 skills:
 - valory/abstract_round_abci:0.1.0:bafybeiey45kkbniukmtpdjduwazpyygaiayeo7mh3tu6wfbau2bxvuljmy
-- valory/decision_maker_abci:0.1.0:bafybeigkg5xgdyp6pngqw2jdqgaxuiwhaunnygvdp27b2hcnitpanhikha
+- valory/decision_maker_abci:0.1.0:bafybeid36vyxqkje3hymlyqxjjdxkwqkc2nimn2njhz7qxm46lhtqmytyi
 - valory/staking_abci:0.1.0:bafybeifupwkfbxa4c4jogpudvzwt5rkgfuedgd65sj2bf2z5ver4phq64m
 - valory/mech_interact_abci:0.1.0:bafybeigkizx3ecohtyshr6tq55zvp4sl5cou344a2t6nvwfgund4xnrj4a
 behaviours:


### PR DESCRIPTION
Previously, if the old mech marketplace was used, the trader would follow the path for the new mech marketplace.

This PR introduces a detection mechanism for the marketplace version (legacy vs new) on the trader, so that it follows the corresponding path.

Moreover, a new error is logged when no metadata have been obtained.