### PR TITLE
restoring requests volume factor to 0.5

### DIFF
--- a/packages/packages.json
+++ b/packages/packages.json
@@ -16,14 +16,14 @@
         "contract/valory/relayer/0.1.0": "bafybeihypuljybkocl6iiacy52py7i5iqxdli3ily66q7b3nego4qajvne",
         "contract/valory/market_maker/0.1.0": "bafybeiepwclhyg7oo7wcffmben42wmwrxgb4ovoomw2zbjqljcy7b2neke",
         "skill/valory/market_manager_abci/0.1.0": "bafybeidblnaypi5fbci6zyk4ekngxq5zf2jiptssfhfiodzg7rilq24cz4",
-        "skill/valory/decision_maker_abci/0.1.0": "bafybeid36vyxqkje3hymlyqxjjdxkwqkc2nimn2njhz7qxm46lhtqmytyi",
-        "skill/valory/trader_abci/0.1.0": "bafybeifjevfpkkpiheomggdbagrjf2cablt36k7ge56zgxyxun3ddbtppq",
-        "skill/valory/tx_settlement_multiplexer_abci/0.1.0": "bafybeifiofckl77nnq6xbbf2v3lamsh5lgcxhhmgxje6m3nfegycbhj37m",
+        "skill/valory/decision_maker_abci/0.1.0": "bafybeicjh467vijequkgwyfdczlhnwgkmt22mabtvrq6mx2qf64wuexbp4",
+        "skill/valory/trader_abci/0.1.0": "bafybeiargf524fpbswjz7rrae5un7knw5gsrdr3ylr5dibt7mewbmikfne",
+        "skill/valory/tx_settlement_multiplexer_abci/0.1.0": "bafybeib6bxr6gcajzazadjydxteucfs6ttpbr762kk74m5b3cgf2azza4y",
         "skill/valory/staking_abci/0.1.0": "bafybeifupwkfbxa4c4jogpudvzwt5rkgfuedgd65sj2bf2z5ver4phq64m",
         "skill/valory/check_stop_trading_abci/0.1.0": "bafybeie3f4o3ddygddyqqpeydguxvrcqvtcjaw5wjecngbjbrv5oizbzmu",
