### PR TITLE
Fix multi-bets issue

### DIFF
--- a/packages/packages.json
+++ b/packages/packages.json
@@ -15,15 +15,15 @@
         "contract/valory/staking_token/0.1.0": "bafybeigzerw3sxvrd4y6g4b5j6duqbjvxmqvarf2m5xovjsthhxyogpypm",
         "contract/valory/relayer/0.1.0": "bafybeihypuljybkocl6iiacy52py7i5iqxdli3ily66q7b3nego4qajvne",
         "contract/valory/market_maker/0.1.0": "bafybeiepwclhyg7oo7wcffmben42wmwrxgb4ovoomw2zbjqljcy7b2neke",
-        "skill/valory/market_manager_abci/0.1.0": "bafybeidblnaypi5fbci6zyk4ekngxq5zf2jiptssfhfiodzg7rilq24cz4",
-        "skill/valory/decision_maker_abci/0.1.0": "bafybeiebyilooxucaqjl3b3syjlov2jpu2wwrdtzdwjgnggwujiww4eac4",
-        "skill/valory/trader_abci/0.1.0": "bafybeibm7lk3jvuuzq42rspwxfssa7dsturnbs3iophti7gtdfvsvmph3q",
-        "skill/valory/tx_settlement_multiplexer_abci/0.1.0": "bafybeictifd2d4ptjshuzsr7hwdw66ssaaowteubnkapyhbgphwrqcuewy",
+        "skill/valory/market_manager_abci/0.1.0": "bafybeihievdcieyf5lad7iamrgkuahxlcjyuqc4kzomi4chcy2pap47ehu",
+        "skill/valory/decision_maker_abci/0.1.0": "bafybeibgg5rkzsb66ptusxuy3wuqellt5lummg52evwkbszsumwbxlqx6y",
+        "skill/valory/trader_abci/0.1.0": "bafybeih4qvtk7rvugs7p2s6sqlpvzddjyy3g4dz6jkkoryw2eu7hx4nsju",
+        "skill/valory/tx_settlement_multiplexer_abci/0.1.0": "bafybeiescma4y3lw6bpxx7eybijmrxycvtpb6fi4npmijam6nlvfte64s4",
         "skill/valory/staking_abci/0.1.0": "bafybeifupwkfbxa4c4jogpudvzwt5rkgfuedgd65sj2bf2z5ver4phq64m",
         "skill/valory/check_stop_trading_abci/0.1.0": "bafybeie6mavlrdy6o6cpgz2lecvla22rywsjq3qjblvw56lubwa3ph44ui",
