### PR TITLE
feat: added logic to swap pol to usdc

### DIFF
--- a/packages/valory/agents/trader/aea-config.yaml
+++ b/packages/valory/agents/trader/aea-config.yaml
@@ -282,6 +282,7 @@ models:
       polymarket_neg_risk_ctf_exchange_address: ${str:0xC5d563A36AE78145C45a50134d48A1215220f80a}
       polymarket_neg_risk_adapter_address: ${str:0xd91E80cF2E7be2e162c6513ceD06f1dD0dA35296}
       polymarket_market_slug_to_bet_on: ${str:slug}
+      pol_threshold_for_swap: ${int:2000000000000000000}
   benchmarking_mode:
     args:
       enabled: ${bool:false}

--- a/packages/valory/services/polymarket_trader/service.yaml
+++ b/packages/valory/services/polymarket_trader/service.yaml
@@ -154,6 +154,7 @@ models:
       is_agent_performance_summary_enabled: ${IS_AGENT_PERFORMANCE_SUMMARY_ENABLED:bool:true}
       is_running_on_polymarket: ${IS_RUNNING_ON_POLYMARKET:bool:true}
       polymarket_builder_program_enabled: ${POLYMARKET_BUILDER_PROGRAM_ENABLED:bool:false}
+      pol_threshold_for_swap: ${POL_THRESHOLD_FOR_SWAP:int:2000000000000000000}
   benchmark_tool:
     args:
       log_dir: ${LOG_DIR:str:/benchmarks}

