### PR TITLE
chore: update hashes to use the right ABI for mech-marketplace [2]

### DIFF
--- a/packages/packages.json
+++ b/packages/packages.json
@@ -16,14 +16,14 @@
         "contract/valory/relayer/0.1.0": "bafybeihypuljybkocl6iiacy52py7i5iqxdli3ily66q7b3nego4qajvne",
         "contract/valory/market_maker/0.1.0": "bafybeigzfyzbixum5cqvcbyc24dqwce25dr6nyqvgjm2eqpt6tgo2perd4",
         "skill/valory/market_manager_abci/0.1.0": "bafybeigzbjix5utljmbw5nqhw3tkozlb6r73urutdpxtefge4ijdwqqwuq",
-        "skill/valory/decision_maker_abci/0.1.0": "bafybeiczwgfwcm5uytezv2upsbvzpkjpiv4etp5bkz4osvo7zgef6xwvwa",
-        "skill/valory/trader_abci/0.1.0": "bafybeidm5ovxt7d3ivdtvfz222jdwaw7ebzkfnebzcjp76b5gnmta6lmiq",
-        "skill/valory/tx_settlement_multiplexer_abci/0.1.0": "bafybeidtojnjs7z6xnjrmnfwxitcldpt5cqa6yvoupjla6rlfebbrprfri",
+        "skill/valory/decision_maker_abci/0.1.0": "bafybeidnk3j46n57yuytiyxidcexvp6htymwbgxduxwhqrofqupsdro2ii",
+        "skill/valory/trader_abci/0.1.0": "bafybeidynr2wrodygexag5dqj2bl7sxnu7i7mvue3ipvtljx66mmueudee",
+        "skill/valory/tx_settlement_multiplexer_abci/0.1.0": "bafybeicse7mucign56twhsfg2faek7fqk7kpltt6alzmowo5ywtmazudky",
         "skill/valory/staking_abci/0.1.0": "bafybeifupwkfbxa4c4jogpudvzwt5rkgfuedgd65sj2bf2z5ver4phq64m",