-        "agent/valory/trader/0.1.0": "bafybeibgwmpy2qsuy3sxiklvrhcaovsbr7ca6ibouqxfyri2yxdzjyu33e",
-        "service/valory/trader/0.1.0": "bafybeiemnzgcz5ezu7a3o5wif5gavj6gytinjtsibm5f35ftznl6vhkr4i",
-        "service/valory/trader_pearl/0.1.0": "bafybeihx6hwq67kz5axncqyfhep7n4a2hodl54dlv22egwtk4e3s7nrz5a"
+        "agent/valory/trader/0.1.0": "bafybeiag65ojpf3wu7jhkfh2q337mkq6i4qttq6cbu446sapbcjkdkofom",
+        "service/valory/trader/0.1.0": "bafybeihpjnpnndh2hyq6g5plgbw7izh54yc4qocunqz5kvvlquit5yuv4a",
+        "service/valory/trader_pearl/0.1.0": "bafybeidx6rhgf3u5w6msow6ekh2gjxxti6ox5t2qbnbn2fwub6fa37jnlm"
     },
     "third_party": {
         "protocol/valory/acn_data_share/0.1.0": "bafybeih5ydonnvrwvy2ygfqgfabkr47s4yw3uqxztmwyfprulwfsoe7ipq",

--- a/packages/valory/agents/trader/aea-config.yaml
+++ b/packages/valory/agents/trader/aea-config.yaml
@@ -52,10 +52,10 @@ skills:
 - valory/reset_pause_abci:0.1.0:bafybeiachgo6reit2q4jw75mefw2acj4ldedeqmn3rewjm4dbzts2l7oxe
 - valory/termination_abci:0.1.0:bafybeibtbboau3q5fxfviwm7lbeix4z55uptfqqiyiu6siivxwkp3o5pju
 - valory/transaction_settlement_abci:0.1.0:bafybeic2ywzpwkyeqbzsvkbvurhsptemam4xtceihax2tmxmlxtgd3xpya
-- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeictifd2d4ptjshuzsr7hwdw66ssaaowteubnkapyhbgphwrqcuewy
-- valory/market_manager_abci:0.1.0:bafybeidblnaypi5fbci6zyk4ekngxq5zf2jiptssfhfiodzg7rilq24cz4
-- valory/decision_maker_abci:0.1.0:bafybeiebyilooxucaqjl3b3syjlov2jpu2wwrdtzdwjgnggwujiww4eac4
-- valory/trader_abci:0.1.0:bafybeibm7lk3jvuuzq42rspwxfssa7dsturnbs3iophti7gtdfvsvmph3q
+- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeiescma4y3lw6bpxx7eybijmrxycvtpb6fi4npmijam6nlvfte64s4
+- valory/market_manager_abci:0.1.0:bafybeihievdcieyf5lad7iamrgkuahxlcjyuqc4kzomi4chcy2pap47ehu
+- valory/decision_maker_abci:0.1.0:bafybeibgg5rkzsb66ptusxuy3wuqellt5lummg52evwkbszsumwbxlqx6y
+- valory/trader_abci:0.1.0:bafybeih4qvtk7rvugs7p2s6sqlpvzddjyy3g4dz6jkkoryw2eu7hx4nsju
 - valory/staking_abci:0.1.0:bafybeifupwkfbxa4c4jogpudvzwt5rkgfuedgd65sj2bf2z5ver4phq64m
 - valory/check_stop_trading_abci:0.1.0:bafybeie6mavlrdy6o6cpgz2lecvla22rywsjq3qjblvw56lubwa3ph44ui
 - valory/mech_interact_abci:0.1.0:bafybeiedcaz6tmjg2irpntcco7ny2vwyqvffxl3mpji7qi6esdjr6qv3za

--- a/packages/valory/services/trader/service.yaml
+++ b/packages/valory/services/trader/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeigtuothskwyvrhfosps2bu6suauycolj67dpuxqvnicdrdu7yhtvq
 fingerprint_ignore_patterns: []
-agent: valory/trader:0.1.0:bafybeibgwmpy2qsuy3sxiklvrhcaovsbr7ca6ibouqxfyri2yxdzjyu33e
+agent: valory/trader:0.1.0:bafybeiag65ojpf3wu7jhkfh2q337mkq6i4qttq6cbu446sapbcjkdkofom
 number_of_agents: 4
 deployment:
   agent:

--- a/packages/valory/services/trader_pearl/service.yaml
+++ b/packages/valory/services/trader_pearl/service.yaml
@@ -8,7 +8,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeibg7bdqpioh4lmvknw3ygnllfku32oca4eq5pqtvdrdsgw6buko7e
 fingerprint_ignore_patterns: []
-agent: valory/trader:0.1.0:bafybeibgwmpy2qsuy3sxiklvrhcaovsbr7ca6ibouqxfyri2yxdzjyu33e
+agent: valory/trader:0.1.0:bafybeiag65ojpf3wu7jhkfh2q337mkq6i4qttq6cbu446sapbcjkdkofom
 number_of_agents: 1
 deployment:
   agent:

--- a/packages/valory/skills/decision_maker_abci/behaviours/sampling.py
+++ b/packages/valory/skills/decision_maker_abci/behaviours/sampling.py
@@ -65,6 +65,8 @@ class SamplingBehaviour(DecisionMakerBaseBehaviour):
             - self.params.opening_margin
             - self.params.safe_voting_range
         )
+        if not within_safe_range:
+            bet.blacklist_forever()
 
         within_ranges = within_opening_range and within_safe_range
 

--- a/packages/valory/skills/decision_maker_abci/skill.yaml
+++ b/packages/valory/skills/decision_maker_abci/skill.yaml
@@ -24,7 +24,7 @@ fingerprint:
   behaviours/randomness.py: bafybeiaoj3awyyg2onhpsdsn3dyczs23gr4smuzqcbw3e5ocljwxswjkce
   behaviours/reedem.py: bafybeibg5daqyov2mzfhoirzft6lkar5bflcza6aekovtcl3vy23d2zrmu
   behaviours/round_behaviour.py: bafybeih63hpia2bwwzu563hxs5yd3t5ycvxvkfnhvxbzghbyy3mw3xjl3i