--- a/packages/valory/skills/decision_maker_abci/behaviours/polymarket_swap.py
+++ b/packages/valory/skills/decision_maker_abci/behaviours/polymarket_swap.py
@@ -1,0 +1,284 @@
+# -*- coding: utf-8 -*-
+# ------------------------------------------------------------------------------
+#
+#   Copyright 2026 Valory AG
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ------------------------------------------------------------------------------
+
+"""This module contains the PolymarketSwapUsdcBehaviour of the 'DecisionMakerAbci' skill."""
+
+import json
+from typing import Generator, Optional, cast
+
+from packages.valory.contracts.gnosis_safe.contract import (
+    GnosisSafeContract,
+    SafeOperation,
+)
+from packages.valory.protocols.contract_api import ContractApiMessage
+from packages.valory.protocols.ledger_api import LedgerApiMessage
+from packages.valory.skills.decision_maker_abci.behaviours.base import (
+    DecisionMakerBaseBehaviour,
+)
+from packages.valory.skills.decision_maker_abci.payloads import PolymarketSwapPayload
+from packages.valory.skills.decision_maker_abci.rounds import PolymarketSwapUsdcRound
+from packages.valory.skills.transaction_settlement_abci.payload_tools import (
+    hash_payload_to_hex,
+)
+
+
+SAFE_TX_GAS = 0
+ETHER_VALUE = 0
+
+# Polygon network constants
+POLYGON_CHAIN_ID = 137
+POL_ADDRESS = "0x0000000000000000000000000000000000001010"  # Native POL on Polygon
+USDC_ADDRESS = "0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359"  # USDC on Polygon
+LIFI_QUOTE_URL = "https://li.quest/v1/quote"
+HTTP_OK = [200]
+INTEGRATOR = "valory"
+
+
+class PolymarketSwapUsdcBehaviour(DecisionMakerBaseBehaviour):
+    """PolymarketSwapUsdcBehaviour"""
+
+    matching_round = PolymarketSwapUsdcRound
+
+    def async_act(self) -> Generator:
+        """Implement the act."""
+        with self.context.benchmark_tool.measure(self.behaviour_id).local():
+            agent = self.context.agent_address
+            if not self.params.is_running_on_polymarket:
+                self.context.logger.info(
+                    "[SwapPOLBehaviour] Not running on Polymarket network. Skipping swap."
+                )
+                payload = PolymarketSwapPayload(
+                    sender=agent,
+                    tx_submitter=None,
+                    tx_hash=None,
+                    should_swap=False,
+                )
+                yield from self.send_a2a_transaction(payload)
+                self.set_done()
+                return
+            tx_hash = yield from self.get_tx_hash()
+            if tx_hash is None:
+                tx_submitter = None
+                should_swap = False
+            else:
+                tx_submitter = self.matching_round.auto_round_id()
+                should_swap = True
+            payload = PolymarketSwapPayload(
+                sender=agent,
+                tx_submitter=tx_submitter,
+                tx_hash=tx_hash,
+                should_swap=should_swap,
+            )
+        with self.context.benchmark_tool.measure(self.behaviour_id).consensus():
+            yield from self.send_a2a_transaction(payload)
+            yield from self.wait_until_round_end()
+        self.set_done()
+
+    def _get_balance(self, address: str) -> Generator[None, None, Optional[int]]:
+        """Get the POL balance of the provided address on Polygon"""
+        ledger_api_response = yield from self.get_ledger_api_response(
+            performative=LedgerApiMessage.Performative.GET_STATE,  # type: ignore
+            ledger_callable="get_balance",
+            account=address,
+            chain_id="polygon",
+        )
+        if ledger_api_response.performative != LedgerApiMessage.Performative.STATE:
+            self.context.logger.error(
+                f"Couldn't get balance. "
+                f"Expected response performative {LedgerApiMessage.Performative.STATE.value}, "  # type: ignore
+                f"received {ledger_api_response.performative.value}."
+            )
+            return None
+        balance = cast(int, ledger_api_response.state.body.get("get_balance_result"))
+        self.context.logger.info(f"balance: {balance / 10 ** 18} POL")
+        return balance
+
+    def _get_safe_tx_hash(
+        self,
+        to_address: str,
+        data: bytes,
+        value: int = ETHER_VALUE,
+        safe_tx_gas: int = SAFE_TX_GAS,
+        operation: int = SafeOperation.CALL.value,
+    ) -> Generator[None, None, Optional[str]]:
+        """Prepares and returns the safe tx hash."""
+        response = yield from self.get_contract_api_response(
+            performative=ContractApiMessage.Performative.GET_STATE,
+            contract_address=self.synchronized_data.safe_contract_address,  # the safe contract address
+            contract_id=str(GnosisSafeContract.contract_id),
+            contract_callable="get_raw_safe_transaction_hash",
+            to_address=to_address,  # the contract the safe will invoke
+            value=value,
+            data=data,
+            safe_tx_gas=safe_tx_gas,
+            operation=operation,
+            chain_id="polygon",
+        )
+        if response.performative != ContractApiMessage.Performative.STATE:
+            self.context.logger.error(
+                f"Couldn't get safe hash. "
+                f"Expected response performative {ContractApiMessage.Performative.STATE.value}, "
+                f"received {response.performative.value}."
+            )
+            return None
+
+        # strip "0x" from the response hash
+        tx_hash = cast(str, response.state.body["tx_hash"])[2:]
+        return tx_hash
+
+    def get_tx_hash(self) -> Generator[None, None, Optional[str]]:
+        """Get the tx_hash for swapping POL to USDC."""
+        safe_address = self.synchronized_data.safe_contract_address
+        balance = yield from self._get_balance(safe_address)
+        if balance is None:
+            self.context.logger.error("[SwapPOLBehaviour] Couldn't get balance.")
+            return None
+
+        self.context.logger.info(
+            f"[SwapPOLBehaviour] POL balance: {balance} wei ({balance / 10**18} POL)"
+        )
+
+        # Check if the balance is above threshold
+        if balance <= self.params.pol_threshold_for_swap:
+            self.context.logger.info(
+                f"[SwapPOLBehaviour] Balance {balance} below or equal to threshold {self.params.pol_threshold_for_swap}."
+            )
+            return None
+
+        self.context.logger.info("[SwapPOLBehaviour] Proceeding with swap")
+
+        # Leave pol threshold in the safe for non-swap purposes
+        balance_to_swap = balance - self.params.pol_threshold_for_swap
+        self.context.logger.info(
+            f"[SwapPOLBehaviour] Amount to swap: {balance_to_swap} wei ({balance_to_swap / 10**18} POL)"
+        )
+
+        # Get LiFi quote for POL -> USDC swap
+        quote = yield from self._get_lifi_quote(safe_address, balance_to_swap)
+        if quote is None:
+            self.context.logger.error("[SwapPOLBehaviour] Failed to get LiFi quote.")
+            return None
+
+        # Extract transaction data from quote
+        tx_request = quote.get("transactionRequest")
+        if not tx_request:
+            self.context.logger.error(
+                "[SwapPOLBehaviour] No transaction request in quote."
+            )
+            return None
+
+        lifi_contract = tx_request.get("to")
+        tx_data_hex = tx_request.get("data")
+        tx_value = (
+            int(tx_request.get("value", "0"), 16)
+            if isinstance(tx_request.get("value"), str)
+            else tx_request.get("value", 0)
+        )
+
+        if not lifi_contract or not tx_data_hex:
+            self.context.logger.error(
+                "[SwapPOLBehaviour] Missing LiFi contract address or transaction data."
+            )
+            return None
+
+        self.context.logger.info(f"[SwapPOLBehaviour] LiFi contract: {lifi_contract}")
+        self.context.logger.info(
+            f"[SwapPOLBehaviour] Transaction value: {tx_value} wei"
+        )
+
+        try:
+            tx_data = bytes.fromhex(
+                tx_data_hex[2:] if tx_data_hex.startswith("0x") else tx_data_hex
+            )
+        except Exception as e:
+            self.context.logger.error(
+                f"[SwapPOLBehaviour] Failed to decode transaction data: {e}"
+            )
+            return None
+
+        # Create safe transaction directly to LiFi contract (no multisend needed for single call)
+        safe_tx_hash = yield from self._get_safe_tx_hash(
+            to_address=lifi_contract,
+            data=tx_data,
+            value=tx_value,  # POL value to send
+            safe_tx_gas=SAFE_TX_GAS,
+            operation=SafeOperation.CALL.value,
+        )
+
+        if safe_tx_hash is None:
+            self.context.logger.error(
+                "[SwapPOLBehaviour] _get_safe_tx_hash() output is None."
+            )
+            return None
+
+        self.context.logger.info(f"[SwapPOLBehaviour] Safe tx hash: {safe_tx_hash}")
+
+        tx_payload_data = hash_payload_to_hex(
+            safe_tx_hash=safe_tx_hash,
+            ether_value=tx_value,
+            safe_tx_gas=SAFE_TX_GAS,
+            to_address=lifi_contract,
+            data=tx_data,
+            operation=SafeOperation.CALL.value,
+        )
+        return tx_payload_data
+
+    def _get_lifi_quote(
+        self, from_address: str, amount: int
+    ) -> Generator[None, None, Optional[dict]]:
+        """Get a quote from LiFi for swapping POL to USDC."""
+        params = {
+            "fromChain": str(POLYGON_CHAIN_ID),
+            "toChain": str(POLYGON_CHAIN_ID),
+            "fromToken": POL_ADDRESS,
+            "toToken": USDC_ADDRESS,
+            "fromAmount": str(amount),
+            "fromAddress": from_address,
+            "toAddress": from_address,
+            "integrator": INTEGRATOR,
+        }
+
+        self.context.logger.info(
+            f"[SwapPOLBehaviour] Fetching LiFi quote with params: {params}"
+        )
+
+        response = yield from self.get_http_response(
+            method="GET",
+            url=LIFI_QUOTE_URL,
+            headers={"accept": "application/json"},
+            parameters=params,
+        )
+
+        if response.status_code not in HTTP_OK:
+            self.context.logger.error(
+                f"[SwapPOLBehaviour] LiFi API returned status {response.status_code}: {response.body}"
+            )
+            return None
+
+        try:
+            quote = json.loads(response.body)
+            self.context.logger.info(
+                "[SwapPOLBehaviour] Received LiFi quote successfully"
+            )
+            return quote
+        except (ValueError, TypeError) as e:
+            self.context.logger.error(
+                f"[SwapPOLBehaviour] Failed to parse LiFi quote: {e}"
+            )
+            return None

