### PR TITLE
hotfix: redeeming positions

### DIFF
--- a/packages/valory/skills/decision_maker_abci/behaviours/reedem.py
+++ b/packages/valory/skills/decision_maker_abci/behaviours/reedem.py
@@ -539,8 +539,10 @@ class RedeemBehaviour(RedeemInfoBehaviour):
 
         payouts = self.redeeming_progress.payouts
         payouts_amount = sum(payouts.values())
+        zero_payouts = {condition_id: payout for condition_id, payout in payouts.items() if payout == 0}
+
         if payouts_amount > 0:
-            self.redeemed_condition_ids |= set(payouts.keys())
+            self.redeemed_condition_ids |= set(zero_payouts.keys())
             if self.params.use_subgraph_for_redeeming:
                 self.payout_so_far = payouts_amount
             else:
@@ -816,7 +818,7 @@ class RedeemBehaviour(RedeemInfoBehaviour):
             condition_id = redeem_candidate.fpmm.condition.id.hex().lower()
             if (
                 condition_id not in self.redeeming_progress.unredeemed_trades
-                or self.redeeming_progress.unredeemed_trades[condition_id] == 0
+                or self.redeeming_progress.unredeemed_trades.get(condition_id, None) == 0
             ):
                 return False
 

--- a/packages/valory/skills/market_manager_abci/graph_tooling/queries/conditional_tokens.py
+++ b/packages/valory/skills/market_manager_abci/graph_tooling/queries/conditional_tokens.py
@@ -41,7 +41,10 @@ user_positions = Template(
                     lifetimeValue
                     indexSets
                     conditions {
+                        id
                         outcomes
+                        payoutDenominator
+                        payoutNumerators
                     }
                 }
                 totalBalance

--- a/packages/valory/skills/market_manager_abci/graph_tooling/utils.py
+++ b/packages/valory/skills/market_manager_abci/graph_tooling/utils.py
@@ -71,9 +71,19 @@ def get_position_lifetime_value(
 ) -> int:
     """Get the balance of a position."""
     for position in user_positions:
-        position_condition_ids = position["position"]["conditionIds"]
+        position_condition_ids = map(lambda x: x.lower(), position["position"]["conditionIds"])
         balance = int(position["position"]["lifetimeValue"])
-        if condition_id.lower() in position_condition_ids:
+
+        matching_positions = []
+
+        for condition in position["position"]["conditions"]:
+            if condition["id"].lower() == condition_id.lower():
+                # if position is claimed, balance is 0
+                balance = int(position["totalBalance"])
+                if balance > 0:
+                    matching_positions.append(condition)
+
+        if condition_id.lower() in position_condition_ids and len(matching_positions) > 0:
             return balance
 
     return 0