-        "skill/valory/check_stop_trading_abci/0.1.0": "bafybeignl5w4o4ghcpan7nsor5elvuid4si7t4rnfqga47bwvlgp22xwsa",
-        "agent/valory/trader/0.1.0": "bafybeibblyf224a3abcrtkolwuq7qztz7scsbzaltm5rv3giybsuehasqy",
-        "service/valory/trader/0.1.0": "bafybeibmgaxyit2v6hf5ptmqbc3zvo64ppjdvuz5rxch4g2l3hyheyguvu",
-        "service/valory/trader_pearl/0.1.0": "bafybeicbynv4o3dqdrzv724b73qag6wsnmv7ny4pbxrkn77b3j5xh2wp2y"
+        "skill/valory/check_stop_trading_abci/0.1.0": "bafybeibb4gq5u4w6dmabdgsaffsispamxbgkm27oc3llclyvtwezc3df5q",
+        "agent/valory/trader/0.1.0": "bafybeigjkxarqcmilwcj23ucsrahgoafvohomv7s6uiqttjdooqocjztea",
+        "service/valory/trader/0.1.0": "bafybeigavavxqzph4chfiperwo4ygmoekmgbgwwtlxggt43w7mgdyctq64",
+        "service/valory/trader_pearl/0.1.0": "bafybeidugmpnwbxyfe74dli7cgs27kjwirvlw2ufqeuyqqbrbzktoklfsi"
     },
     "third_party": {
         "protocol/valory/acn_data_share/0.1.0": "bafybeih5ydonnvrwvy2ygfqgfabkr47s4yw3uqxztmwyfprulwfsoe7ipq",
@@ -41,11 +41,11 @@
         "contract/valory/gnosis_safe_proxy_factory/0.1.0": "bafybeidfvyc6bw4uigv3jfcxr23vysctki6x5rh5htp2azhncib27ydxdm",
         "contract/valory/gnosis_safe/0.1.0": "bafybeibgpgpi7w6xtxg3zr7tye3f6g6tu7fnvy7yxlgunbjqin3ou7e5pi",
         "contract/valory/mech/0.1.0": "bafybeib32m5zriagivlj7insajfs4jm5o5h53eym32wjjjp6qwv4lzl3pu",
+        "contract/valory/mech_marketplace/0.1.0": "bafybeiar6rga33fkh5krhny5grcvpdbrpqglexle67am3livz35ksjiquq",
         "contract/valory/mech_mm/0.1.0": "bafybeibbz2hlyvtg6yfojzdnou2xqbpu32a4mjvn2xidfypvwy5oj6gx4u",
         "contract/valory/service_registry/0.1.0": "bafybeigaginvk2i6rycppfomk6tldkvunik6atuxtjpuuw6ndckymcojne",
         "contract/valory/multisend/0.1.0": "bafybeig5byt5urg2d2bsecufxe5ql7f4mezg3mekfleeh32nmuusx66p4y",
         "contract/valory/erc20/0.1.0": "bafybeifyjub3v62r53by76u7cli7oqvg5qukb4e6gaa62z34euqfwnrsvi",
-        "contract/valory/mech_marketplace/0.1.0": "bafybeiccn4ohizw2wrjt7goidiakfik26ugm735lnm3fna3khko7qgkawm",
         "contract/valory/mech_marketplace_legacy/0.1.0": "bafybeiafwem7v7po7xb7rag4zfdqe2uoaqki3xybviciypxr5w6zkoxgse",
         "connection/valory/abci/0.1.0": "bafybeidn5gc6y3a6tkhgv753kkiub3mfas3tkemm4fs7i4kc4klkjlxpui",
         "connection/valory/http_client/0.23.0": "bafybeid5ffvg76ejjoese7brj5ji3lx66cu7p2ixfwflpo6rgofkypfd7y",
@@ -60,6 +60,6 @@
         "skill/valory/abstract_round_abci/0.1.0": "bafybeiey45kkbniukmtpdjduwazpyygaiayeo7mh3tu6wfbau2bxvuljmy",
         "skill/valory/transaction_settlement_abci/0.1.0": "bafybeic2ywzpwkyeqbzsvkbvurhsptemam4xtceihax2tmxmlxtgd3xpya",
         "skill/valory/termination_abci/0.1.0": "bafybeibtbboau3q5fxfviwm7lbeix4z55uptfqqiyiu6siivxwkp3o5pju",
-        "skill/valory/mech_interact_abci/0.1.0": "bafybeigkizx3ecohtyshr6tq55zvp4sl5cou344a2t6nvwfgund4xnrj4a"
+        "skill/valory/mech_interact_abci/0.1.0": "bafybeib6hw4c6u56j2xrfdj6vsr27ppkpzmsmrlflhsvkq42ifol45crni"
     }
 }

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -16,14 +16,14 @@
         "contract/valory/relayer/0.1.0": "bafybeihypuljybkocl6iiacy52py7i5iqxdli3ily66q7b3nego4qajvne",
         "contract/valory/market_maker/0.1.0": "bafybeigzfyzbixum5cqvcbyc24dqwce25dr6nyqvgjm2eqpt6tgo2perd4",
         "skill/valory/market_manager_abci/0.1.0": "bafybeigzbjix5utljmbw5nqhw3tkozlb6r73urutdpxtefge4ijdwqqwuq",
-        "skill/valory/decision_maker_abci/0.1.0": "bafybeidnk3j46n57yuytiyxidcexvp6htymwbgxduxwhqrofqupsdro2ii",
-        "skill/valory/trader_abci/0.1.0": "bafybeidynr2wrodygexag5dqj2bl7sxnu7i7mvue3ipvtljx66mmueudee",
-        "skill/valory/tx_settlement_multiplexer_abci/0.1.0": "bafybeicse7mucign56twhsfg2faek7fqk7kpltt6alzmowo5ywtmazudky",
+        "skill/valory/decision_maker_abci/0.1.0": "bafybeigrsirmazw5dgsr7cpi4j7l6nxfwz4i4pyjgljo57txnbh5mt2jx4",
+        "skill/valory/trader_abci/0.1.0": "bafybeieelasm5xpafawawp6z4p67v2uqq7jfc4tycxyg7qsr3qvs4wxqry",
+        "skill/valory/tx_settlement_multiplexer_abci/0.1.0": "bafybeie2a3ddqpzfbyka37yx75ohcxp36gjkkaldfsu4gj2zbtwymjedwa",
         "skill/valory/staking_abci/0.1.0": "bafybeifupwkfbxa4c4jogpudvzwt5rkgfuedgd65sj2bf2z5ver4phq64m",