--- a/packages/valory/skills/decision_maker_abci/behaviours/round_behaviour.py
+++ b/packages/valory/skills/decision_maker_abci/behaviours/round_behaviour.py
@@ -75,6 +75,9 @@ from packages.valory.skills.decision_maker_abci.behaviours.sampling import (
 from packages.valory.skills.decision_maker_abci.behaviours.sell_outcome_tokens import (
     SellOutcomeTokensBehaviour,
 )
+from packages.valory.skills.decision_maker_abci.behaviours.polymarket_swap import (
+    PolymarketSwapUsdcBehaviour,
+)
 from packages.valory.skills.decision_maker_abci.behaviours.tool_selection import (
     ToolSelectionBehaviour,
 )
@@ -106,4 +109,5 @@ class AgentDecisionMakerRoundBehaviour(AbstractRoundBehaviour):
         PolymarketFetchMarketBehaviour,  # type: ignore
         PolymarketSetApprovalBehaviour,  # type: ignore
         PolymarketPostSetApprovalBehaviour,  # type: ignore
+        PolymarketSwapUsdcBehaviour,  # type: ignore
     }

--- a/packages/valory/skills/decision_maker_abci/models.py
+++ b/packages/valory/skills/decision_maker_abci/models.py
@@ -501,6 +501,9 @@ class DecisionMakerParams(
         self.polymarket_neg_risk_adapter_address: str = self._ensure(
             "polymarket_neg_risk_adapter_address", kwargs, str
         )
+        self.pol_threshold_for_swap: int = self._ensure(
+            "pol_threshold_for_swap", kwargs, int
+        )
         super().__init__(*args, **kwargs)
 
     @property

--- a/packages/valory/skills/decision_maker_abci/payloads.py
+++ b/packages/valory/skills/decision_maker_abci/payloads.py
@@ -168,3 +168,10 @@ class PolymarketRedeemPayload(MultisigTxPayload):
     redeemed_condition_ids: Optional[str] = None
     payout_so_far: Optional[int] = None
     event: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class PolymarketSwapPayload(MultisigTxPayload):
+    """Represents a transaction payload for preparing an on-chain transaction for swapping."""
+
+    should_swap: Optional[bool] = None

--- a/packages/valory/skills/decision_maker_abci/rounds_info.py
+++ b/packages/valory/skills/decision_maker_abci/rounds_info.py
@@ -257,6 +257,11 @@ ROUNDS_INFO = {
         "description": "Fetches multiple markets from Polymarket using category tags with filtering.",
         "transitions": {},
     },
+    "polymarket_swap_usdc_round": {
+        "name": "Swapping POL to USDC for placing mech requests",
+        "description": "Swaps POL tokens to USDC tokens",
+        "transitions": {},
+    },
 }
 
 

