### PR TITLE
fix(1): weighted accuracy weights

### DIFF
--- a/packages/packages.json
+++ b/packages/packages.json
@@ -16,14 +16,14 @@
         "contract/valory/relayer/0.1.0": "bafybeihypuljybkocl6iiacy52py7i5iqxdli3ily66q7b3nego4qajvne",
         "contract/valory/market_maker/0.1.0": "bafybeigzfyzbixum5cqvcbyc24dqwce25dr6nyqvgjm2eqpt6tgo2perd4",
         "skill/valory/market_manager_abci/0.1.0": "bafybeif3zwrjq6suryleltxd3vkta5zeiczyrzpgsbwjlpo26g2gfxf4iq",
-        "skill/valory/decision_maker_abci/0.1.0": "bafybeigkgckbouyrwxz5xlghe67grkfxfouncfo5kfx4fbqjhj4zfk6dsm",
-        "skill/valory/trader_abci/0.1.0": "bafybeicl6x5vpb255xusjmnejmwei45s4cdrpq7skrl6e6qbz6juwlka7y",
-        "skill/valory/tx_settlement_multiplexer_abci/0.1.0": "bafybeieqlxslnt7fuy3x2xwzbig4dkjwgyz7q7rrjlskhcaxzok6fgntv4",
+        "skill/valory/decision_maker_abci/0.1.0": "bafybeib2ddd7dekivmneujo6pr6prtbrtztz2z3e7dm6jbuoljiaunjtxa",
+        "skill/valory/trader_abci/0.1.0": "bafybeiddhexjfyywieoh2kjriltqlhhay55q6kdrplrk5tpyszjyct2aa4",
+        "skill/valory/tx_settlement_multiplexer_abci/0.1.0": "bafybeiffx7l5yooxvgo3u6idighcvqp72scwt5nk5engo5ikdg4istb5c4",
         "skill/valory/staking_abci/0.1.0": "bafybeifupwkfbxa4c4jogpudvzwt5rkgfuedgd65sj2bf2z5ver4phq64m",
         "skill/valory/check_stop_trading_abci/0.1.0": "bafybeifcc2dkyijmzuwli2ovg72ypmx6vplj3klgxcblnwvyxz3t4jfcpy",