-        "skill/valory/check_stop_trading_abci/0.1.0": "bafybeibb4gq5u4w6dmabdgsaffsispamxbgkm27oc3llclyvtwezc3df5q",
-        "agent/valory/trader/0.1.0": "bafybeigjkxarqcmilwcj23ucsrahgoafvohomv7s6uiqttjdooqocjztea",
-        "service/valory/trader/0.1.0": "bafybeigavavxqzph4chfiperwo4ygmoekmgbgwwtlxggt43w7mgdyctq64",
-        "service/valory/trader_pearl/0.1.0": "bafybeidugmpnwbxyfe74dli7cgs27kjwirvlw2ufqeuyqqbrbzktoklfsi"
+        "skill/valory/check_stop_trading_abci/0.1.0": "bafybeiavitzh3du5ofru6ezxtuoikzjit2cne5bwgv65zncqi6y5olaffu",
+        "agent/valory/trader/0.1.0": "bafybeif5rrxve7flpfj3vkc5hxivfeyuzxbcmzmu6qphujnkwhsj6ewxmm",
+        "service/valory/trader/0.1.0": "bafybeidmc5uywgagj6dx7iklxd4y2335eiofbqla4p4bhzs2grmq37uaya",
+        "service/valory/trader_pearl/0.1.0": "bafybeiglxzayqr4sxzawmdezfvs4uni4hsnngy3gp5pgekmsfccfegszxy"
     },
     "third_party": {
         "protocol/valory/acn_data_share/0.1.0": "bafybeih5ydonnvrwvy2ygfqgfabkr47s4yw3uqxztmwyfprulwfsoe7ipq",
@@ -41,7 +41,7 @@
         "contract/valory/gnosis_safe_proxy_factory/0.1.0": "bafybeidfvyc6bw4uigv3jfcxr23vysctki6x5rh5htp2azhncib27ydxdm",
         "contract/valory/gnosis_safe/0.1.0": "bafybeibgpgpi7w6xtxg3zr7tye3f6g6tu7fnvy7yxlgunbjqin3ou7e5pi",
         "contract/valory/mech/0.1.0": "bafybeib32m5zriagivlj7insajfs4jm5o5h53eym32wjjjp6qwv4lzl3pu",
-        "contract/valory/mech_marketplace/0.1.0": "bafybeiar6rga33fkh5krhny5grcvpdbrpqglexle67am3livz35ksjiquq",
+        "contract/valory/mech_marketplace/0.1.0": "bafybeibrojfogyvfv5pvcozjvjks7hfhsqmxzuod7cdkkqzybv376bpysu",
         "contract/valory/mech_mm/0.1.0": "bafybeibbz2hlyvtg6yfojzdnou2xqbpu32a4mjvn2xidfypvwy5oj6gx4u",
         "contract/valory/service_registry/0.1.0": "bafybeigaginvk2i6rycppfomk6tldkvunik6atuxtjpuuw6ndckymcojne",
         "contract/valory/multisend/0.1.0": "bafybeig5byt5urg2d2bsecufxe5ql7f4mezg3mekfleeh32nmuusx66p4y",
@@ -60,6 +60,6 @@
         "skill/valory/abstract_round_abci/0.1.0": "bafybeiey45kkbniukmtpdjduwazpyygaiayeo7mh3tu6wfbau2bxvuljmy",
         "skill/valory/transaction_settlement_abci/0.1.0": "bafybeic2ywzpwkyeqbzsvkbvurhsptemam4xtceihax2tmxmlxtgd3xpya",
         "skill/valory/termination_abci/0.1.0": "bafybeibtbboau3q5fxfviwm7lbeix4z55uptfqqiyiu6siivxwkp3o5pju",
-        "skill/valory/mech_interact_abci/0.1.0": "bafybeib6hw4c6u56j2xrfdj6vsr27ppkpzmsmrlflhsvkq42ifol45crni"
+        "skill/valory/mech_interact_abci/0.1.0": "bafybeibxvbgtj5pi24e2fh7kskdcv72buevqzaykw4lirkr4n7qn5ba2re"
     }
 }

--- a/packages/valory/agents/trader/aea-config.yaml
+++ b/packages/valory/agents/trader/aea-config.yaml
@@ -32,7 +32,7 @@ contracts:
 - valory/erc20:0.1.0:bafybeifyjub3v62r53by76u7cli7oqvg5qukb4e6gaa62z34euqfwnrsvi
 - valory/staking_token:0.1.0:bafybeigzerw3sxvrd4y6g4b5j6duqbjvxmqvarf2m5xovjsthhxyogpypm
 - valory/mech_activity:0.1.0:bafybeib3fsk4vaigytomohw6hovems7sr4nsbwlfm52724st5eorail444
-- valory/mech_marketplace:0.1.0:bafybeiccn4ohizw2wrjt7goidiakfik26ugm735lnm3fna3khko7qgkawm
+- valory/mech_marketplace:0.1.0:bafybeiar6rga33fkh5krhny5grcvpdbrpqglexle67am3livz35ksjiquq
 - valory/relayer:0.1.0:bafybeihypuljybkocl6iiacy52py7i5iqxdli3ily66q7b3nego4qajvne
 - valory/mech_marketplace_legacy:0.1.0:bafybeiafwem7v7po7xb7rag4zfdqe2uoaqki3xybviciypxr5w6zkoxgse
 - valory/mech_mm:0.1.0:bafybeibbz2hlyvtg6yfojzdnou2xqbpu32a4mjvn2xidfypvwy5oj6gx4u