--- a/packages/valory/skills/decision_maker_abci/skill.yaml
+++ b/packages/valory/skills/decision_maker_abci/skill.yaml
@@ -303,6 +303,7 @@ models:
       store_path: data/
       is_running_on_polymarket: false
       polymarket_builder_program_enabled: true
+      pol_threshold_for_swap: 2000000000000000000
     class_name: DecisionMakerParams
   acc_info_fields:
     args:

--- a/packages/valory/skills/decision_maker_abci/states/final_states.py
+++ b/packages/valory/skills/decision_maker_abci/states/final_states.py
@@ -83,3 +83,7 @@ class FinishedFetchMarketsRouterRound(DegenerateRound):
 
 class FinishedPolymarketFetchMarketRound(DegenerateRound):
     """A round representing that Polymarket fetch market has finished."""
+
+
+class FinishedPolymarketSwapTxPreparationRound(DegenerateRound):
+    """A round representing that Polymarket swap has finished and needs to go to tx settlement."""

--- a/packages/valory/skills/decision_maker_abci/states/polymarket_swap.py
+++ b/packages/valory/skills/decision_maker_abci/states/polymarket_swap.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+# ------------------------------------------------------------------------------
+#
+#   Copyright 2026 Valory AG
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ------------------------------------------------------------------------------
+
+"""This module contains the PolymarketSwapUsdcRound of the 'DecisionMakerAbci' skill."""
+
+from enum import Enum
+from typing import Optional, Tuple, cast
+
+from packages.valory.skills.abstract_round_abci.base import BaseSynchronizedData
+from packages.valory.skills.decision_maker_abci.payloads import PolymarketSwapPayload
+from packages.valory.skills.decision_maker_abci.states.base import (
+    Event,
+    SynchronizedData,
+    TxPreparationRound,
+)
+
+
+class PolymarketSwapUsdcRound(TxPreparationRound):
+    """A round for swapping POL to USDC."""
+
+    payload_class = PolymarketSwapPayload
+    none_event = Event.NONE
+
+    def end_block(self) -> Optional[Tuple[BaseSynchronizedData, Enum]]:
+        """Process the end of the block."""
+        res = super().end_block()
+        if res is None:
+            return None
+
+        synced_data, event = cast(Tuple[SynchronizedData, Enum], res)
+        should_swap = self.most_voted_payload_values[-1]
+        event = Event.PREPARE_TX if should_swap else Event.DONE
+
+        return synced_data, event

--- a/packages/valory/skills/trader_abci/composition.py
+++ b/packages/valory/skills/trader_abci/composition.py
@@ -48,34 +48,38 @@ from packages.valory.skills.decision_maker_abci.states.check_benchmarking import
 from packages.valory.skills.decision_maker_abci.states.decision_receive import (
     DecisionReceiveRound,
 )
+from packages.valory.skills.decision_maker_abci.states.decision_request import (
+    DecisionRequestRound,
+)
+from packages.valory.skills.decision_maker_abci.states.fetch_markets_router import (
+    FetchMarketsRouterRound,
+)
 from packages.valory.skills.decision_maker_abci.states.final_states import (
     BenchmarkingDoneRound,
     BenchmarkingModeDisabledRound,
     FinishedDecisionMakerRound,
     FinishedDecisionRequestRound,
+    FinishedFetchMarketsRouterRound,
+    FinishedPolymarketFetchMarketRound,
     FinishedPolymarketRedeemRound,
+    FinishedPolymarketSwapTxPreparationRound,
     FinishedRedeemTxPreparationRound,
     FinishedSetApprovalTxPreparationRound,
     FinishedWithoutDecisionRound,
     FinishedWithoutRedeemingRound,
-    FinishedFetchMarketsRouterRound,
-    FinishedPolymarketFetchMarketRound,
     RefillRequiredRound,
 )
 from packages.valory.skills.decision_maker_abci.states.handle_failed_tx import (
     HandleFailedTxRound,
+)
+from packages.valory.skills.decision_maker_abci.states.polymarket_fetch_market import (
+    PolymarketFetchMarketRound,
 )
 from packages.valory.skills.decision_maker_abci.states.polymarket_post_set_approval import (
     PolymarketPostSetApprovalRound,
 )
 from packages.valory.skills.decision_maker_abci.states.randomness import RandomnessRound
 from packages.valory.skills.decision_maker_abci.states.redeem import RedeemRound