-  behaviours/sampling.py: bafybeigyepi5uyen5vrh33sg5n4wy6stklusly6f364hnle6qwhan6jmvq
+  behaviours/sampling.py: bafybeiewpy4p3qr6q3hyr6dbnmgxycbmn7vl4kspxjgcufmbr5sqqd43ki
   behaviours/storage_manager.py: bafybeiginbllxqnupheqczdpvuwbug7he7sivs4tebjq3eaehyh3ns4vpi
   behaviours/tool_selection.py: bafybeienlxcgjs3ogyofli3d7q3p5rst3mcxxcnwqf7qolqjeefjtixeke
   dialogues.py: bafybeigpwuzku3we7axmxeamg7vn656maww6emuztau5pg3ebsoquyfdqm
@@ -102,7 +102,7 @@ protocols:
 - valory/http:1.0.0:bafybeih4azmfwtamdbkhztkm4xitep3gx6tfdnoz6tvllmaqnhu3klejfa
 skills:
 - valory/abstract_round_abci:0.1.0:bafybeiey45kkbniukmtpdjduwazpyygaiayeo7mh3tu6wfbau2bxvuljmy
-- valory/market_manager_abci:0.1.0:bafybeidblnaypi5fbci6zyk4ekngxq5zf2jiptssfhfiodzg7rilq24cz4
+- valory/market_manager_abci:0.1.0:bafybeihievdcieyf5lad7iamrgkuahxlcjyuqc4kzomi4chcy2pap47ehu
 - valory/transaction_settlement_abci:0.1.0:bafybeic2ywzpwkyeqbzsvkbvurhsptemam4xtceihax2tmxmlxtgd3xpya
 - valory/mech_interact_abci:0.1.0:bafybeiedcaz6tmjg2irpntcco7ny2vwyqvffxl3mpji7qi6esdjr6qv3za
 - valory/staking_abci:0.1.0:bafybeifupwkfbxa4c4jogpudvzwt5rkgfuedgd65sj2bf2z5ver4phq64m

--- a/packages/valory/skills/market_manager_abci/behaviours.py
+++ b/packages/valory/skills/market_manager_abci/behaviours.py
@@ -98,29 +98,30 @@ class BetsManagerBehaviour(BaseBehaviour, ABC):
     def read_bets(self) -> None:
         """Read the bets from the agent's data dir as JSON."""
         self.bets = []
-        _read_path = self.multi_bets_filepath
+        read_path = self.multi_bets_filepath
 
-        if not os.path.isfile(_read_path):
+        if not os.path.isfile(read_path):
             self.context.logger.warning(
-                f"No stored bets file was detected in {_read_path}. Assuming trader is being run for the first time in multi-bets mode."
+                f"No stored bets file was detected in {read_path}. "
+                "Assuming trader is being run for the first time in multi-bets mode."
             )
-            _read_path = self.bets_filepath
+            read_path = self.bets_filepath
 
-        if not os.path.isfile(_read_path):
+        if not os.path.isfile(read_path):
             self.context.logger.warning(
-                f"No stored bets file was detected in {_read_path}. Assuming bets are empty"
+                f"No stored bets file was detected in {read_path}. Assuming bets are empty"
             )
             return
 
         try:
-            with open(_read_path, READ_MODE) as bets_file:
+            with open(read_path, READ_MODE) as bets_file:
                 try:
                     self.bets = json.load(bets_file, cls=BetsDecoder)
                     return
                 except (JSONDecodeError, TypeError):
-                    err = f"Error decoding file {_read_path!r} to a list of bets!"
+                    err = f"Error decoding file {read_path!r} to a list of bets!"
         except (FileNotFoundError, PermissionError, OSError):
-            err = f"Error opening file {_read_path!r} in read mode!"
+            err = f"Error opening file {read_path!r} in read mode!"
 
         self.context.logger.error(err)
 

--- a/packages/valory/skills/market_manager_abci/behaviours.py
+++ b/packages/valory/skills/market_manager_abci/behaviours.py
@@ -109,7 +109,7 @@ class BetsManagerBehaviour(BaseBehaviour, ABC):
 
         if not os.path.isfile(read_path):
             self.context.logger.warning(
-                f"No stored bets file was detected in {read_path}. Assuming bets are empty"
+                f"No stored bets file was detected in {read_path}. Assuming bets are empty."
             )
             return
 