@@ -55,13 +55,13 @@ skills:
 - valory/reset_pause_abci:0.1.0:bafybeiachgo6reit2q4jw75mefw2acj4ldedeqmn3rewjm4dbzts2l7oxe
 - valory/termination_abci:0.1.0:bafybeibtbboau3q5fxfviwm7lbeix4z55uptfqqiyiu6siivxwkp3o5pju
 - valory/transaction_settlement_abci:0.1.0:bafybeic2ywzpwkyeqbzsvkbvurhsptemam4xtceihax2tmxmlxtgd3xpya
-- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeidtojnjs7z6xnjrmnfwxitcldpt5cqa6yvoupjla6rlfebbrprfri
+- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeicse7mucign56twhsfg2faek7fqk7kpltt6alzmowo5ywtmazudky
 - valory/market_manager_abci:0.1.0:bafybeigzbjix5utljmbw5nqhw3tkozlb6r73urutdpxtefge4ijdwqqwuq
-- valory/decision_maker_abci:0.1.0:bafybeiczwgfwcm5uytezv2upsbvzpkjpiv4etp5bkz4osvo7zgef6xwvwa
-- valory/trader_abci:0.1.0:bafybeidm5ovxt7d3ivdtvfz222jdwaw7ebzkfnebzcjp76b5gnmta6lmiq
+- valory/decision_maker_abci:0.1.0:bafybeidnk3j46n57yuytiyxidcexvp6htymwbgxduxwhqrofqupsdro2ii
+- valory/trader_abci:0.1.0:bafybeidynr2wrodygexag5dqj2bl7sxnu7i7mvue3ipvtljx66mmueudee
 - valory/staking_abci:0.1.0:bafybeifupwkfbxa4c4jogpudvzwt5rkgfuedgd65sj2bf2z5ver4phq64m
-- valory/check_stop_trading_abci:0.1.0:bafybeignl5w4o4ghcpan7nsor5elvuid4si7t4rnfqga47bwvlgp22xwsa
-- valory/mech_interact_abci:0.1.0:bafybeigkizx3ecohtyshr6tq55zvp4sl5cou344a2t6nvwfgund4xnrj4a
+- valory/check_stop_trading_abci:0.1.0:bafybeibb4gq5u4w6dmabdgsaffsispamxbgkm27oc3llclyvtwezc3df5q
+- valory/mech_interact_abci:0.1.0:bafybeib6hw4c6u56j2xrfdj6vsr27ppkpzmsmrlflhsvkq42ifol45crni
 customs:
 - valory/mike_strat:0.1.0:bafybeihjiol7f4ch4piwfikurdtfwzsh6qydkbsztpbwbwb2yrqdqf726m
 - valory/bet_amount_per_threshold:0.1.0:bafybeihsjx7we6b2scjt7777xmjte36rrubblusitqsipjhkttk4cmf5iu

--- a/packages/valory/agents/trader/aea-config.yaml
+++ b/packages/valory/agents/trader/aea-config.yaml
@@ -32,7 +32,7 @@ contracts:
 - valory/erc20:0.1.0:bafybeifyjub3v62r53by76u7cli7oqvg5qukb4e6gaa62z34euqfwnrsvi
 - valory/staking_token:0.1.0:bafybeigzerw3sxvrd4y6g4b5j6duqbjvxmqvarf2m5xovjsthhxyogpypm
 - valory/mech_activity:0.1.0:bafybeib3fsk4vaigytomohw6hovems7sr4nsbwlfm52724st5eorail444
-- valory/mech_marketplace:0.1.0:bafybeiar6rga33fkh5krhny5grcvpdbrpqglexle67am3livz35ksjiquq
+- valory/mech_marketplace:0.1.0:bafybeibrojfogyvfv5pvcozjvjks7hfhsqmxzuod7cdkkqzybv376bpysu
 - valory/relayer:0.1.0:bafybeihypuljybkocl6iiacy52py7i5iqxdli3ily66q7b3nego4qajvne
 - valory/mech_marketplace_legacy:0.1.0:bafybeiafwem7v7po7xb7rag4zfdqe2uoaqki3xybviciypxr5w6zkoxgse
 - valory/mech_mm:0.1.0:bafybeibbz2hlyvtg6yfojzdnou2xqbpu32a4mjvn2xidfypvwy5oj6gx4u