-from packages.valory.skills.decision_maker_abci.states.fetch_markets_router import (
-    FetchMarketsRouterRound,
-)
-from packages.valory.skills.decision_maker_abci.states.polymarket_fetch_market import (
-    PolymarketFetchMarketRound,
-)
 from packages.valory.skills.market_manager_abci.rounds import (
     FailedMarketManagerRound,
     FinishedMarketManagerRound,
@@ -125,6 +129,7 @@ from packages.valory.skills.tx_settlement_multiplexer_abci.rounds import (
     ChecksPassedRound,
     FinishedBetPlacementTxRound,
     FinishedMechRequestTxRound,
+    FinishedPolymarketSwapTxRound,
     FinishedRedeemingTxRound,
     FinishedSellOutcomeTokensTxRound,
     FinishedSetApprovalTxRound,
@@ -163,6 +168,8 @@ abci_app_transition_mapping: AbciAppTransitionMapping = {
     FinishedBetPlacementTxRound: RedeemRound,
     FinishedSellOutcomeTokensTxRound: RedeemRound,
     FinishedRedeemingTxRound: CallCheckpointRound,
+    FinishedPolymarketSwapTxPreparationRound: PreTxSettlementRound,
+    FinishedPolymarketSwapTxRound: DecisionRequestRound,
     FinishedPolymarketRedeemRound: CallCheckpointRound,
     FinishedRedeemTxPreparationRound: PreTxSettlementRound,
     FinishedSetApprovalTxPreparationRound: PreTxSettlementRound,

--- a/packages/valory/skills/trader_abci/fsm_specification.yaml
+++ b/packages/valory/skills/trader_abci/fsm_specification.yaml
@@ -65,6 +65,7 @@ final_states:
     - ImpossibleRound
     - ServiceEvictedRound
     - FinishedPolymarketRedeemRound
+    - FinishedPolymarketSwapTxPreparationRound
 label: TraderAbciApp
 start_states:
     - RegistrationRound
@@ -117,6 +118,7 @@ states:
     - FetchMarketsRouterRound
     - PolymarketFetchMarketRound
     - ValidateTransactionRound
+    - PolymarketSwapUsdcRound
 transition_func:
     (BenchmarkingRandomnessRound, DONE): SamplingRound
     (BenchmarkingRandomnessRound, NONE): ImpossibleRound
@@ -309,10 +311,15 @@ transition_func:
     (SynchronizeLateMessagesRound, NONE): SelectKeeperTransactionSubmissionBRound
     (SynchronizeLateMessagesRound, ROUND_TIMEOUT): SynchronizeLateMessagesRound
     (SynchronizeLateMessagesRound, SUSPICIOUS_ACTIVITY): HandleFailedTxRound
-    (ToolSelectionRound, DONE): DecisionRequestRound
+    (ToolSelectionRound, DONE): PolymarketSwapUsdcRound
     (ToolSelectionRound, NONE): ToolSelectionRound
     (ToolSelectionRound, NO_MAJORITY): ToolSelectionRound
     (ToolSelectionRound, ROUND_TIMEOUT): ToolSelectionRound
+    (PolymarketSwapUsdcRound, DONE): DecisionRequestRound
+    (PolymarketSwapUsdcRound, NONE): DecisionRequestRound
+    (PolymarketSwapUsdcRound, PREPARE_TX): PreTxSettlementRound
+    (PolymarketSwapUsdcRound, NO_MAJORITY): PolymarketSwapUsdcRound
+    (PolymarketSwapUsdcRound, ROUND_TIMEOUT): PolymarketSwapUsdcRound
     (UpdateBetsRound, DONE): CheckStopTradingRound
     (UpdateBetsRound, FETCH_ERROR): ResetAndPauseRound
     (UpdateBetsRound, NO_MAJORITY): UpdateBetsRound

--- a/packages/valory/skills/trader_abci/skill.yaml
+++ b/packages/valory/skills/trader_abci/skill.yaml
@@ -9,11 +9,11 @@ fingerprint:
   README.md: bafybeiab4xgadptz4mhvno4p6xvkh7p4peg7iuhotabydriu74dmj6ljga
   __init__.py: bafybeido7wa33h4dtleap57vzgyb4fsofk4vindsqcekyfo5i56i2rll2a
   behaviours.py: bafybeiae4j35uqsubdy7pjzfhlcewcb3mfhhyny7h46wf4bquf27or4iu4
-  composition.py: bafybeibuprpyqych43fcetzj5w4ztrexoeujn2gaxlkhrq7ce5fsuniksa
+  composition.py: bafybeiep6jpbsnlsdgvq4z6y6lfqw2lpb3vocrub7v2cc7ovwnqczcze7i
   dialogues.py: bafybeiaiv562rcf7cjenuowrus744jc2njycrobkl72jwebocuh3htx2mu
-  fsm_specification.yaml: bafybeigjdfo62wldq4rjujmrbf3aspq6edsmitmrdj2d7qkovc42bipmvu
-  handlers.py: bafybeidac7ht5n3cyy2jimhvminal46jc2hlzulp5ywo2oyw7bwk4qr2hi
-  models.py: bafybeighcpwxdqohc2wbplgd474t3q6smiavxtft64xlv3yjzwsacabyvi
+  fsm_specification.yaml: bafybeig5ut2hftypcixzs2qix6bjriuznng6niitmy3gxp3e47wloorfvu
+  handlers.py: bafybeihs5imfzhof7tera6cqf7obbfilp3hvxsirxczkzvvkoeoywhl7gy
+  models.py: bafybeic7yv2cc5pgamruiijyyds726bbkutgsr7cs2xfouhb5u3kwuhomm
   predict-ui-build/README.md: bafybeie6yr3viscukl7jibuhoh3bvhoyivw3c4kblgxk5w52ucirosqc34
   predict-ui-build/assets/agentsfun-chat-CQO2MvlO.png: bafybeibm5nhmhfa54gimrsjt7pupvw3bkg2ayr6nul5o5krlj67ivh26oy
   predict-ui-build/assets/index-CXmEbKlU.js: bafybeibqdpts5s3p7yzbbdah2hvuiwkwrypompr7j2pzfoz3pxehranvxi
@@ -34,20 +34,20 @@ protocols:
 - valory/http:1.0.0:bafybeibxab2yfpchusrzw4rgrasjomtpphazanpivhhtznmuao5ny2lsmi
 - valory/srr:0.1.0:bafybeiee2dgy6r2z5x6vu2ug5vcxvfgg4v3liq2x7v3hxchtp45mwnchg4
 skills:
-- valory/abstract_round_abci:0.1.0:bafybeib4xpcpuiryyfnkuyhypdvqi5ebbl7ugavv6ig6yp4nzk3fxosntm
-- valory/registration_abci:0.1.0:bafybeibf5nhislatztx2q3u46v7d36vmm7dnxpmuhrbxqxkz4lvdgifwha
-- valory/reset_pause_abci:0.1.0:bafybeihuxdetmcyqoqr7iatqsddufolzoebdxsxb4lxd2uiyvuwhb52ttq
-- valory/transaction_settlement_abci:0.1.0:bafybeids5bopaujr5bh2jfhvysl6fzf7zexsbdifaurf4nerp24hv5uqnm
-- valory/termination_abci:0.1.0:bafybeigysvgr5m6zj5b6ofadeddzpxxlhxzn2hyxfilcybhcpp252vdft4
-- valory/market_manager_abci:0.1.0:bafybeidbt5utmwgcdnggihgehbfmaq3cwt5wvag6die4z4tnjfyifwbsu4
-- valory/decision_maker_abci:0.1.0:bafybeihtlfuof5ljyj4jwfkt5mtbxirtwp36bjaz3p53vh5jibme42rlly
-- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeiab54oncvqclzrdh7rtrelf5lixptgc2kggiq2guggdqud3m5p63u
-- valory/staking_abci:0.1.0:bafybeiagiknu254j5a5sabwf3t73yhiawx422mhuyf2vsezmc756l2qh3e
-- valory/check_stop_trading_abci:0.1.0:bafybeidpku2p6kuowfdhrinhaptsxz3xvyaxfum2izsraicoxfjhisnuem
-- valory/mech_interact_abci:0.1.0:bafybeiapma3xyf5cozepeakwidouehv3shaykmvxwsos4bgn4256q7cw24
-- valory/chatui_abci:0.1.0:bafybeies4u7bxfxfk6wlvuayei3qokyxfshha7ypvl5uzlo3errgv2wydq
-- valory/agent_performance_summary_abci:0.1.0:bafybeib4umxilj7l2x7fr6ef5myyf76zz3suwj4ozlst6xvspfkpxnu2ee
-- valory/funds_manager:0.1.0:bafybeihcvkhm46u6zenf5hf3ktkktc5t7cnttekkxzpxoslmfi7iwngpau
+- valory/abstract_round_abci:0.1.0:bafybeib4apybhtx3gx6o4x5b2nwqjkbdqi7dx7rxyrb5r3zztcdjiezvh4
+- valory/registration_abci:0.1.0:bafybeigqusergxx4zwnaxccl7gs2gu5sva4uz2dosdppfmwjihlpebywkq
+- valory/reset_pause_abci:0.1.0:bafybeibbgedhxkf44obw7mdcczz2hxkjnvfnifnsk6txq7z64v372bbgpa
+- valory/transaction_settlement_abci:0.1.0:bafybeifw2sem532gwdcyujknhsgdcgubpwsrrjtve4ztzxlkpmporjp4rq
+- valory/termination_abci:0.1.0:bafybeidrcpgdldhnxrhqbu5wpqjypwha6vmbzzjmaescto4vk5vut4fvha
+- valory/market_manager_abci:0.1.0:bafybeifkhj5wwyv3hhvia2ab6qsbcdgjqyup66p5vl6deoexjskawiih6u
+- valory/decision_maker_abci:0.1.0:bafybeifpbqvy4hzxsqi3seeax2rebc6mevivxm6kd2nueb754raslg36ry
+- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeidctoyniq7aenexro53sx7ac6tvjlf76clgfrv4vr5kryicfas64u
+- valory/staking_abci:0.1.0:bafybeifaw3hbbroix264sigrawnmqg7y3r2pxcrj47homdkl3avjp4m7a4
+- valory/check_stop_trading_abci:0.1.0:bafybeiaesbeh6t7v4nugcwkl7kftoazy7g3ionztp3ejuvrmfyqyvc4o5y
+- valory/mech_interact_abci:0.1.0:bafybeiao2yg2nzbbhjmg2dv43dhobtcnfakm2l4wb6lfx3iad5d7qhpyhu
+- valory/chatui_abci:0.1.0:bafybeifrzpeucrs7hqlox7ks32jotatoodysceykk6ryc6i4ylah2burlm
+- valory/agent_performance_summary_abci:0.1.0:bafybeihusrpuvgk4g7jtsqximrt5ay6vg4dpseszc6vpzsxslm5xzm7jlu
+- valory/funds_manager:0.1.0:bafybeiarjrgtot7gbqmwnu6ljfczf7gur6q35f3esgxzlw4hwwijbzrxgi
 behaviours:
   main:
     args: {}
@@ -279,6 +279,7 @@ models:
       polymarket_neg_risk_ctf_exchange_address: '0xC5d563A36AE78145C45a50134d48A1215220f80a'
       polymarket_neg_risk_adapter_address: '0xd91E80cF2E7be2e162c6513ceD06f1dD0dA35296'
       polymarket_market_slug_to_bet_on: ''
+      pol_threshold_for_swap: 2000000000000000000
     class_name: TraderParams
   benchmarking_mode:
     args:

--- a/packages/valory/skills/tx_settlement_multiplexer_abci/fsm_specification.yaml
+++ b/packages/valory/skills/tx_settlement_multiplexer_abci/fsm_specification.yaml
@@ -17,6 +17,7 @@ final_states:
 - FinishedBetPlacementTxRound
 - FinishedMechRequestTxRound
 - FinishedRedeemingTxRound
+- FinishedPolymarketSwapTxRound
 - FinishedSellOutcomeTokensTxRound
 - FinishedStakingTxRound
 - FinishedSubscriptionTxRound
@@ -30,6 +31,7 @@ states:
 - FinishedBetPlacementTxRound
 - FinishedMechRequestTxRound
 - FinishedRedeemingTxRound
+- FinishedPolymarketSwapTxRound
 - FinishedSellOutcomeTokensTxRound
 - FinishedStakingTxRound
 - FinishedSubscriptionTxRound
@@ -39,6 +41,7 @@ transition_func:
     (PostTxSettlementRound, BET_PLACEMENT_DONE): FinishedBetPlacementTxRound
     (PostTxSettlementRound, MECH_REQUESTING_DONE): FinishedMechRequestTxRound
     (PostTxSettlementRound, REDEEMING_DONE): FinishedRedeemingTxRound
+    (PostTxSettlementRound, SWAP_DONE): FinishedPolymarketSwapTxRound
     (PostTxSettlementRound, ROUND_TIMEOUT): PostTxSettlementRound
     (PostTxSettlementRound, SELL_OUTCOME_TOKENS_DONE): FinishedSellOutcomeTokensTxRound
     (PostTxSettlementRound, STAKING_DONE): FinishedStakingTxRound

--- a/packages/valory/skills/tx_settlement_multiplexer_abci/rounds.py
+++ b/packages/valory/skills/tx_settlement_multiplexer_abci/rounds.py
@@ -45,6 +45,9 @@ from packages.valory.skills.decision_maker_abci.states.polymarket_redeem import 
 from packages.valory.skills.decision_maker_abci.states.polymarket_set_approval import (
     PolymarketSetApprovalRound,
 )
+from packages.valory.skills.decision_maker_abci.states.polymarket_swap import (
+    PolymarketSwapUsdcRound,
+)
 from packages.valory.skills.decision_maker_abci.states.redeem import RedeemRound
 from packages.valory.skills.decision_maker_abci.states.sell_outcome_tokens import (
     SellOutcomeTokensRound,
@@ -71,6 +74,7 @@ class Event(Enum):
     ROUND_TIMEOUT = "round_timeout"
     UNRECOGNIZED = "unrecognized"
     NO_MAJORITY = "no_majority"
+    SWAP_DONE = "swap_done"
 
 
 class PreTxSettlementRound(VotingRound):
@@ -119,6 +123,7 @@ class PostTxSettlementRound(CollectSameUntilThresholdRound):
             CallCheckpointRound.auto_round_id(): Event.STAKING_DONE,
             MechPurchaseSubscriptionRound.auto_round_id(): Event.SUBSCRIPTION_DONE,
             PolymarketSetApprovalRound.auto_round_id(): Event.SET_APPROVAL_DONE,
+            PolymarketSwapUsdcRound.auto_round_id(): Event.SWAP_DONE,
         }
 
         synced_data = SynchronizedData(self.synchronized_data.db)
@@ -177,6 +182,10 @@ class FailedMultiplexerRound(DegenerateRound):
     """Round that represents failure in identifying the transmitter round."""
 
 
+class FinishedPolymarketSwapTxRound(DegenerateRound):
+    """Round that represents that polymarket swap has finished."""
+
+
 class TxSettlementMultiplexerAbciApp(AbciApp[Event]):
     """TxSettlementMultiplexerAbciApp
 
@@ -228,6 +237,7 @@ class TxSettlementMultiplexerAbciApp(AbciApp[Event]):
             Event.BET_PLACEMENT_DONE: FinishedBetPlacementTxRound,
             Event.SELL_OUTCOME_TOKENS_DONE: FinishedSellOutcomeTokensTxRound,
             Event.REDEEMING_DONE: FinishedRedeemingTxRound,
+            Event.SWAP_DONE: FinishedPolymarketSwapTxRound,
             Event.STAKING_DONE: FinishedStakingTxRound,
             Event.SUBSCRIPTION_DONE: FinishedSubscriptionTxRound,
             Event.SET_APPROVAL_DONE: FinishedSetApprovalTxRound,
@@ -241,6 +251,7 @@ class TxSettlementMultiplexerAbciApp(AbciApp[Event]):
         FinishedSubscriptionTxRound: {},
         FinishedSetApprovalTxRound: {},
         FinishedRedeemingTxRound: {},
+        FinishedPolymarketSwapTxRound: {},
         FinishedStakingTxRound: {},
         FailedMultiplexerRound: {},
     }
@@ -253,6 +264,7 @@ class TxSettlementMultiplexerAbciApp(AbciApp[Event]):
         FinishedBetPlacementTxRound,
         FinishedSellOutcomeTokensTxRound,
         FinishedRedeemingTxRound,
+        FinishedPolymarketSwapTxRound,
         FinishedStakingTxRound,
         FinishedSubscriptionTxRound,
         FinishedSetApprovalTxRound,
@@ -268,6 +280,7 @@ class TxSettlementMultiplexerAbciApp(AbciApp[Event]):
         FinishedBetPlacementTxRound: set(),
         FinishedSellOutcomeTokensTxRound: set(),
         FinishedRedeemingTxRound: set(),
+        FinishedPolymarketSwapTxRound: set(),
         FinishedStakingTxRound: set(),
         FailedMultiplexerRound: set(),
         FinishedSubscriptionTxRound: set(),


### PR DESCRIPTION
- Adds round and behavior to swap POL to USDC on agent safe. Needed for mech requests
- Keeps 2 POL in the agent safe. All extra POL is converted to USDC
- Round sits between `ToolSelectionRound` and `DecisionRequestRound`, ie, just before placing a mech request
- Only runs for Polymarket trader