-        "agent/valory/trader/0.1.0": "bafybeig2ued5fzjpxf5g5girkyrxe3mki7ynjto4u3aivefqf4bhc7qkg4",
-        "service/valory/trader/0.1.0": "bafybeialbj4pe543o365ml3loakjnlblkg7wksbvohquvjshpoxolpgzsm",
-        "service/valory/trader_pearl/0.1.0": "bafybeifhxeoar5hdwilmnzhy6jf664zqp5lgrzi6lpbkc4qmoqrr24ow4q"
+        "agent/valory/trader/0.1.0": "bafybeial3c65yci556ujqrfxr2poxdq7aokwzfschd4xu2xofixxcetmrm",
+        "service/valory/trader/0.1.0": "bafybeie7grgtbddkau5ttvxlb6g3pbdigoghnq3rbubbkpulrw54cqschm",
+        "service/valory/trader_pearl/0.1.0": "bafybeide5p2v6xvopooqz3qyexse67uqswh4uhljzqkifj3u3t5wenc43y"
     },
     "third_party": {
         "protocol/valory/acn_data_share/0.1.0": "bafybeih5ydonnvrwvy2ygfqgfabkr47s4yw3uqxztmwyfprulwfsoe7ipq",

--- a/packages/valory/agents/trader/aea-config.yaml
+++ b/packages/valory/agents/trader/aea-config.yaml
@@ -55,10 +55,10 @@ skills:
 - valory/reset_pause_abci:0.1.0:bafybeiachgo6reit2q4jw75mefw2acj4ldedeqmn3rewjm4dbzts2l7oxe
 - valory/termination_abci:0.1.0:bafybeibtbboau3q5fxfviwm7lbeix4z55uptfqqiyiu6siivxwkp3o5pju
 - valory/transaction_settlement_abci:0.1.0:bafybeic2ywzpwkyeqbzsvkbvurhsptemam4xtceihax2tmxmlxtgd3xpya
-- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeieqlxslnt7fuy3x2xwzbig4dkjwgyz7q7rrjlskhcaxzok6fgntv4
+- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeiffx7l5yooxvgo3u6idighcvqp72scwt5nk5engo5ikdg4istb5c4
 - valory/market_manager_abci:0.1.0:bafybeif3zwrjq6suryleltxd3vkta5zeiczyrzpgsbwjlpo26g2gfxf4iq
-- valory/decision_maker_abci:0.1.0:bafybeigkgckbouyrwxz5xlghe67grkfxfouncfo5kfx4fbqjhj4zfk6dsm
-- valory/trader_abci:0.1.0:bafybeicl6x5vpb255xusjmnejmwei45s4cdrpq7skrl6e6qbz6juwlka7y
+- valory/decision_maker_abci:0.1.0:bafybeib2ddd7dekivmneujo6pr6prtbrtztz2z3e7dm6jbuoljiaunjtxa
+- valory/trader_abci:0.1.0:bafybeiddhexjfyywieoh2kjriltqlhhay55q6kdrplrk5tpyszjyct2aa4
 - valory/staking_abci:0.1.0:bafybeifupwkfbxa4c4jogpudvzwt5rkgfuedgd65sj2bf2z5ver4phq64m
 - valory/check_stop_trading_abci:0.1.0:bafybeifcc2dkyijmzuwli2ovg72ypmx6vplj3klgxcblnwvyxz3t4jfcpy
 - valory/mech_interact_abci:0.1.0:bafybeihwuhjifsksoht35q6wk2qwwkzsqvo6sjgzwapyeg2wr7w2lpjp3m

--- a/packages/valory/services/trader/service.yaml
+++ b/packages/valory/services/trader/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeigtuothskwyvrhfosps2bu6suauycolj67dpuxqvnicdrdu7yhtvq
 fingerprint_ignore_patterns: []
-agent: valory/trader:0.1.0:bafybeig2ued5fzjpxf5g5girkyrxe3mki7ynjto4u3aivefqf4bhc7qkg4
+agent: valory/trader:0.1.0:bafybeial3c65yci556ujqrfxr2poxdq7aokwzfschd4xu2xofixxcetmrm
 number_of_agents: 4
 deployment:
   agent:

--- a/packages/valory/services/trader_pearl/service.yaml
+++ b/packages/valory/services/trader_pearl/service.yaml
@@ -8,7 +8,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeibg7bdqpioh4lmvknw3ygnllfku32oca4eq5pqtvdrdsgw6buko7e
 fingerprint_ignore_patterns: []
-agent: valory/trader:0.1.0:bafybeig2ued5fzjpxf5g5girkyrxe3mki7ynjto4u3aivefqf4bhc7qkg4
+agent: valory/trader:0.1.0:bafybeial3c65yci556ujqrfxr2poxdq7aokwzfschd4xu2xofixxcetmrm
 number_of_agents: 1
 deployment:
   agent:

--- a/packages/valory/skills/decision_maker_abci/policy.py
+++ b/packages/valory/skills/decision_maker_abci/policy.py
@@ -30,7 +30,7 @@ from packages.valory.skills.decision_maker_abci.utils.scaling import scale_value
 
 RandomnessType = Union[int, float, str, bytes, bytearray, None]
 
-VOLUME_FACTOR_REGULARIZATION = 0.25
+VOLUME_FACTOR_REGULARIZATION = 0.1
 UNSCALED_WEIGHTED_ACCURACY_INTERVAL = (-0.5, 80.5)
 SCALED_WEIGHTED_ACCURACY_INTERVAL = (0, 1)
 

--- a/packages/valory/skills/decision_maker_abci/skill.yaml
+++ b/packages/valory/skills/decision_maker_abci/skill.yaml
@@ -35,7 +35,7 @@ fingerprint:
   io_/loader.py: bafybeih3sdsx5dhe4kzhtoafexjgkutsujwqy3zcdrlrkhtdks45bc7exa
   models.py: bafybeihp2tw5zpvx2huingqfgcr5bssxn5bogxdchlxdwx56jhkbetvdge
   payloads.py: bafybeiadhhiabu2tyszy5oijpxbf2iwovw3g4v7lkihcgpjimrmo4cafiu
-  policy.py: bafybeigmstzp26no6lg2hcsusaybpdidzqgek4wc6hzay4zg4ybjjbij44
+  policy.py: bafybeig5dnlwua4pzyz74rifkauuu2xvrusuwkqfsvetbh7trp3kzkpdyq
   redeem_info.py: bafybeifiiix4gihfo4avraxt34sfw35v6dqq45do2drrssei2shbps63mm
   rounds.py: bafybeiam6tej3klskwa4bsrjtaqozc6iawa4cgqbcalewy5nloqqbsjsni
   rounds_info.py: bafybeig66zkrefk2di2feq5n55jlc6iyofpernq56o37pytgsllpxhrfiy
@@ -80,6 +80,7 @@ fingerprint:
   tests/test_dialogues.py: bafybeibulo64tgfrq4e5qbcqnmifrlehkqciwuavublints353zaj2mlpa
   tests/test_handlers.py: bafybeihpkgtjjm3uegpup6zkznpoaxqpu6kmp3ujiggrzbe73p5fzlq7im
   tests/test_payloads.py: bafybeiagxnhi6cllwu6u67ehfjcj2ucoygfsxgivvj2ecpggsobywro5ye
+  tests/test_policy.py: bafybeicam5j67poflsqz7mrifenzh2l4cj6u4xcekoakhksfunvmkmcfci
   tests/test_rounds.py: bafybeih3y5abfrt7p3xnji4n24ngbmpd3xsgo5v552o2ns7t4k6hyw3xgi
   utils/__init__.py: bafybeiazrfg3kwfdl5q45azwz6b6mobqxngxpf4hazmrnkhinpk4qhbbf4
   utils/general.py: bafybeidklil35bhvew7556zv3rohbruwkxe7d7n2qnbrohunfalw2okigm

--- a/packages/valory/skills/decision_maker_abci/tests/test_policy.py
+++ b/packages/valory/skills/decision_maker_abci/tests/test_policy.py
@@ -1,0 +1,175 @@
+# -*- coding: utf-8 -*-
+# ------------------------------------------------------------------------------
+#
+#   Copyright 2025 Valory AG
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ------------------------------------------------------------------------------
+
+"""This module contains the test for utils of decision maker"""
+
+import pytest
+
+from packages.valory.skills.decision_maker_abci.policy import (
+    AccuracyInfo,
+    ConsecutiveFailures,
+    EGreedyPolicy,
+)
+
+
+@pytest.fixture
+def e_greedy_policy_mock() -> EGreedyPolicy:
+    """Mock the e greedy policy."""
+    return EGreedyPolicy(
+        eps=0.25,
+        consecutive_failures_threshold=2,
+        quarantine_duration=10800,
+        accuracy_store={
+            "claude-prediction-offline": AccuracyInfo(
+                accuracy=0.57965, pending=-8, requests=521
+            ),
+            "claude-prediction-online": AccuracyInfo(
+                accuracy=0.58541, pending=-2, requests=521
+            ),
+            "prediction-offline": AccuracyInfo(
+                accuracy=0.60845, pending=-26, requests=521
+            ),
+            "prediction-online": AccuracyInfo(
+                accuracy=0.62188, pending=-44, requests=521
+            ),
+            "prediction-online-sme": AccuracyInfo(
+                accuracy=0.54894, pending=0, requests=521
+            ),
+            "prediction-request-rag": AccuracyInfo(
+                accuracy=0.57965, pending=-6, requests=521
+            ),
+            "prediction-request-reasoning": AccuracyInfo(
+                accuracy=0.66411, pending=-1, requests=521
+            ),
+        },
+        consecutive_failures={
+            "claude-prediction-offline": ConsecutiveFailures(
+                n_failures=0, timestamp=1756130390
+            ),
+            "claude-prediction-online": ConsecutiveFailures(
+                n_failures=0, timestamp=1755469100
+            ),
+            "prediction-offline": ConsecutiveFailures(
+                n_failures=0, timestamp=1755900057
+            ),
+            "prediction-online": ConsecutiveFailures(
+                n_failures=0, timestamp=1755707431
+            ),
+            "prediction-online-sme": ConsecutiveFailures(
+                n_failures=0, timestamp=1755707833
+            ),
+            "prediction-request-rag": ConsecutiveFailures(
+                n_failures=0, timestamp=1755708069
+            ),
+            "prediction-request-reasoning": ConsecutiveFailures(
+                n_failures=0, timestamp=1756202233
+            ),
+        },
+        weighted_accuracy={
+            "claude-prediction-offline": 0.0137876404494382,
+            "claude-prediction-online": 0.0138535497295048,
+            "prediction-offline": 0.0141588014981273,
+            "prediction-online": 0.0143402094603967,
+            "prediction-online-sme": 0.013401568872243,
+            "prediction-request-rag": 0.0137859065057567,
+            "prediction-request-reasoning": 0.0148242876959356,
+        },
+        updated_ts=1756201545,
+    )
+
+
+def test_e_greedy_policy_select_tool_default(
+    e_greedy_policy_mock: EGreedyPolicy,
+) -> None:
+    """Test the default tool selection. Selects the value with biggest weighted accuracy."""
+    best_tool = e_greedy_policy_mock.best_tool
+    assert best_tool == "prediction-request-reasoning"
+
+
+def test_e_greedy_policy_select_tool_randomness(
+    e_greedy_policy_mock: EGreedyPolicy,
+) -> None:
+    """Test the tool selection with randomness. Selects the value with biggest weighted accuracy."""
+    randomness = 1234567890
+    best_tool = e_greedy_policy_mock.select_tool(randomness)
+    assert best_tool == "prediction-request-reasoning"
+
+
+def test_e_greedy_policy_select_tool_weighted_accuracy_zero(
+    e_greedy_policy_mock: EGreedyPolicy,
+) -> None:
+    """Test the tool selection with weighted accuracy near zero. Value would be selected regardles of other tools"""
+    e_greedy_policy_mock.weighted_accuracy.update(
+        {"prediction-request-reasoning": 0.00000000001}
+    )
+    e_greedy_policy_mock.update_weighted_accuracy()
+
+    best_tool = e_greedy_policy_mock.best_tool
+    assert best_tool == "prediction-request-reasoning"
+
+
+def test_e_greedy_policy_select_tool_weighted_accuracy_biggest(
+    e_greedy_policy_mock: EGreedyPolicy,
+) -> None:
+    """Test the tool selection with weighted accuracy biggest. Value would be selected regardles of other tools"""
+    e_greedy_policy_mock.weighted_accuracy.update({"prediction-request-rag": 0.95})
+    e_greedy_policy_mock.update_weighted_accuracy()
+
+    best_tool = e_greedy_policy_mock.best_tool
+    assert best_tool == "prediction-request-reasoning"
+
+
+def test_e_greedy_policy_select_tool_weighted_accuracy_calls_increased(
+    e_greedy_policy_mock: EGreedyPolicy,
+) -> None:
+    """Test the tool selection with weighted accuracy calls decreased. Value would be selected"""
+    e_greedy_policy_mock.accuracy_store.update(
+        {
+            "prediction-request-rag": AccuracyInfo(
+                accuracy=0.57965, pending=-6, requests=5021
+            ),
+            "prediction-request-reasoning": AccuracyInfo(
+                accuracy=0.66411, pending=-6, requests=1021
+            ),
+        }
+    )
+    e_greedy_policy_mock.update_weighted_accuracy()
+
+    best_tool = e_greedy_policy_mock.best_tool
+    assert best_tool == "prediction-request-reasoning"
+
+
+def test_e_greedy_policy_select_tool_weighted_accuracy_calls_decreased(
+    e_greedy_policy_mock: EGreedyPolicy,
+) -> None:
+    """Test the tool selection with weighted accuracy calls decreased. Value would be selected"""
+    e_greedy_policy_mock.accuracy_store.update(
+        {
+            "prediction-request-rag": AccuracyInfo(
+                accuracy=0.57965, pending=-6, requests=5021
+            ),
+            "prediction-request-reasoning": AccuracyInfo(
+                accuracy=0.66411, pending=-6, requests=521
+            ),
+        }
+    )
+    e_greedy_policy_mock.update_weighted_accuracy()
+
+    best_tool = e_greedy_policy_mock.best_tool
+    assert best_tool == "prediction-request-reasoning"

--- a/packages/valory/skills/trader_abci/skill.yaml
+++ b/packages/valory/skills/trader_abci/skill.yaml
@@ -39,8 +39,8 @@ skills:
 - valory/transaction_settlement_abci:0.1.0:bafybeic2ywzpwkyeqbzsvkbvurhsptemam4xtceihax2tmxmlxtgd3xpya
 - valory/termination_abci:0.1.0:bafybeibtbboau3q5fxfviwm7lbeix4z55uptfqqiyiu6siivxwkp3o5pju
 - valory/market_manager_abci:0.1.0:bafybeif3zwrjq6suryleltxd3vkta5zeiczyrzpgsbwjlpo26g2gfxf4iq
-- valory/decision_maker_abci:0.1.0:bafybeigkgckbouyrwxz5xlghe67grkfxfouncfo5kfx4fbqjhj4zfk6dsm
-- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeieqlxslnt7fuy3x2xwzbig4dkjwgyz7q7rrjlskhcaxzok6fgntv4
+- valory/decision_maker_abci:0.1.0:bafybeib2ddd7dekivmneujo6pr6prtbrtztz2z3e7dm6jbuoljiaunjtxa
+- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeiffx7l5yooxvgo3u6idighcvqp72scwt5nk5engo5ikdg4istb5c4
 - valory/staking_abci:0.1.0:bafybeifupwkfbxa4c4jogpudvzwt5rkgfuedgd65sj2bf2z5ver4phq64m
 - valory/check_stop_trading_abci:0.1.0:bafybeifcc2dkyijmzuwli2ovg72ypmx6vplj3klgxcblnwvyxz3t4jfcpy
 - valory/mech_interact_abci:0.1.0:bafybeihwuhjifsksoht35q6wk2qwwkzsqvo6sjgzwapyeg2wr7w2lpjp3m

--- a/packages/valory/skills/tx_settlement_multiplexer_abci/skill.yaml
+++ b/packages/valory/skills/tx_settlement_multiplexer_abci/skill.yaml
@@ -23,7 +23,7 @@ protocols:
 - valory/ledger_api:1.0.0:bafybeihmqzcbj6t7vxz2aehd5726ofnzsfjs5cwlf42ro4tn6i34cbfrc4
 skills:
 - valory/abstract_round_abci:0.1.0:bafybeiey45kkbniukmtpdjduwazpyygaiayeo7mh3tu6wfbau2bxvuljmy
-- valory/decision_maker_abci:0.1.0:bafybeigkgckbouyrwxz5xlghe67grkfxfouncfo5kfx4fbqjhj4zfk6dsm
+- valory/decision_maker_abci:0.1.0:bafybeib2ddd7dekivmneujo6pr6prtbrtztz2z3e7dm6jbuoljiaunjtxa
 - valory/staking_abci:0.1.0:bafybeifupwkfbxa4c4jogpudvzwt5rkgfuedgd65sj2bf2z5ver4phq64m
 - valory/mech_interact_abci:0.1.0:bafybeihwuhjifsksoht35q6wk2qwwkzsqvo6sjgzwapyeg2wr7w2lpjp3m
 behaviours:

--- a/tox.ini
+++ b/tox.ini
@@ -165,7 +165,9 @@ commands = {[commands-packages]commands}
 [testenv:bandit]
 skipsdist = True
 skip_install = True
-deps = tomte[bandit]==0.2.17
+deps =
+    tomte[bandit]==0.2.17
+    pbr
 commands =
     bandit -s B101 -r {env:SERVICE_SPECIFIC_PACKAGES}
     bandit -s B101 -r scripts


### PR DESCRIPTION
This PR introduced a small change related to the weight of selected tools. The new accuracy hash contains best best-picked tools, and existing user history might affect a tool selection depending on the historical amount of requests. 

In this PR, I changed the value from `0.25` to `0.1`, decreasing the weight by almost 2.5 times. 
It resulted in the expected behaviour, which is described in the `test_e_greedy_policy_select_tool_weighted_accuracy_calls_decreased ` test.

For a situation like this, the selected tool would still be `prediction-request-reasoning`, as it has the higher accuracy. If we change back the `VOLUME_FACTOR_REGULARIZATION =0.25` then the `prediction-request-rag` would be selected

```
e_greedy_policy_mock.accuracy_store.update(
        {
            "prediction-request-rag": AccuracyInfo(
                accuracy=0.57965, pending=-6, requests=5021
            ),
            "prediction-request-reasoning": AccuracyInfo(
                accuracy=0.66411, pending=-6, requests=521
            ),
        }
```