### PR TITLE
removing tools with bad performance

### DIFF
--- a/packages/packages.json
+++ b/packages/packages.json
@@ -21,9 +21,9 @@
         "skill/valory/tx_settlement_multiplexer_abci/0.1.0": "bafybeicse7mucign56twhsfg2faek7fqk7kpltt6alzmowo5ywtmazudky",
         "skill/valory/staking_abci/0.1.0": "bafybeifupwkfbxa4c4jogpudvzwt5rkgfuedgd65sj2bf2z5ver4phq64m",
         "skill/valory/check_stop_trading_abci/0.1.0": "bafybeibb4gq5u4w6dmabdgsaffsispamxbgkm27oc3llclyvtwezc3df5q",
-        "agent/valory/trader/0.1.0": "bafybeigjkxarqcmilwcj23ucsrahgoafvohomv7s6uiqttjdooqocjztea",
-        "service/valory/trader/0.1.0": "bafybeigavavxqzph4chfiperwo4ygmoekmgbgwwtlxggt43w7mgdyctq64",
-        "service/valory/trader_pearl/0.1.0": "bafybeidugmpnwbxyfe74dli7cgs27kjwirvlw2ufqeuyqqbrbzktoklfsi"
+        "agent/valory/trader/0.1.0": "bafybeiephzhu7unfg47jegmpnyglfa5iu3om3mxqncs5p5vwjvgbrb4gca",
+        "service/valory/trader/0.1.0": "bafybeicy64qyvlxupiiwceek37ikhgjhkyu6reseswwvnyd4epffagrj5e",
+        "service/valory/trader_pearl/0.1.0": "bafybeicbik42c26myvbzglgfptzx3yupxyz4raalampkpo6vfrsm3pptpq"
     },
     "third_party": {
         "protocol/valory/acn_data_share/0.1.0": "bafybeih5ydonnvrwvy2ygfqgfabkr47s4yw3uqxztmwyfprulwfsoe7ipq",

--- a/packages/valory/agents/trader/aea-config.yaml
+++ b/packages/valory/agents/trader/aea-config.yaml
@@ -225,7 +225,8 @@ models:
       irrelevant_tools: ${list:["openai-text-davinci-002", "openai-text-davinci-003",
         "openai-gpt-3.5-turbo", "openai-gpt-4", "stabilityai-stable-diffusion-v1-5",
         "stabilityai-stable-diffusion-xl-beta-v2-2-2", "stabilityai-stable-diffusion-512-v2-1",
-        "stabilityai-stable-diffusion-768-v2-1"]}
+        "stabilityai-stable-diffusion-768-v2-1", "prediction-offline-sme", "prediction-url-cot-claude",
+        "prediction-url-cot"]}
       use_nevermined: ${bool:true}
       mech_to_subscription_params: ${dict:{"base_url":"https://marketplace-api.gnosis.nevermined.app/api/v1/metadata/assets/ddo",
         "did":"did:nv:01706149da2f9f3f67cf79ec86c37d63cec87fc148f5633b12bf6695653d5b3c",

--- a/packages/valory/services/trader/service.yaml
+++ b/packages/valory/services/trader/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeigtuothskwyvrhfosps2bu6suauycolj67dpuxqvnicdrdu7yhtvq
 fingerprint_ignore_patterns: []
-agent: valory/trader:0.1.0:bafybeigjkxarqcmilwcj23ucsrahgoafvohomv7s6uiqttjdooqocjztea
+agent: valory/trader:0.1.0:bafybeiephzhu7unfg47jegmpnyglfa5iu3om3mxqncs5p5vwjvgbrb4gca
 number_of_agents: 4
 deployment:
   agent:
@@ -117,7 +117,8 @@ type: skill
         irrelevant_tools: ${IRRELEVANT_TOOLS:list:["openai-text-davinci-002", "openai-text-davinci-003",
           "openai-gpt-3.5-turbo", "openai-gpt-4", "stabilityai-stable-diffusion-v1-5",
           "stabilityai-stable-diffusion-xl-beta-v2-2-2", "stabilityai-stable-diffusion-512-v2-1",
-          "stabilityai-stable-diffusion-768-v2-1"]}
+          "stabilityai-stable-diffusion-768-v2-1", "prediction-offline-sme", "prediction-url-cot-claude",
+          "prediction-url-cot"]}
         staking_contract_address: ${STAKING_CONTRACT_ADDRESS:str:0x2Ef503950Be67a98746F484DA0bBAdA339DF3326}
         staking_interaction_sleep_time: ${STAKING_INTERACTION_SLEEP_TIME:int:5}
         disable_trading: ${DISABLE_TRADING:bool:false}

--- a/packages/valory/services/trader_pearl/service.yaml
+++ b/packages/valory/services/trader_pearl/service.yaml
@@ -8,7 +8,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeibg7bdqpioh4lmvknw3ygnllfku32oca4eq5pqtvdrdsgw6buko7e
 fingerprint_ignore_patterns: []
-agent: valory/trader:0.1.0:bafybeigjkxarqcmilwcj23ucsrahgoafvohomv7s6uiqttjdooqocjztea
+agent: valory/trader:0.1.0:bafybeiephzhu7unfg47jegmpnyglfa5iu3om3mxqncs5p5vwjvgbrb4gca
 number_of_agents: 1
 deployment:
   agent:
@@ -116,7 +116,7 @@ models:
       policy_epsilon: ${POLICY_EPSILON:float:0.25}
       store_path: ${STORE_PATH:str:/data/}
       irrelevant_tools: ${IRRELEVANT_TOOLS:list:["native-transfer","prediction-online-lite","claude-prediction-online-lite","prediction-online-sme-lite","prediction-request-reasoning-lite","prediction-request-reasoning-claude-lite","prediction-offline-sme","deepmind-optimization",
-        "deepmind-optimization-strong","openai-gpt-3.5-turbo","openai-gpt-3.5-turbo-instruct","openai-gpt-4","openai-text-davinci-002","openai-text-davinci-003","prediction-online-sum-url-content","prediction-online-summarized-info","stabilityai-stable-diffusion-512-v2-1","stabilityai-stable-diffusion-768-v2-1","stabilityai-stable-diffusion-v1-5","stabilityai-stable-diffusion-xl-beta-v2-2-2"]}
+        "deepmind-optimization-strong","openai-gpt-3.5-turbo","openai-gpt-3.5-turbo-instruct","openai-gpt-4","openai-text-davinci-002","openai-text-davinci-003","prediction-online-sum-url-content","prediction-online-summarized-info","stabilityai-stable-diffusion-512-v2-1","stabilityai-stable-diffusion-768-v2-1","stabilityai-stable-diffusion-v1-5","stabilityai-stable-diffusion-xl-beta-v2-2-2","prediction-url-cot-claude","prediction-url-cot"]}
       staking_contract_address: ${STAKING_CONTRACT_ADDRESS:str:0x0000000000000000000000000000000000000000}
       staking_interaction_sleep_time: ${STAKING_INTERACTION_SLEEP_TIME:int:5}
       disable_trading: ${DISABLE_TRADING:bool:false}


### PR DESCRIPTION
After latest accuracy computation we found there are two tools not performing well so we are going to remove them from the options available to the traders.

The tools are:
prediction-offline-sme
prediction-url-cot-claude
prediction-url-cot