@@ -55,13 +55,13 @@ skills:
 - valory/reset_pause_abci:0.1.0:bafybeiachgo6reit2q4jw75mefw2acj4ldedeqmn3rewjm4dbzts2l7oxe
 - valory/termination_abci:0.1.0:bafybeibtbboau3q5fxfviwm7lbeix4z55uptfqqiyiu6siivxwkp3o5pju
 - valory/transaction_settlement_abci:0.1.0:bafybeic2ywzpwkyeqbzsvkbvurhsptemam4xtceihax2tmxmlxtgd3xpya
-- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeicse7mucign56twhsfg2faek7fqk7kpltt6alzmowo5ywtmazudky
+- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeie2a3ddqpzfbyka37yx75ohcxp36gjkkaldfsu4gj2zbtwymjedwa
 - valory/market_manager_abci:0.1.0:bafybeigzbjix5utljmbw5nqhw3tkozlb6r73urutdpxtefge4ijdwqqwuq
-- valory/decision_maker_abci:0.1.0:bafybeidnk3j46n57yuytiyxidcexvp6htymwbgxduxwhqrofqupsdro2ii
-- valory/trader_abci:0.1.0:bafybeidynr2wrodygexag5dqj2bl7sxnu7i7mvue3ipvtljx66mmueudee
+- valory/decision_maker_abci:0.1.0:bafybeigrsirmazw5dgsr7cpi4j7l6nxfwz4i4pyjgljo57txnbh5mt2jx4
+- valory/trader_abci:0.1.0:bafybeieelasm5xpafawawp6z4p67v2uqq7jfc4tycxyg7qsr3qvs4wxqry
 - valory/staking_abci:0.1.0:bafybeifupwkfbxa4c4jogpudvzwt5rkgfuedgd65sj2bf2z5ver4phq64m
-- valory/check_stop_trading_abci:0.1.0:bafybeibb4gq5u4w6dmabdgsaffsispamxbgkm27oc3llclyvtwezc3df5q
-- valory/mech_interact_abci:0.1.0:bafybeib6hw4c6u56j2xrfdj6vsr27ppkpzmsmrlflhsvkq42ifol45crni
+- valory/check_stop_trading_abci:0.1.0:bafybeiavitzh3du5ofru6ezxtuoikzjit2cne5bwgv65zncqi6y5olaffu
+- valory/mech_interact_abci:0.1.0:bafybeibxvbgtj5pi24e2fh7kskdcv72buevqzaykw4lirkr4n7qn5ba2re
 customs:
 - valory/mike_strat:0.1.0:bafybeihjiol7f4ch4piwfikurdtfwzsh6qydkbsztpbwbwb2yrqdqf726m
 - valory/bet_amount_per_threshold:0.1.0:bafybeihsjx7we6b2scjt7777xmjte36rrubblusitqsipjhkttk4cmf5iu

--- a/packages/valory/services/trader/service.yaml
+++ b/packages/valory/services/trader/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeigtuothskwyvrhfosps2bu6suauycolj67dpuxqvnicdrdu7yhtvq
 fingerprint_ignore_patterns: []
-agent: valory/trader:0.1.0:bafybeibblyf224a3abcrtkolwuq7qztz7scsbzaltm5rv3giybsuehasqy
+agent: valory/trader:0.1.0:bafybeigjkxarqcmilwcj23ucsrahgoafvohomv7s6uiqttjdooqocjztea
 number_of_agents: 4
 deployment:
   agent:

--- a/packages/valory/services/trader/service.yaml
+++ b/packages/valory/services/trader/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeigtuothskwyvrhfosps2bu6suauycolj67dpuxqvnicdrdu7yhtvq
 fingerprint_ignore_patterns: []
-agent: valory/trader:0.1.0:bafybeigjkxarqcmilwcj23ucsrahgoafvohomv7s6uiqttjdooqocjztea
+agent: valory/trader:0.1.0:bafybeif5rrxve7flpfj3vkc5hxivfeyuzxbcmzmu6qphujnkwhsj6ewxmm
 number_of_agents: 4
 deployment:
   agent:

--- a/packages/valory/services/trader_pearl/service.yaml
+++ b/packages/valory/services/trader_pearl/service.yaml
@@ -8,7 +8,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeibg7bdqpioh4lmvknw3ygnllfku32oca4eq5pqtvdrdsgw6buko7e
 fingerprint_ignore_patterns: []
-agent: valory/trader:0.1.0:bafybeibblyf224a3abcrtkolwuq7qztz7scsbzaltm5rv3giybsuehasqy
+agent: valory/trader:0.1.0:bafybeigjkxarqcmilwcj23ucsrahgoafvohomv7s6uiqttjdooqocjztea
 number_of_agents: 1
 deployment:
   agent:

--- a/packages/valory/services/trader_pearl/service.yaml
+++ b/packages/valory/services/trader_pearl/service.yaml
@@ -8,7 +8,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeibg7bdqpioh4lmvknw3ygnllfku32oca4eq5pqtvdrdsgw6buko7e
 fingerprint_ignore_patterns: []