--- a/packages/valory/skills/market_manager_abci/behaviours.py
+++ b/packages/valory/skills/market_manager_abci/behaviours.py
@@ -98,18 +98,6 @@ class BetsManagerBehaviour(BaseBehaviour, ABC):
     def read_bets(self) -> None:
         """Read the bets from the agent's data dir as JSON."""
         self.bets = []
-
-        if not self.benchmarking_mode.enabled and self.shared_state.first_read:
-            # this is a temporary hack to overcome a multi-bets issue
-            # if a bet that is in the `TO_PROCESS` queue cannot be selected because of the constraints
-            # (e.g., not in opening margin), then everything is blocked because the `FRESH` status will never be updated:
-            # https://github.com/valory-xyz/trader/blob/v0.23.1/packages/valory/skills/market_manager_abci/behaviours.py#L200-L202
-            self.context.logger.info(
-                "Multi-bets storage temporarily disabled on startup!"
-            )
-            self.shared_state.first_read = False
-            return
-
         _read_path = self.multi_bets_filepath
 
         if not os.path.isfile(_read_path):

--- a/packages/valory/skills/market_manager_abci/behaviours.py
+++ b/packages/valory/skills/market_manager_abci/behaviours.py
@@ -105,7 +105,8 @@ class BetsManagerBehaviour(BaseBehaviour, ABC):
                 f"No stored bets file was detected in {_read_path}. Assuming trader is being run for the first time in multi-bets mode."
             )
             _read_path = self.bets_filepath
-        elif not os.path.isfile(_read_path):
+
+        if not os.path.isfile(_read_path):
             self.context.logger.warning(
                 f"No stored bets file was detected in {_read_path}. Assuming bets are empty"
             )

--- a/packages/valory/skills/market_manager_abci/models.py
+++ b/packages/valory/skills/market_manager_abci/models.py
@@ -24,7 +24,7 @@ import builtins
 from pathlib import Path
 from typing import Any, Dict, Iterator, List, Tuple, Type
 
-from aea.skills.base import Model, SkillContext
+from aea.skills.base import Model
 
 from packages.valory.protocols.http import HttpMessage
 from packages.valory.skills.abstract_round_abci.base import AbciApp
@@ -49,11 +49,6 @@ class SharedState(BaseSharedState):
     """Keep the current shared state of the skill."""
 
     abci_app_cls: Type[AbciApp[Any]] = MarketManagerAbciApp
-
-    def __init__(self, *args: Any, skill_context: SkillContext, **kwargs: Any) -> None:
-        """Initialize the state."""
-        super().__init__(*args, skill_context=skill_context, **kwargs)
-        self.first_read: bool = True
 
 
 class Subgraph(ApiSpecs):

--- a/packages/valory/skills/market_manager_abci/skill.yaml
+++ b/packages/valory/skills/market_manager_abci/skill.yaml
@@ -8,7 +8,7 @@ aea_version: '>=1.0.0, <2.0.0'
 fingerprint:
   README.md: bafybeie6miwn67uin3bphukmf7qgiifh4xtm42i5v3nuyqxzxtehxsqvcq
   __init__.py: bafybeigrtedqzlq5mtql2ssjsdriw76ml3666m4e2c3fay6vmyzofl6v6e
-  behaviours.py: bafybeigxe7d66msaddai6zkgjtukve3zkciav4kw6qs32jathzxjjpvea4
+  behaviours.py: bafybeibcf3rrl3l4zd57jojo3neyxpunnnzhwge6yclsv7mtkp4kewcata
   bets.py: bafybeid3tzd3ikwdcyplltxttycrv3bixhxuxv56p3bfpru6gzigpoeu4i
   dialogues.py: bafybeiebofyykseqp3fmif36cqmmyf3k7d2zbocpl6t6wnlpv4szghrxbm
   fsm_specification.yaml: bafybeic5cvwfbiu5pywyp3h5s2elvu7jqdrcwayay7o3v3ow47vu2jw53q
@@ -22,7 +22,7 @@ fingerprint:
   graph_tooling/requests.py: bafybeibjyb6av33aswnptttekj6t7k7xysgphh2bigoorcgkc54y2j3xkm
   graph_tooling/utils.py: bafybeig5hxhnqgyfn5ym3poc5nziqwpeozqbd6wa4s6c2hjn6iyedg3t3y
   handlers.py: bafybeihot2i2yvfkz2gcowvt66wdu6tkjbmv7hsmc4jzt4reqeaiuphbtu
