### PR TITLE
hotfix: apt coingecko None issue

### DIFF
--- a/packages/valory/skills/agent_performance_summary_abci/graph_tooling/requests.py
+++ b/packages/valory/skills/agent_performance_summary_abci/graph_tooling/requests.py
@@ -230,4 +230,9 @@ class APTQueryingBehaviour(BaseBehaviour, ABC):
             return None
 
         usd_price = response_data.get(OLAS_TOKEN_ADDRESS, {}).get(USD_PRICE_FIELD, None)
+        if usd_price is None:
+            self.context.logger.error(
+                f"Could not get {USD_PRICE_FIELD} price for OLAS from the response: {response_data}"
+            )
+            return None
         return int(usd_price * DECIMAL_SCALING_FACTOR)  # scale to 18 decimals


### PR DESCRIPTION
Fixes: https://linear.app/valory-xyz/issue/PREDICT-387

None mostly because of rate limits

```
"/home/agent/vendor/valory/skills/agent_performance_summary_abci/graph_tooling/requests.py", line 233, in _fetch_olas_in_usd_price
    return int(usd_price * DECIMAL_SCALING_FACTOR)  # scale to 18 decimals
               ~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~

TypeError: unsupported operand type(s) for *: 'NoneType' and 'int'
```