--- a/packages/valory/skills/market_manager_abci/graph_tooling/utils.py
+++ b/packages/valory/skills/market_manager_abci/graph_tooling/utils.py
@@ -156,6 +156,8 @@ def get_condition_id_to_balances(
                 payout = get_position_lifetime_value(user_positions, condition_id)
                 if payout > 0 and balance[str(outcome_index)] == 0:
                     condition_id_to_payout[condition_id] = payout
+                    # if position is not claimed, balance is the payout
+                    condition_id_to_balance[condition_id] = payout
 
     return condition_id_to_payout, condition_id_to_balance
 

--- a/packages/valory/skills/market_manager_abci/tests/test_utils.py
+++ b/packages/valory/skills/market_manager_abci/tests/test_utils.py
@@ -28,6 +28,7 @@ from packages.valory.skills.market_manager_abci.bets import (
     QueueStatus,
     serialize_bets,
 )
+from packages.valory.skills.market_manager_abci.graph_tooling.utils import get_position_lifetime_value
 
 
 @pytest.mark.parametrize(
@@ -65,3 +66,52 @@ from packages.valory.skills.market_manager_abci.bets import (
 def test_serialize_bets(bets: List[Bet], expected: str) -> None:
     """Test the serialize_bets function."""
     assert serialize_bets(bets) == expected
+
+
+def test_get_position_lifetime_value_claimed() -> None:
+    """Test the get_position_lifetime_value function."""
+
+    condition_id = "0x1"
+    user_positions = [
+        {
+            "position": {
+                "conditionIds": [condition_id],
+                "lifetimeValue": "36587407016997229890",
+                "conditions": [
+                    {
+                        "id": condition_id,
+                        "outcomes": ["Yes", "No"],
+                        "payoutDenominator": 100,
+                        "payoutNumerators": [100, 100],
+                    }
+                ]
+            },
+            "totalBalance": "0",
+        }
+    ]
+
+
+    assert get_position_lifetime_value(user_positions, condition_id) == 0
+
+def test_get_position_lifetime_value_unclaimed() -> None:
+    """Test the get_position_lifetime_value function."""
+
+    condition_id = "0x1"
+    user_positions = [
+        {
+            "position": {
+                "conditionIds": [condition_id],
+                "lifetimeValue": "25556977789032118615",
+                "conditions": [
+                    {
+                        "id": condition_id,
+                        "outcomes": ["Yes", "No"],
+                        "payoutDenominator": 100,
+                        "payoutNumerators": [100, 100],
+                    }
+                ]
+            },
+            "totalBalance": "2238183507853351332",
+        }
+    ]
+    assert get_position_lifetime_value(user_positions, condition_id) == 2238183507853351332

--- a/packages/valory/skills/market_manager_abci/tests/test_utils.py
+++ b/packages/valory/skills/market_manager_abci/tests/test_utils.py
@@ -28,7 +28,7 @@ from packages.valory.skills.market_manager_abci.bets import (
     QueueStatus,
     serialize_bets,
 )
-from packages.valory.skills.market_manager_abci.graph_tooling.utils import get_position_lifetime_value
+from packages.valory.skills.market_manager_abci.graph_tooling.utils import get_position_lifetime_value, get_condition_id_to_balances
 
 
 @pytest.mark.parametrize(
@@ -93,6 +93,7 @@ def test_get_position_lifetime_value_claimed() -> None:
 
     assert get_position_lifetime_value(user_positions, condition_id) == 0
 
+
 def test_get_position_lifetime_value_unclaimed() -> None:
     """Test the get_position_lifetime_value function."""
 
@@ -115,3 +116,50 @@ def test_get_position_lifetime_value_unclaimed() -> None:
         }
     ]
     assert get_position_lifetime_value(user_positions, condition_id) == 2238183507853351332
+
+
+def test_get_condition_id_to_balances() -> None:
+    """Test the get_condition_id_to_balances function."""
+
+    condition_id = "0x1"
+    trades = [
+        {
+            "outcomeIndex": 0,
+            "fpmm": {
+                "id": "0x1",
+                "currentAnswer": "0x0",
+                "answerFinalizedTimestamp": "1754092800",
+                "isPendingArbitration": False,
+                "condition": {
+                    "id": condition_id,
+                },
+                "openingTimestamp": "1754092800",
+            }
+        }
+    ]
+    user_positions = [
+        {
+            "position": {
+                "indexSets": ["0"],
+                "conditionIds": [condition_id],
+                "lifetimeValue": "2238183507853351332",
+                "balance": "2238183507853351332",
+                "conditions": [
+                    {
+                        "id": condition_id,
+                        "outcomes": ["Yes", "No"],
+                        "payoutDenominator": 100,
+                        "payoutNumerators": [100, 100],
+                    }
+                ]
+            },
+            "balance": "2238183507853351332",
+            "totalBalance": "2238183507853351332",
+        }
+    ]
+
+    condition_to_payout, condition_to_balance = get_condition_id_to_balances(trades, user_positions)
+
+    # needs to be presented in both
+    assert condition_to_payout[condition_id] == 2238183507853351332
+    assert condition_to_balance[condition_id] == 2238183507853351332


### PR DESCRIPTION
Initially, I discovered several issues, such as:

- The function `get_position_lifetime_value` did not properly account for claimed positions 
- All existing positions were considered claimed if there were no payouts to claim

To test that the agent works as expected, you'd need to have unclaimed positions on Presagio, run the agent, and it will claim everything over a few rounds. 