-  models.py: bafybeicqsuhtzernjqwdiwy6gbfvtv4ashlxsfutnqldivxc5iufgk7sbu
+  models.py: bafybeifytda5kxew5bgsz52amrrsrs4bkumet3icyayw4yht3vkoj5gury
   payloads.py: bafybeicfymvvtdpkcgmkvthfzmb7dqakepkzslqrz6rcs7nxkz7qq3mrzy
   rounds.py: bafybeibqqq3vjotaasc67olhlqthka6e6refodguntkmpksgdbqlzme73a
   tests/__init__.py: bafybeigaewntxawezvygss345kytjijo56bfwddjtfm6egzxfajsgojam4

--- a/packages/valory/skills/trader_abci/skill.yaml
+++ b/packages/valory/skills/trader_abci/skill.yaml
@@ -34,9 +34,9 @@ skills:
 - valory/reset_pause_abci:0.1.0:bafybeiachgo6reit2q4jw75mefw2acj4ldedeqmn3rewjm4dbzts2l7oxe
 - valory/transaction_settlement_abci:0.1.0:bafybeic2ywzpwkyeqbzsvkbvurhsptemam4xtceihax2tmxmlxtgd3xpya
 - valory/termination_abci:0.1.0:bafybeibtbboau3q5fxfviwm7lbeix4z55uptfqqiyiu6siivxwkp3o5pju
-- valory/market_manager_abci:0.1.0:bafybeidblnaypi5fbci6zyk4ekngxq5zf2jiptssfhfiodzg7rilq24cz4
-- valory/decision_maker_abci:0.1.0:bafybeiebyilooxucaqjl3b3syjlov2jpu2wwrdtzdwjgnggwujiww4eac4
-- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeictifd2d4ptjshuzsr7hwdw66ssaaowteubnkapyhbgphwrqcuewy
+- valory/market_manager_abci:0.1.0:bafybeihievdcieyf5lad7iamrgkuahxlcjyuqc4kzomi4chcy2pap47ehu
+- valory/decision_maker_abci:0.1.0:bafybeibgg5rkzsb66ptusxuy3wuqellt5lummg52evwkbszsumwbxlqx6y
+- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeiescma4y3lw6bpxx7eybijmrxycvtpb6fi4npmijam6nlvfte64s4
 - valory/staking_abci:0.1.0:bafybeifupwkfbxa4c4jogpudvzwt5rkgfuedgd65sj2bf2z5ver4phq64m
 - valory/check_stop_trading_abci:0.1.0:bafybeie6mavlrdy6o6cpgz2lecvla22rywsjq3qjblvw56lubwa3ph44ui
 - valory/mech_interact_abci:0.1.0:bafybeiedcaz6tmjg2irpntcco7ny2vwyqvffxl3mpji7qi6esdjr6qv3za

--- a/packages/valory/skills/tx_settlement_multiplexer_abci/skill.yaml
+++ b/packages/valory/skills/tx_settlement_multiplexer_abci/skill.yaml
@@ -23,7 +23,7 @@ protocols:
 - valory/ledger_api:1.0.0:bafybeihmqzcbj6t7vxz2aehd5726ofnzsfjs5cwlf42ro4tn6i34cbfrc4
 skills:
 - valory/abstract_round_abci:0.1.0:bafybeiey45kkbniukmtpdjduwazpyygaiayeo7mh3tu6wfbau2bxvuljmy
-- valory/decision_maker_abci:0.1.0:bafybeiebyilooxucaqjl3b3syjlov2jpu2wwrdtzdwjgnggwujiww4eac4
+- valory/decision_maker_abci:0.1.0:bafybeibgg5rkzsb66ptusxuy3wuqellt5lummg52evwkbszsumwbxlqx6y
 - valory/staking_abci:0.1.0:bafybeifupwkfbxa4c4jogpudvzwt5rkgfuedgd65sj2bf2z5ver4phq64m
 - valory/mech_interact_abci:0.1.0:bafybeiedcaz6tmjg2irpntcco7ny2vwyqvffxl3mpji7qi6esdjr6qv3za
 behaviours:


### PR DESCRIPTION
if a bet was in the `TO_PROCESS` queue and could not be selected because of the constraints (e.g., not in opening margin), then everything was blocked because the `FRESH` status would never be updated.

This is fixed by blacklisting the unprocessable bets of the `TO_PROCESS` queue.