-agent: valory/trader:0.1.0:bafybeigjkxarqcmilwcj23ucsrahgoafvohomv7s6uiqttjdooqocjztea
+agent: valory/trader:0.1.0:bafybeif5rrxve7flpfj3vkc5hxivfeyuzxbcmzmu6qphujnkwhsj6ewxmm
 number_of_agents: 1
 deployment:
   agent:

--- a/packages/valory/skills/check_stop_trading_abci/skill.yaml
+++ b/packages/valory/skills/check_stop_trading_abci/skill.yaml
@@ -24,11 +24,11 @@ fingerprint_ignore_patterns: []
 connections: []
 contracts:
 - valory/mech:0.1.0:bafybeib32m5zriagivlj7insajfs4jm5o5h53eym32wjjjp6qwv4lzl3pu
-- valory/mech_marketplace:0.1.0:bafybeiccn4ohizw2wrjt7goidiakfik26ugm735lnm3fna3khko7qgkawm
+- valory/mech_marketplace:0.1.0:bafybeiar6rga33fkh5krhny5grcvpdbrpqglexle67am3livz35ksjiquq
 protocols: []
 skills:
 - valory/abstract_round_abci:0.1.0:bafybeiey45kkbniukmtpdjduwazpyygaiayeo7mh3tu6wfbau2bxvuljmy
-- valory/mech_interact_abci:0.1.0:bafybeigkizx3ecohtyshr6tq55zvp4sl5cou344a2t6nvwfgund4xnrj4a
+- valory/mech_interact_abci:0.1.0:bafybeib6hw4c6u56j2xrfdj6vsr27ppkpzmsmrlflhsvkq42ifol45crni
 - valory/staking_abci:0.1.0:bafybeifupwkfbxa4c4jogpudvzwt5rkgfuedgd65sj2bf2z5ver4phq64m
 behaviours:
   main:

--- a/packages/valory/skills/check_stop_trading_abci/skill.yaml
+++ b/packages/valory/skills/check_stop_trading_abci/skill.yaml
@@ -24,11 +24,11 @@ fingerprint_ignore_patterns: []
 connections: []
 contracts:
 - valory/mech:0.1.0:bafybeib32m5zriagivlj7insajfs4jm5o5h53eym32wjjjp6qwv4lzl3pu
-- valory/mech_marketplace:0.1.0:bafybeiar6rga33fkh5krhny5grcvpdbrpqglexle67am3livz35ksjiquq
+- valory/mech_marketplace:0.1.0:bafybeibrojfogyvfv5pvcozjvjks7hfhsqmxzuod7cdkkqzybv376bpysu
 protocols: []
 skills:
 - valory/abstract_round_abci:0.1.0:bafybeiey45kkbniukmtpdjduwazpyygaiayeo7mh3tu6wfbau2bxvuljmy
-- valory/mech_interact_abci:0.1.0:bafybeib6hw4c6u56j2xrfdj6vsr27ppkpzmsmrlflhsvkq42ifol45crni
+- valory/mech_interact_abci:0.1.0:bafybeibxvbgtj5pi24e2fh7kskdcv72buevqzaykw4lirkr4n7qn5ba2re
 - valory/staking_abci:0.1.0:bafybeifupwkfbxa4c4jogpudvzwt5rkgfuedgd65sj2bf2z5ver4phq64m
 behaviours:
   main:

--- a/packages/valory/skills/decision_maker_abci/skill.yaml
+++ b/packages/valory/skills/decision_maker_abci/skill.yaml
@@ -110,7 +110,7 @@ skills:
 - valory/abstract_round_abci:0.1.0:bafybeiey45kkbniukmtpdjduwazpyygaiayeo7mh3tu6wfbau2bxvuljmy
 - valory/market_manager_abci:0.1.0:bafybeigzbjix5utljmbw5nqhw3tkozlb6r73urutdpxtefge4ijdwqqwuq
 - valory/transaction_settlement_abci:0.1.0:bafybeic2ywzpwkyeqbzsvkbvurhsptemam4xtceihax2tmxmlxtgd3xpya
-- valory/mech_interact_abci:0.1.0:bafybeib6hw4c6u56j2xrfdj6vsr27ppkpzmsmrlflhsvkq42ifol45crni
+- valory/mech_interact_abci:0.1.0:bafybeibxvbgtj5pi24e2fh7kskdcv72buevqzaykw4lirkr4n7qn5ba2re
 - valory/staking_abci:0.1.0:bafybeifupwkfbxa4c4jogpudvzwt5rkgfuedgd65sj2bf2z5ver4phq64m
 behaviours:
   main:

