### PR TITLE
feat: add logic to fetch markets by slug

### DIFF
--- a/packages/valory/agents/trader/aea-config.yaml
+++ b/packages/valory/agents/trader/aea-config.yaml
@@ -281,6 +281,7 @@ models:
       polymarket_ctf_exchange_address: ${str:0x4bFb41d5B3570DeFd03C39a9A4D8dE6Bd8B8982E}
       polymarket_neg_risk_ctf_exchange_address: ${str:0xC5d563A36AE78145C45a50134d48A1215220f80a}
       polymarket_neg_risk_adapter_address: ${str:0xd91E80cF2E7be2e162c6513ceD06f1dD0dA35296}
+      polymarket_market_slug_to_bet_on: ${str:slug}
   benchmarking_mode:
     args:
       enabled: ${bool:false}

--- a/packages/valory/skills/decision_maker_abci/rounds.py
+++ b/packages/valory/skills/decision_maker_abci/rounds.py
@@ -63,13 +63,7 @@ from packages.valory.skills.decision_maker_abci.states.handle_failed_tx import (
     HandleFailedTxRound,
 )
 from packages.valory.skills.decision_maker_abci.states.polymarket_bet_placement import (
-    PolymarketBetPlacementRound
-)
-from packages.valory.skills.decision_maker_abci.states.polymarket_set_approval import (
-    PolymarketSetApprovalRound
-)
-from packages.valory.skills.decision_maker_abci.states.polymarket_post_set_approval import (
-    PolymarketPostSetApprovalRound
+    PolymarketBetPlacementRound,
 )
 from packages.valory.skills.decision_maker_abci.states.polymarket_post_set_approval import (
     PolymarketPostSetApprovalRound,
@@ -98,7 +92,6 @@ from packages.valory.skills.decision_maker_abci.states.tool_selection import (
 from packages.valory.skills.market_manager_abci.rounds import (
     Event as MarketManagerEvent,
 )
-
 
 
 class DecisionMakerAbciApp(AbciApp[Event]):
@@ -313,31 +306,6 @@ class DecisionMakerAbciApp(AbciApp[Event]):
             Event.CALC_BUY_AMOUNT_FAILED: HandleFailedTxRound,
             Event.NO_MAJORITY: PolymarketBetPlacementRound,
             Event.ROUND_TIMEOUT: PolymarketBetPlacementRound,
-            # this is here because of `autonomy analyse fsm-specs`
-            # falsely reporting it as missing from the transition
-            Event.NONE: ImpossibleRound,
-        },
-        PolymarketSetApprovalRound: {
-            Event.DONE: PolymarketPostSetApprovalRound,
-            Event.PREPARE_TX: FinishedSetApprovalTxPreparationRound,
-            # skip the bet placement tx
-            Event.SKIP: BenchmarkingModeDisabledRound,
-            # degenerate round on purpose, owner must refill the safe
-            Event.APPROVAL_FAILED: PolymarketSetApprovalRound,
-            Event.NO_MAJORITY: PolymarketSetApprovalRound,
-            Event.ROUND_TIMEOUT: PolymarketSetApprovalRound,
-            # this is here because of `autonomy analyse fsm-specs`
-            # falsely reporting it as missing from the transition
-            Event.NONE: ImpossibleRound,
-        },
-        PolymarketPostSetApprovalRound: {
-            Event.DONE: BenchmarkingModeDisabledRound,
-            # skip the bet placement tx
-            Event.SKIP: BenchmarkingModeDisabledRound,
-            # degenerate round on purpose, owner must refill the safe
-            Event.APPROVAL_FAILED: PolymarketSetApprovalRound,
-            Event.NO_MAJORITY: PolymarketPostSetApprovalRound,
-            Event.ROUND_TIMEOUT: PolymarketPostSetApprovalRound,
             # this is here because of `autonomy analyse fsm-specs`
             # falsely reporting it as missing from the transition
             Event.NONE: ImpossibleRound,

--- a/packages/valory/skills/market_manager_abci/behaviours.py
+++ b/packages/valory/skills/market_manager_abci/behaviours.py
@@ -27,9 +27,18 @@ from json import JSONDecodeError
 from typing import Any, Dict, Generator, List, Optional, Set, Type, cast
 
 from aea.helpers.ipfs.base import IPFSHashOnly
+from aea.protocols.base import Message
+from dateutil import parser as date_parser
 
+from packages.valory.connections.polymarket_client.connection import (
+    PUBLIC_ID as POLYMARKET_CLIENT_CONNECTION_PUBLIC_ID,
+)
+from packages.valory.connections.polymarket_client.request_types import RequestType
+from packages.valory.protocols.srr.dialogues import SrrDialogue, SrrDialogues
+from packages.valory.protocols.srr.message import SrrMessage
 from packages.valory.skills.abstract_round_abci.behaviour_utils import BaseBehaviour
 from packages.valory.skills.abstract_round_abci.behaviours import AbstractRoundBehaviour
+from packages.valory.skills.abstract_round_abci.models import Requests
 from packages.valory.skills.market_manager_abci.bets import (
     Bet,
     BetsDecoder,
@@ -37,7 +46,6 @@ from packages.valory.skills.market_manager_abci.bets import (
     serialize_bets,
 )
 from packages.valory.skills.market_manager_abci.graph_tooling.requests import (
-    FetchStatus,
     MAX_LOG_SIZE,
     QueryingBehaviour,
 )
@@ -59,6 +67,10 @@ BETS_FILENAME = "bets.json"
 MULTI_BETS_FILENAME = "multi_bets.json"
 READ_MODE = "r"
 WRITE_MODE = "w"
+
+
+USCDE_POLYGON = "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174"
+ZERO_ADDRESS = "0x0000000000000000000000000000000000000000"
 
 
 class BetsManagerBehaviour(BaseBehaviour, ABC):
@@ -133,6 +145,63 @@ class BetsManagerBehaviour(BaseBehaviour, ABC):
     def hash_stored_bets(self) -> str:
         """Get the hash of the stored bets' file."""
         return IPFSHashOnly.hash_file(self.multi_bets_filepath)
+
+    def _do_connection_request(
+        self,
+        message: Message,
+        dialogue: Message,
+        timeout: Optional[float] = None,
+    ) -> Generator[None, None, Message]:
+        """Do a request and wait the response, asynchronously."""
+
+        self.context.outbox.put_message(message=message)
+        request_nonce = self._get_request_nonce_from_dialogue(dialogue)  # type: ignore
+        cast(Requests, self.context.requests).request_id_to_callback[
+            request_nonce
+        ] = self.get_callback_request()
+        response = yield from self.wait_for_message(timeout=timeout)
+        return response
+
+    def do_connection_request(
+        self,
+        message: Message,
+        dialogue: Message,
+        timeout: Optional[float] = None,
+    ) -> Generator[None, None, Message]:
+        """
+        Public wrapper for making a connection request and waiting for response.
+
+        Args:
+            message: The message to send
+            dialogue: The dialogue context
+            timeout: Optional timeout duration
+
+        Returns:
+            Message: The response message
+        """
+        return (yield from self._do_connection_request(message, dialogue, timeout))
+
+    def send_polymarket_connection_request(
+        self,
+        payload_data: Dict[str, Any],
+    ) -> Generator[None, None, Optional[str]]:
+
+        self.context.logger.info(f"Payload data: {payload_data}")
+
+        srr_dialogues = cast(SrrDialogues, self.context.srr_dialogues)
+        srr_message, srr_dialogue = srr_dialogues.create(
+            counterparty=str(POLYMARKET_CLIENT_CONNECTION_PUBLIC_ID),
+            performative=SrrMessage.Performative.REQUEST,
+            payload=json.dumps(payload_data),
+        )
+
+        srr_message = cast(SrrMessage, srr_message)
+        srr_dialogue = cast(SrrDialogue, srr_dialogue)
+        response = yield from self.do_connection_request(srr_message, srr_dialogue)  # type: ignore
+
+        response_json = json.loads(response.payload)  # type: ignore
+
+        return response_json  # type: ignore
 
 
 class UpdateBetsBehaviour(BetsManagerBehaviour, QueryingBehaviour):
@@ -258,6 +327,64 @@ class UpdateBetsBehaviour(BetsManagerBehaviour, QueryingBehaviour):
             else:
                 self.bets[index].update_market_info(bet)
 
+    def _fetch_markets_from_polymarket(self) -> Generator:
+        """Fetch the markets from Polymarket."""
+        # TODO:
+        # Prepare payload data
+        polymarket_fetch_market_payload = {
+            "request_type": RequestType.FETCH_MARKET.value,
+            "params": {
+                "slug": self.params.polymarket_market_slug_to_bet_on,
+            },
+        }
+        response = yield from self.send_polymarket_connection_request(
+            polymarket_fetch_market_payload
+        )
+        print(f"!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! fetched market response: {response}")
+
+        # Parse JSON fields from response
+        outcomes = json.loads(response.get("outcomes", "[]"))
+        outcome_prices = json.loads(response.get("outcomePrices", "[]"))
+        clob_token_ids = json.loads(response.get("clobTokenIds", "[]"))
+
+        end_date = response.get("endDate", "")
+        opening_timestamp = (
+            int(date_parser.isoparse(end_date).timestamp()) if end_date else 0
+        )
+
+        # Calculate outcomeTokenAmounts from liquidity and prices
+        liquidity = float(response.get("liquidity", "0"))
+        outcome_token_amounts = [
+            int(liquidity * float(price) * 10**6) for price in outcome_prices
+        ]
+
+        # Create outcome_token_ids mapping
+        outcome_token_ids = {
+            outcome: token_id for outcome, token_id in zip(outcomes, clob_token_ids)
+        }
+
+        bet_dict = {
+            "id": response.get("id"),
+            "condition_id": response.get("conditionId"),
+            "title": response.get("question"),
+            "collateralToken": USCDE_POLYGON,  # Polymarket uses USDC.e on Polygon
+            "creator": response.get("submitted_by", ZERO_ADDRESS),
+            "fee": 0,  # Polymarket fee is typically 0 or handled differently
+            "openingTimestamp": opening_timestamp,
+            "outcomeSlotCount": len(outcomes),
+            "outcomeTokenAmounts": outcome_token_amounts,
+            "outcomeTokenMarginalPrices": [float(price) for price in outcome_prices],
+            "outcomes": outcomes,
+            "scaledLiquidityMeasure": liquidity,
+            "processed_timestamp": 0,
+            "position_liquidity": 0,
+            "potential_net_profit": 0,
+            "investments": {},
+            "outcome_token_ids": outcome_token_ids,
+        }
+        print(f"!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! constructed bet_dict: {bet_dict}")
+        return [bet_dict]
+
     def _update_bets(
         self,
     ) -> Generator:
@@ -265,16 +392,23 @@ class UpdateBetsBehaviour(BetsManagerBehaviour, QueryingBehaviour):
 
         # Fetching bets from the prediction markets
         while True:
-            can_proceed = self._prepare_fetching()
-            if not can_proceed:
-                break
+            # can_proceed = self._prepare_fetching()
+            # if not can_proceed:
+            #     break
 
-            bets_market_chunk = yield from self._fetch_bets()
+            # Deleting all current markets. To be removed
+            with open(self.context.params.store_path / MULTI_BETS_FILENAME, "w") as f:
+                f.write("")
+
+            # bets_market_chunk = yield from self._fetch_bets()
+            bets_market_chunk = yield from self._fetch_markets_from_polymarket()
             self._process_chunk(bets_market_chunk)
+            break
 
-        if self._fetch_status != FetchStatus.SUCCESS:
-            # this won't wipe the bets as the `store_bets` of the `BetsManagerBehaviour` takes this into consideration
-            self.bets = []
+        # TODO: Uncomment
+        # if self._fetch_status != FetchStatus.SUCCESS:
+        #     # this won't wipe the bets as the `store_bets` of the `BetsManagerBehaviour` takes this into consideration
+        #     self.bets = []
 
         # truncate the bets, otherwise logs get too big
         bets_str = str(self.bets)[:MAX_LOG_SIZE]
@@ -306,7 +440,8 @@ class UpdateBetsBehaviour(BetsManagerBehaviour, QueryingBehaviour):
         with self.context.benchmark_tool.measure(self.behaviour_id).local():
             # Update the bets list with new bets or update existing ones
             yield from self._update_bets()
-            yield from self.update_bets_investments()
+            # TODO: Uncomment when investment tracking is ready
+            # yield from self.update_bets_investments()
 
             if self.review_bets_for_selling():
                 self._requeue_bets_for_selling()

--- a/packages/valory/skills/market_manager_abci/bets.py
+++ b/packages/valory/skills/market_manager_abci/bets.py
@@ -161,6 +161,7 @@ class Bet:
     # a mapping from vote to investment amounts
     investments: Dict[str, List[int]] = dataclasses.field(default_factory=dict)
     outcome_token_ids: Optional[Dict[str, str]] = None
+    condition_id: Optional[str] = None
 
     def __post_init__(self) -> None:
         """Post initialization to adjust the values."""

--- a/packages/valory/skills/market_manager_abci/models.py
+++ b/packages/valory/skills/market_manager_abci/models.py
@@ -108,6 +108,9 @@ class MarketManagerParams(BaseParams):
         self.use_multi_bets_mode: bool = self._ensure(
             "use_multi_bets_mode", kwargs, bool
         )
+        self.polymarket_market_slug_to_bet_on: str = self._ensure(
+            "polymarket_market_slug_to_bet_on", kwargs, str
+        )
         super().__init__(*args, **kwargs)
 
     @property

--- a/packages/valory/skills/market_manager_abci/skill.yaml
+++ b/packages/valory/skills/market_manager_abci/skill.yaml
@@ -151,6 +151,7 @@ models:
       the_graph_error_message_key: message
       the_graph_payment_required_error: payment required for subsequent requests for
         this API key
+      polymarket_market_slug_to_bet_on: ''
     class_name: MarketManagerParams
   benchmarking_mode:
     args:

--- a/packages/valory/skills/trader_abci/skill.yaml
+++ b/packages/valory/skills/trader_abci/skill.yaml
@@ -278,6 +278,7 @@ models:
       polymarket_ctf_exchange_address: '0x4bFb41d5B3570DeFd03C39a9A4D8dE6Bd8B8982E'
       polymarket_neg_risk_ctf_exchange_address: '0xC5d563A36AE78145C45a50134d48A1215220f80a'
       polymarket_neg_risk_adapter_address: '0xd91E80cF2E7be2e162c6513ceD06f1dD0dA35296'
+      polymarket_market_slug_to_bet_on: ''
     class_name: TraderParams
   benchmarking_mode:
     args:

--- a/scripts/aea-config-replace.py
+++ b/scripts/aea-config-replace.py
@@ -76,6 +76,7 @@ PATH_TO_VAR = {
     "config/neg_risk_ctf_exchange": "NEG_RISK_CTF_EXCHANGE",
     "config/neg_risk_adapter": "NEG_RISK_ADAPTER",
     "models/params/args/bet_threshold": "BET_THRESHOLD",
+    "models/params/args/polymarket_market_slug_to_bet_on": "POLYMARKET_MARKET_SLUG_TO_BET_ON",
 }
 
 CONFIG_REGEX = r"\${.*?:(.*)}"


### PR DESCRIPTION
A lot of things hardcoded for now. Even this logic to fetch markets by slug would be removed. But for now with this logic, it would be easier to test. Things that should be updated are marked with `TODO`