-        "agent/valory/trader/0.1.0": "bafybeicp7ve2jiy2n65nz3ounkehxl4w2zvhz4kztvzm3rl26r6746ctiu",
-        "service/valory/trader/0.1.0": "bafybeiakpk2lzxh7gceo6lliydnx52kdf5bzbl57rjegaxdusjjflu6g24",
-        "service/valory/trader_pearl/0.1.0": "bafybeidatmzo4m65sjdfha2aurz4mvsdxeu7coom2zcnfbnwpeyfsn4mza"
+        "agent/valory/trader/0.1.0": "bafybeihv46bwa7vafsbuuxcbpkrbxrdwrri2fa6cfy2yjro7qflxfabb5q",
+        "service/valory/trader/0.1.0": "bafybeifjaj3ssc3tnhdtwa53tdajlm5cside7peefwxb23usc7rsjnodxi",
+        "service/valory/trader_pearl/0.1.0": "bafybeiamg6slnchuqxg6errjfgh5ivhngntckxwl5elng5kgsnwjvlqsmm"
     },
     "third_party": {
         "protocol/valory/acn_data_share/0.1.0": "bafybeih5ydonnvrwvy2ygfqgfabkr47s4yw3uqxztmwyfprulwfsoe7ipq",

--- a/packages/valory/agents/trader/aea-config.yaml
+++ b/packages/valory/agents/trader/aea-config.yaml
@@ -53,10 +53,10 @@ skills:
 - valory/reset_pause_abci:0.1.0:bafybeiachgo6reit2q4jw75mefw2acj4ldedeqmn3rewjm4dbzts2l7oxe
 - valory/termination_abci:0.1.0:bafybeibtbboau3q5fxfviwm7lbeix4z55uptfqqiyiu6siivxwkp3o5pju
 - valory/transaction_settlement_abci:0.1.0:bafybeic2ywzpwkyeqbzsvkbvurhsptemam4xtceihax2tmxmlxtgd3xpya
-- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeifiofckl77nnq6xbbf2v3lamsh5lgcxhhmgxje6m3nfegycbhj37m
+- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeib6bxr6gcajzazadjydxteucfs6ttpbr762kk74m5b3cgf2azza4y
 - valory/market_manager_abci:0.1.0:bafybeidblnaypi5fbci6zyk4ekngxq5zf2jiptssfhfiodzg7rilq24cz4
-- valory/decision_maker_abci:0.1.0:bafybeid36vyxqkje3hymlyqxjjdxkwqkc2nimn2njhz7qxm46lhtqmytyi
-- valory/trader_abci:0.1.0:bafybeifjevfpkkpiheomggdbagrjf2cablt36k7ge56zgxyxun3ddbtppq
+- valory/decision_maker_abci:0.1.0:bafybeicjh467vijequkgwyfdczlhnwgkmt22mabtvrq6mx2qf64wuexbp4
+- valory/trader_abci:0.1.0:bafybeiargf524fpbswjz7rrae5un7knw5gsrdr3ylr5dibt7mewbmikfne
 - valory/staking_abci:0.1.0:bafybeifupwkfbxa4c4jogpudvzwt5rkgfuedgd65sj2bf2z5ver4phq64m
 - valory/check_stop_trading_abci:0.1.0:bafybeie3f4o3ddygddyqqpeydguxvrcqvtcjaw5wjecngbjbrv5oizbzmu
 - valory/mech_interact_abci:0.1.0:bafybeigkizx3ecohtyshr6tq55zvp4sl5cou344a2t6nvwfgund4xnrj4a

--- a/packages/valory/services/trader/service.yaml
+++ b/packages/valory/services/trader/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeigtuothskwyvrhfosps2bu6suauycolj67dpuxqvnicdrdu7yhtvq
 fingerprint_ignore_patterns: []
-agent: valory/trader:0.1.0:bafybeicp7ve2jiy2n65nz3ounkehxl4w2zvhz4kztvzm3rl26r6746ctiu
+agent: valory/trader:0.1.0:bafybeihv46bwa7vafsbuuxcbpkrbxrdwrri2fa6cfy2yjro7qflxfabb5q
 number_of_agents: 4
 deployment:
   agent:

--- a/packages/valory/services/trader_pearl/service.yaml
+++ b/packages/valory/services/trader_pearl/service.yaml
@@ -8,7 +8,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeibg7bdqpioh4lmvknw3ygnllfku32oca4eq5pqtvdrdsgw6buko7e
 fingerprint_ignore_patterns: []
-agent: valory/trader:0.1.0:bafybeicp7ve2jiy2n65nz3ounkehxl4w2zvhz4kztvzm3rl26r6746ctiu
+agent: valory/trader:0.1.0:bafybeihv46bwa7vafsbuuxcbpkrbxrdwrri2fa6cfy2yjro7qflxfabb5q
 number_of_agents: 1
 deployment:
   agent:

--- a/packages/valory/skills/decision_maker_abci/policy.py
+++ b/packages/valory/skills/decision_maker_abci/policy.py
@@ -30,7 +30,7 @@ from packages.valory.skills.decision_maker_abci.utils.scaling import scale_value
 
 RandomnessType = Union[int, float, str, bytes, bytearray, None]
 
-VOLUME_FACTOR_REGULARIZATION = 0.25
+VOLUME_FACTOR_REGULARIZATION = 0.5
 UNSCALED_WEIGHTED_ACCURACY_INTERVAL = (-0.5, 80.5)
 SCALED_WEIGHTED_ACCURACY_INTERVAL = (0, 1)
 

--- a/packages/valory/skills/decision_maker_abci/skill.yaml
+++ b/packages/valory/skills/decision_maker_abci/skill.yaml
@@ -34,7 +34,7 @@ fingerprint:
   io_/loader.py: bafybeih3sdsx5dhe4kzhtoafexjgkutsujwqy3zcdrlrkhtdks45bc7exa
   models.py: bafybeidhqp4d5cwhchqgghwivzsunp75k4b64fik4c4nzy6yqeotagvlga
   payloads.py: bafybeieygushjlrzwzpnhagjgpbs3goot3pnfheh6yawuwctrk3uoeesfm
-  policy.py: bafybeigmstzp26no6lg2hcsusaybpdidzqgek4wc6hzay4zg4ybjjbij44
+  policy.py: bafybeibng3hqgflax7o5onpq6b5nbzekht2hnzpujsjymya5a5wwjofu3u
   redeem_info.py: bafybeifiiix4gihfo4avraxt34sfw35v6dqq45do2drrssei2shbps63mm
   rounds.py: bafybeiedbmmy7jnqvtcdfnd222yyr3r4d7m7bhhwccla4nsqautmavwgrq
   rounds_info.py: bafybeihg6i3h7a7ahfxzhow7gcuszcilq5krfpchze2szjdu7dtem2tnwa

--- a/packages/valory/skills/trader_abci/skill.yaml
+++ b/packages/valory/skills/trader_abci/skill.yaml
@@ -36,8 +36,8 @@ skills:
 - valory/transaction_settlement_abci:0.1.0:bafybeic2ywzpwkyeqbzsvkbvurhsptemam4xtceihax2tmxmlxtgd3xpya
 - valory/termination_abci:0.1.0:bafybeibtbboau3q5fxfviwm7lbeix4z55uptfqqiyiu6siivxwkp3o5pju
 - valory/market_manager_abci:0.1.0:bafybeidblnaypi5fbci6zyk4ekngxq5zf2jiptssfhfiodzg7rilq24cz4
-- valory/decision_maker_abci:0.1.0:bafybeid36vyxqkje3hymlyqxjjdxkwqkc2nimn2njhz7qxm46lhtqmytyi
-- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeifiofckl77nnq6xbbf2v3lamsh5lgcxhhmgxje6m3nfegycbhj37m
+- valory/decision_maker_abci:0.1.0:bafybeicjh467vijequkgwyfdczlhnwgkmt22mabtvrq6mx2qf64wuexbp4
+- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeib6bxr6gcajzazadjydxteucfs6ttpbr762kk74m5b3cgf2azza4y
 - valory/staking_abci:0.1.0:bafybeifupwkfbxa4c4jogpudvzwt5rkgfuedgd65sj2bf2z5ver4phq64m
 - valory/check_stop_trading_abci:0.1.0:bafybeie3f4o3ddygddyqqpeydguxvrcqvtcjaw5wjecngbjbrv5oizbzmu
 - valory/mech_interact_abci:0.1.0:bafybeigkizx3ecohtyshr6tq55zvp4sl5cou344a2t6nvwfgund4xnrj4a

--- a/packages/valory/skills/tx_settlement_multiplexer_abci/skill.yaml
+++ b/packages/valory/skills/tx_settlement_multiplexer_abci/skill.yaml
@@ -23,7 +23,7 @@ protocols:
 - valory/ledger_api:1.0.0:bafybeihmqzcbj6t7vxz2aehd5726ofnzsfjs5cwlf42ro4tn6i34cbfrc4
 skills:
 - valory/abstract_round_abci:0.1.0:bafybeiey45kkbniukmtpdjduwazpyygaiayeo7mh3tu6wfbau2bxvuljmy
-- valory/decision_maker_abci:0.1.0:bafybeid36vyxqkje3hymlyqxjjdxkwqkc2nimn2njhz7qxm46lhtqmytyi
+- valory/decision_maker_abci:0.1.0:bafybeicjh467vijequkgwyfdczlhnwgkmt22mabtvrq6mx2qf64wuexbp4
 - valory/staking_abci:0.1.0:bafybeifupwkfbxa4c4jogpudvzwt5rkgfuedgd65sj2bf2z5ver4phq64m
 - valory/mech_interact_abci:0.1.0:bafybeigkizx3ecohtyshr6tq55zvp4sl5cou344a2t6nvwfgund4xnrj4a
 behaviours:


### PR DESCRIPTION
The change introduced here [here](https://github.com/valory-xyz/trader/commit/cc8e3cb6dec75f3e956d8256993581199c4636d1)

is reducing too much the weight of the volume of requests done by a tool, therefore considering accuracy raw values the same for a tool with low volume of requests vs one with a high volume of requests. 