--- a/packages/valory/skills/decision_maker_abci/skill.yaml
+++ b/packages/valory/skills/decision_maker_abci/skill.yaml
@@ -110,7 +110,7 @@ skills:
 - valory/abstract_round_abci:0.1.0:bafybeiey45kkbniukmtpdjduwazpyygaiayeo7mh3tu6wfbau2bxvuljmy
 - valory/market_manager_abci:0.1.0:bafybeigzbjix5utljmbw5nqhw3tkozlb6r73urutdpxtefge4ijdwqqwuq
 - valory/transaction_settlement_abci:0.1.0:bafybeic2ywzpwkyeqbzsvkbvurhsptemam4xtceihax2tmxmlxtgd3xpya
-- valory/mech_interact_abci:0.1.0:bafybeigkizx3ecohtyshr6tq55zvp4sl5cou344a2t6nvwfgund4xnrj4a
+- valory/mech_interact_abci:0.1.0:bafybeib6hw4c6u56j2xrfdj6vsr27ppkpzmsmrlflhsvkq42ifol45crni
 - valory/staking_abci:0.1.0:bafybeifupwkfbxa4c4jogpudvzwt5rkgfuedgd65sj2bf2z5ver4phq64m
 behaviours:
   main:

--- a/packages/valory/skills/trader_abci/skill.yaml
+++ b/packages/valory/skills/trader_abci/skill.yaml
@@ -39,11 +39,11 @@ skills:
 - valory/transaction_settlement_abci:0.1.0:bafybeic2ywzpwkyeqbzsvkbvurhsptemam4xtceihax2tmxmlxtgd3xpya
 - valory/termination_abci:0.1.0:bafybeibtbboau3q5fxfviwm7lbeix4z55uptfqqiyiu6siivxwkp3o5pju
 - valory/market_manager_abci:0.1.0:bafybeigzbjix5utljmbw5nqhw3tkozlb6r73urutdpxtefge4ijdwqqwuq
-- valory/decision_maker_abci:0.1.0:bafybeidnk3j46n57yuytiyxidcexvp6htymwbgxduxwhqrofqupsdro2ii
-- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeicse7mucign56twhsfg2faek7fqk7kpltt6alzmowo5ywtmazudky
+- valory/decision_maker_abci:0.1.0:bafybeigrsirmazw5dgsr7cpi4j7l6nxfwz4i4pyjgljo57txnbh5mt2jx4
+- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeie2a3ddqpzfbyka37yx75ohcxp36gjkkaldfsu4gj2zbtwymjedwa
 - valory/staking_abci:0.1.0:bafybeifupwkfbxa4c4jogpudvzwt5rkgfuedgd65sj2bf2z5ver4phq64m
-- valory/check_stop_trading_abci:0.1.0:bafybeibb4gq5u4w6dmabdgsaffsispamxbgkm27oc3llclyvtwezc3df5q
-- valory/mech_interact_abci:0.1.0:bafybeib6hw4c6u56j2xrfdj6vsr27ppkpzmsmrlflhsvkq42ifol45crni
+- valory/check_stop_trading_abci:0.1.0:bafybeiavitzh3du5ofru6ezxtuoikzjit2cne5bwgv65zncqi6y5olaffu
+- valory/mech_interact_abci:0.1.0:bafybeibxvbgtj5pi24e2fh7kskdcv72buevqzaykw4lirkr4n7qn5ba2re
 behaviours:
   main:
     args: {}

--- a/packages/valory/skills/trader_abci/skill.yaml
+++ b/packages/valory/skills/trader_abci/skill.yaml
@@ -39,11 +39,11 @@ skills:
 - valory/transaction_settlement_abci:0.1.0:bafybeic2ywzpwkyeqbzsvkbvurhsptemam4xtceihax2tmxmlxtgd3xpya
 - valory/termination_abci:0.1.0:bafybeibtbboau3q5fxfviwm7lbeix4z55uptfqqiyiu6siivxwkp3o5pju
 - valory/market_manager_abci:0.1.0:bafybeigzbjix5utljmbw5nqhw3tkozlb6r73urutdpxtefge4ijdwqqwuq
-- valory/decision_maker_abci:0.1.0:bafybeiczwgfwcm5uytezv2upsbvzpkjpiv4etp5bkz4osvo7zgef6xwvwa
-- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeidtojnjs7z6xnjrmnfwxitcldpt5cqa6yvoupjla6rlfebbrprfri
+- valory/decision_maker_abci:0.1.0:bafybeidnk3j46n57yuytiyxidcexvp6htymwbgxduxwhqrofqupsdro2ii
+- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeicse7mucign56twhsfg2faek7fqk7kpltt6alzmowo5ywtmazudky
 - valory/staking_abci:0.1.0:bafybeifupwkfbxa4c4jogpudvzwt5rkgfuedgd65sj2bf2z5ver4phq64m
-- valory/check_stop_trading_abci:0.1.0:bafybeignl5w4o4ghcpan7nsor5elvuid4si7t4rnfqga47bwvlgp22xwsa
-- valory/mech_interact_abci:0.1.0:bafybeigkizx3ecohtyshr6tq55zvp4sl5cou344a2t6nvwfgund4xnrj4a
+- valory/check_stop_trading_abci:0.1.0:bafybeibb4gq5u4w6dmabdgsaffsispamxbgkm27oc3llclyvtwezc3df5q
+- valory/mech_interact_abci:0.1.0:bafybeib6hw4c6u56j2xrfdj6vsr27ppkpzmsmrlflhsvkq42ifol45crni
 behaviours:
   main:
     args: {}

--- a/packages/valory/skills/tx_settlement_multiplexer_abci/skill.yaml
+++ b/packages/valory/skills/tx_settlement_multiplexer_abci/skill.yaml
@@ -23,9 +23,9 @@ protocols:
 - valory/ledger_api:1.0.0:bafybeihmqzcbj6t7vxz2aehd5726ofnzsfjs5cwlf42ro4tn6i34cbfrc4
 skills:
 - valory/abstract_round_abci:0.1.0:bafybeiey45kkbniukmtpdjduwazpyygaiayeo7mh3tu6wfbau2bxvuljmy
-- valory/decision_maker_abci:0.1.0:bafybeidnk3j46n57yuytiyxidcexvp6htymwbgxduxwhqrofqupsdro2ii
+- valory/decision_maker_abci:0.1.0:bafybeigrsirmazw5dgsr7cpi4j7l6nxfwz4i4pyjgljo57txnbh5mt2jx4
 - valory/staking_abci:0.1.0:bafybeifupwkfbxa4c4jogpudvzwt5rkgfuedgd65sj2bf2z5ver4phq64m
-- valory/mech_interact_abci:0.1.0:bafybeib6hw4c6u56j2xrfdj6vsr27ppkpzmsmrlflhsvkq42ifol45crni
+- valory/mech_interact_abci:0.1.0:bafybeibxvbgtj5pi24e2fh7kskdcv72buevqzaykw4lirkr4n7qn5ba2re
 behaviours:
   main:
     args: {}

--- a/packages/valory/skills/tx_settlement_multiplexer_abci/skill.yaml
+++ b/packages/valory/skills/tx_settlement_multiplexer_abci/skill.yaml
@@ -23,9 +23,9 @@ protocols:
 - valory/ledger_api:1.0.0:bafybeihmqzcbj6t7vxz2aehd5726ofnzsfjs5cwlf42ro4tn6i34cbfrc4
 skills:
 - valory/abstract_round_abci:0.1.0:bafybeiey45kkbniukmtpdjduwazpyygaiayeo7mh3tu6wfbau2bxvuljmy
-- valory/decision_maker_abci:0.1.0:bafybeiczwgfwcm5uytezv2upsbvzpkjpiv4etp5bkz4osvo7zgef6xwvwa
+- valory/decision_maker_abci:0.1.0:bafybeidnk3j46n57yuytiyxidcexvp6htymwbgxduxwhqrofqupsdro2ii
 - valory/staking_abci:0.1.0:bafybeifupwkfbxa4c4jogpudvzwt5rkgfuedgd65sj2bf2z5ver4phq64m
-- valory/mech_interact_abci:0.1.0:bafybeigkizx3ecohtyshr6tq55zvp4sl5cou344a2t6nvwfgund4xnrj4a
+- valory/mech_interact_abci:0.1.0:bafybeib6hw4c6u56j2xrfdj6vsr27ppkpzmsmrlflhsvkq42ifol45crni
 behaviours:
   main:
     args: {}


### PR DESCRIPTION
```
        "contract/valory/mech_marketplace/0.1.0": "bafybeibrojfogyvfv5pvcozjvjks7hfhsqmxzuod7cdkkqzybv376bpysu",
        "skill/valory/mech_interact_abci/0.1.0": "bafybeibxvbgtj5pi24e2fh7kskdcv72buevqzaykw4lirkr4n7qn5ba2re"
```

To build this version we had to move both to the `dev` packages, apply the change locally, lock hashes, push them to IPFS and then return packages back to the third_party. As we had some problems with using hash directly. 

This version contains a variant of the fix which uses`data` here. 
https://github.com/valory-xyz/mech-interact/blob/main/packages/valory/contracts/mech_marketplace/contract.py#L197
