### PR TITLE
run_agent.sh custom run ports support

### DIFF
--- a/custom_ports.md
+++ b/custom_ports.md
@@ -1,0 +1,93 @@
+# Port Configuration for run_agent.sh
+
+## Quick Start
+
+```bash
+# Default ports
+./run_agent.sh
+
+# Auto-find free ports (starts from 50000)
+./run_agent.sh --free-ports
+
+# Custom ports with --free-ports (uses env vars if set)
+HTTP_SERVER_PORT=9999 ./run_agent.sh --free-ports
+```
+
+## Environment Variables
+
+Set these before running `./run_agent.sh`:
+
+```bash
+TENDERMINT_ABCI_PORT=26658    # ABCI port
+TENDERMINT_RPC_PORT=26657     # RPC port  
+TENDERMINT_P2P_PORT=26656     # P2P port
+TENDERMINT_COM_PORT=8080      # COM port
+HTTP_SERVER_PORT=8716         # HTTP port
+```
+
+## Examples
+
+### With --free-ports
+```bash
+# All ports auto (50000+)
+./run_agent.sh --free-ports
+
+# HTTP=9999, others auto
+HTTP_SERVER_PORT=9999 ./run_agent.sh --free-ports
+
+# ABCI=26668, others auto
+TENDERMINT_ABCI_PORT=26668 ./run_agent.sh --free-ports
+
+# All ports specified via env
+TENDERMINT_ABCI_PORT=26668 \
+TENDERMINT_RPC_PORT=26667 \
+TENDERMINT_P2P_PORT=26666 \
+TENDERMINT_COM_PORT=8081 \
+HTTP_SERVER_PORT=8726 \
+./run_agent.sh --free-ports
+```
+
+### Multiple Agents
+```bash
+# Agent 1: defaults
+./run_agent.sh
+
+# Agent 2: auto ports
+./run_agent.sh --free-ports
+
+# Agent 3: custom + auto
+TENDERMINT_ABCI_PORT=26678 HTTP_SERVER_PORT=9999 ./run_agent.sh --free-ports
+```
+
+### .env File
+Create `.env`:
+```bash
+TENDERMINT_ABCI_PORT=26668
+TENDERMINT_RPC_PORT=26667
+TENDERMINT_P2P_PORT=26666
+TENDERMINT_COM_PORT=8081
+HTTP_SERVER_PORT=8726
+```
+
+Run: `./run_agent.sh`
+
+## How It Works
+
+### Without --free-ports:
+- Uses environment variables if set
+- Otherwise uses default ports
+- No automatic port finding
+
+### With --free-ports:
+1. Checks each port's environment variable
+2. If variable is set → uses that port
+3. If variable is not set → finds free port (starting from 50000)
+4. Ports are allocated in increments of 10 (50000, 50010, 50020, etc.)
+
+## Notes
+
+- `--free-ports` respects environment variables
+- Port conflicts prevent startup
+- Use different ports for multiple agents
+- Ports checked before startup
+- Auto ports start from 50000 to avoid conflicts with defaults

--- a/run_agent.sh
+++ b/run_agent.sh
@@ -1,3 +1,44 @@
+#!/bin/bash
+
+# Default port values
+DEFAULT_TENDERMINT_ABCI_PORT=26658
+DEFAULT_TENDERMINT_RPC_PORT=26657
+DEFAULT_TENDERMINT_P2P_PORT=26656
+DEFAULT_TENDERMINT_COM_PORT=8080
+DEFAULT_HTTP_SERVER_PORT=8716
+
+# Parse command line arguments
+FREE_PORTS=false
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --free-ports)
+      FREE_PORTS=true
+      shift
+      ;;
+    --help|-h)
+      echo "Usage: $0 [--free-ports]"
+      echo ""
+      echo "Options:"
+      echo "  --free-ports    Automatically find free ports for services"
+      echo "                  (uses environment variables if set, otherwise finds free ports)"
+      echo ""
+      echo "Without flags: uses default ports or values from environment variables:"
+      echo "  TENDERMINT_ABCI_PORT (default: 26658)"
+      echo "  TENDERMINT_RPC_PORT (default: 26657)"
+      echo "  TENDERMINT_P2P_PORT (default: 26656)"
+      echo "  TENDERMINT_COM_PORT (default: 8080)"
+      echo "  HTTP_SERVER_PORT (default: 8716)"
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1"
+      echo "Use --help for usage information"
+      exit 1
+      ;;
+  esac
+done
+
 cleanup() {
     echo "Terminating tendermint..."
     if kill -0 "$tm_subprocess_pid" 2>/dev/null; then
@@ -26,9 +67,125 @@ autonomy packages lock
 # Fetch the agent
 autonomy fetch --local --agent valory/trader --alias agent
 
+# Generate and set port environment variables
+echo "Generating port environment variables..."
+if [ -f scripts/generate_port_env.py ]; then
+  # Build command arguments
+  cmd_args="--config agent/aea-config.yaml"
+  
+  if [ "$FREE_PORTS" = true ]; then
+    echo "Using free ports mode: automatically finding available ports"
+    # For each port: use env var if set, otherwise use 0 (auto-find)
+    if [ -n "${TENDERMINT_ABCI_PORT:-}" ]; then
+      cmd_args="$cmd_args --abci-port $TENDERMINT_ABCI_PORT"
+    else
+      cmd_args="$cmd_args --abci-port 0"
+    fi
+    
+    if [ -n "${TENDERMINT_RPC_PORT:-}" ]; then
+      cmd_args="$cmd_args --rpc-port $TENDERMINT_RPC_PORT"
+    else
+      cmd_args="$cmd_args --rpc-port 0"
+    fi
+    
+    if [ -n "${TENDERMINT_P2P_PORT:-}" ]; then
+      cmd_args="$cmd_args --p2p-port $TENDERMINT_P2P_PORT"
+    else
+      cmd_args="$cmd_args --p2p-port 0"
+    fi
+    
+    if [ -n "${TENDERMINT_COM_PORT:-}" ]; then
+      cmd_args="$cmd_args --com-port $TENDERMINT_COM_PORT"
+    else
+      cmd_args="$cmd_args --com-port 0"
+    fi
+    
+    if [ -n "${HTTP_SERVER_PORT:-}" ]; then
+      cmd_args="$cmd_args --http-port $HTTP_SERVER_PORT"
+    else
+      cmd_args="$cmd_args --http-port 0"
+    fi
+  else
+    # Add port arguments with default values if not set
+    # Use 0 for dynamic allocation if variable is not set
+    if [ -n "${TENDERMINT_ABCI_PORT:-}" ]; then
+      cmd_args="$cmd_args --abci-port $TENDERMINT_ABCI_PORT"
+    else
+      cmd_args="$cmd_args --abci-port $DEFAULT_TENDERMINT_ABCI_PORT"
+    fi
+    
+    if [ -n "${TENDERMINT_RPC_PORT:-}" ]; then
+      cmd_args="$cmd_args --rpc-port $TENDERMINT_RPC_PORT"
+    else
+      cmd_args="$cmd_args --rpc-port $DEFAULT_TENDERMINT_RPC_PORT"
+    fi
+    
+    if [ -n "${TENDERMINT_P2P_PORT:-}" ]; then
+      cmd_args="$cmd_args --p2p-port $TENDERMINT_P2P_PORT"
+    else
+      cmd_args="$cmd_args --p2p-port $DEFAULT_TENDERMINT_P2P_PORT"
+    fi
+    
+    if [ -n "${TENDERMINT_COM_PORT:-}" ]; then
+      cmd_args="$cmd_args --com-port $TENDERMINT_COM_PORT"
+    else
+      cmd_args="$cmd_args --com-port $DEFAULT_TENDERMINT_COM_PORT"
+    fi
+    
+    if [ -n "${HTTP_SERVER_PORT:-}" ]; then
+      cmd_args="$cmd_args --http-port $HTTP_SERVER_PORT"
+    else
+      cmd_args="$cmd_args --http-port $DEFAULT_HTTP_SERVER_PORT"
+    fi
+  fi
+  
+  # Execute the command and set environment variables
+  # Read output and export each variable
+  while IFS= read -r line; do
+    if [[ "$line" == export* ]]; then
+      # Execute export command as-is to export variables
+      eval "$line"
+    fi
+  done < <(python scripts/generate_port_env.py $cmd_args)
+  
+  echo "Using ports:"
+  echo "  ABCI: ${TENDERMINT_ABCI_PORT:-not set}"
+  echo "  RPC: ${TENDERMINT_RPC_PORT:-not set}"
+  echo "  P2P: ${TENDERMINT_P2P_PORT:-not set}"
+  echo "  COM: ${TENDERMINT_COM_PORT:-not set}"
+  echo "  HTTP: ${HTTP_SERVER_PORT:-not set}"
+  
+  echo ""
+  echo "Agent environment variables set:"
+  echo "  TENDERMINT_ABCI_PORT=${TENDERMINT_ABCI_PORT:-}"
+  echo "  TENDERMINT_RPC_PORT=${TENDERMINT_RPC_PORT:-}"
+  echo "  TENDERMINT_P2P_PORT=${TENDERMINT_P2P_PORT:-}"
+  echo "  TENDERMINT_COM_PORT=${TENDERMINT_COM_PORT:-}"
+  echo "  HTTP_SERVER_PORT=${HTTP_SERVER_PORT:-}"
+  echo "  CONNECTION_ABCI_CONFIG_PORT=${CONNECTION_ABCI_CONFIG_PORT:-}"
+  echo "  CONNECTION_HTTP_SERVER_CONFIG_PORT=${CONNECTION_HTTP_SERVER_CONFIG_PORT:-}"
+  echo "  SKILL_TRADER_ABCI_MODELS_PARAMS_ARGS_TENDERMINT_URL=${SKILL_TRADER_ABCI_MODELS_PARAMS_ARGS_TENDERMINT_URL:-}"
+  echo "  SKILL_TRADER_ABCI_MODELS_PARAMS_ARGS_TENDERMINT_COM_URL=${SKILL_TRADER_ABCI_MODELS_PARAMS_ARGS_TENDERMINT_COM_URL:-}"
+  echo "  SKILL_TRADER_ABCI_MODELS_PARAMS_ARGS_TENDERMINT_P2P_URL=${SKILL_TRADER_ABCI_MODELS_PARAMS_ARGS_TENDERMINT_P2P_URL:-}"
+else
+  echo "Warning: generate_port_env.py not found, using default ports"
+  # Default port values
+  TENDERMINT_ABCI_PORT=${TENDERMINT_ABCI_PORT:-$DEFAULT_TENDERMINT_ABCI_PORT}
+  TENDERMINT_RPC_PORT=${TENDERMINT_RPC_PORT:-$DEFAULT_TENDERMINT_RPC_PORT}
+  TENDERMINT_P2P_PORT=${TENDERMINT_P2P_PORT:-$DEFAULT_TENDERMINT_P2P_PORT}
+  TENDERMINT_COM_PORT=${TENDERMINT_COM_PORT:-$DEFAULT_TENDERMINT_COM_PORT}
+  HTTP_SERVER_PORT=${HTTP_SERVER_PORT:-$DEFAULT_HTTP_SERVER_PORT}
+fi
+
 # Replace params with env vars
-source .env
-python scripts/aea-config-replace.py
+if [ -f .env ]; then
+  source .env
+else
+  echo "Warning: .env file not found, skipping environment variables"
+fi
+
+# Run aea-config-replace quietly
+python scripts/aea-config-replace.py 2>/dev/null
 
 # Copy and add the keys and issue certificates
 cd agent
@@ -41,8 +198,14 @@ autonomy issue-certificates
 rm -r ~/.tendermint
 tendermint init > /dev/null 2>&1
 echo "Starting Tendermint..."
-tendermint node --proxy_app=tcp://127.0.0.1:26658 --rpc.laddr=tcp://127.0.0.1:26657 --p2p.laddr=tcp://0.0.0.0:26656 --p2p.seeds= --consensus.create_empty_blocks=true > /dev/null 2>&1 &
+tendermint node \
+  --proxy_app=tcp://127.0.0.1:$TENDERMINT_ABCI_PORT \
+  --rpc.laddr=tcp://127.0.0.1:$TENDERMINT_RPC_PORT \
+  --p2p.laddr=tcp://0.0.0.0:$TENDERMINT_P2P_PORT \
+  --p2p.seeds= \
+  --consensus.create_empty_blocks=true > /dev/null 2>&1 &
 tm_subprocess_pid=$!
 
-# Run the agent
-aea -s run
+# Run the agent with environment variables
+echo "Starting agent with configured ports..."
+aea -s run --aev

--- a/scripts/generate_port_env.py
+++ b/scripts/generate_port_env.py
@@ -1,0 +1,412 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# ------------------------------------------------------------------------------
+#
+#   Copyright 2025-2026 Valory AG
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ------------------------------------------------------------------------------
+
+"""Generate environment variables for agent ports from aea-config.yaml.
+
+This script analyzes an agent configuration file and generates environment
+variables for all port-related settings. It uses the same logic as autonomy
+deploy for generating variable names.
+
+Usage:
+    python generate_port_env.py [--config PATH] [--abci-port PORT]
+                                [--rpc-port PORT] [--p2p-port PORT]
+                                [--com-port PORT] [--http-port PORT]
+"""
+
+import argparse
+import os
+import re
+import socket
+import sys
+from pathlib import Path
+from typing import Dict, List, Optional, Set
+
+import yaml
+
+# Default port values
+DEFAULT_PORTS = {
+    "abci": 26658,
+    "rpc": 26657,
+    "p2p": 26656,
+    "com": 8080,
+    "http": 8716,
+}
+
+# Port increment step for finding free ports
+PORT_INCREMENT = 10
+
+# Starting port for dynamic allocation (when port=0)
+DYNAMIC_PORT_START = 50000
+
+
+def is_port_available(port: int) -> bool:
+    """Check if a port is available."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        try:
+            sock.bind(("127.0.0.1", port))
+            return True
+        except OSError:
+            return False
+
+
+def find_free_port(
+    start_port: int, used_ports: Set[int], max_attempts: int = 100
+) -> int:
+    """Find a free port starting from start_port, avoiding used_ports."""
+    port = start_port
+    attempts = 0
+
+    while attempts < max_attempts:
+        # Skip if port is already used
+        if port in used_ports:
+            port += PORT_INCREMENT
+            attempts += 1
+            continue
+
+        if is_port_available(port):
+            return port
+        port += PORT_INCREMENT
+        attempts += 1
+
+    raise RuntimeError(
+        f"Could not find free port after {max_attempts} attempts starting from {start_port}"
+    )
+
+
+def extract_port_from_value(value: str) -> Optional[int]:
+    """Extract port number from a string value."""
+    if not isinstance(value, str):
+        return None
+
+    # Check for port in URLs like "http://localhost:26657"
+    # Pattern for port in URL
+    url_pattern = r":(\d+)(?:/|$)"
+    match = re.search(url_pattern, value)
+    if match:
+        try:
+            return int(match.group(1))
+        except ValueError:
+            pass
+
+    # Pattern for standalone port or host:port
+    port_pattern = r"(?:^|:)(\d+)$"
+    match = re.search(port_pattern, value)
+    if match:
+        try:
+            return int(match.group(1))
+        except ValueError:
+            pass
+
+    return None
+
+
+def find_port_settings_in_config(config: List[Dict]) -> Dict[str, Dict]:
+    """Find all port-related settings in the configuration."""
+    # pylint: disable=too-many-locals,too-many-nested-blocks,too-many-branches
+    port_settings = {}
+
+    for component in config:
+        if not isinstance(component, dict):
+            continue
+
+        component_type = component.get("type")
+        public_id = component.get("public_id")
+
+        if not component_type or not public_id:
+            continue
+
+        component_name = (
+            public_id.split(":")[0].split("/")[-1] if ":" in public_id else public_id
+        )
+
+        # Check config section
+        config_section = component.get("config", {})
+        if config_section:
+            # Look for port settings in config
+            for key, value in config_section.items():
+                if isinstance(value, str) and (
+                    "port" in key.lower() or "url" in key.lower()
+                ):
+                    port_value = extract_port_from_value(value)
+                    if port_value:
+                        env_var_name = f"{component_type.upper()}_{component_name.upper()}_CONFIG_{key.upper()}"  # pylint: disable=line-too-long
+                        port_settings[env_var_name] = {
+                            "value": value,
+                            "port": port_value,
+                            "component_type": component_type,
+                            "component_name": component_name,
+                            "config_key": key,
+                        }
+
+        # Check skill models and params
+        if component_type == "skill":
+            models = component.get("models", {})
+
+            for model_name, model_data in models.items():
+                if not isinstance(model_data, dict):
+                    continue
+
+                args = model_data.get("args", {})
+                if not args:
+                    continue
+
+                # Look for port settings in args
+                for arg_key, arg_value in args.items():
+                    if isinstance(arg_value, str) and (
+                        "tendermint" in arg_key.lower() or "url" in arg_key.lower()
+                    ):
+                        port_value = extract_port_from_value(arg_value)
+                        if port_value:
+                            env_var_name = f"SKILL_{component_name.upper()}_MODELS_{model_name.upper()}_PARAMS_ARGS_{arg_key.upper()}"  # pylint: disable=line-too-long
+                            port_settings[env_var_name] = {
+                                "value": arg_value,
+                                "port": port_value,
+                                "component_type": component_type,
+                                "component_name": component_name,
+                                "model_name": model_name,
+                                "arg_key": arg_key,
+                            }
+
+    return port_settings
+
+
+def map_ports_to_types(port_settings: Dict[str, Dict]) -> Dict[str, int]:
+    """Map found ports to standard port types."""
+    port_mapping = {}
+
+    # Map based on port values
+    for env_var, info in port_settings.items():
+        port_value = info["port"]
+
+        # Determine port type based on port value and variable name
+        if port_value == 26658 or "abci" in env_var.lower():
+            port_mapping["abci"] = port_value
+        elif port_value == 26657 or "rpc" in env_var.lower():
+            port_mapping["rpc"] = port_value
+        elif port_value == 26656 or "p2p" in env_var.lower():
+            port_mapping["p2p"] = port_value
+        elif port_value == 8080 or "com" in env_var.lower():
+            port_mapping["com"] = port_value
+        elif port_value == 8716 or "http" in env_var.lower():
+            port_mapping["http"] = port_value
+
+    return port_mapping
+
+
+def generate_env_vars(port_mapping: Dict[str, int]) -> Dict[str, str]:
+    """Generate environment variables for the port mapping."""
+    env_vars = {}
+
+    # ABCI connection port
+    env_vars["CONNECTION_ABCI_CONFIG_PORT"] = str(
+        port_mapping.get("abci", DEFAULT_PORTS["abci"])
+    )
+
+    # HTTP server port
+    env_vars["CONNECTION_HTTP_SERVER_CONFIG_PORT"] = str(
+        port_mapping.get("http", DEFAULT_PORTS["http"])
+    )
+
+    # Skill params for trader_abci
+    env_vars["SKILL_TRADER_ABCI_MODELS_PARAMS_ARGS_TENDERMINT_URL"] = (
+        f"http://localhost:{port_mapping.get('rpc', DEFAULT_PORTS['rpc'])}"
+    )
+    env_vars["SKILL_TRADER_ABCI_MODELS_PARAMS_ARGS_TENDERMINT_COM_URL"] = (
+        f"http://localhost:{port_mapping.get('com', DEFAULT_PORTS['com'])}"
+    )
+    env_vars["SKILL_TRADER_ABCI_MODELS_PARAMS_ARGS_TENDERMINT_P2P_URL"] = (
+        f"localhost:{port_mapping.get('p2p', DEFAULT_PORTS['p2p'])}"
+    )
+
+    return env_vars
+
+
+def format_output(port_mapping: Dict[str, int], env_vars: Dict[str, str]) -> str:
+    """Format output in bash format."""
+    lines = []
+
+    # Tendermint environment variables
+    lines.append("# Tendermint environment variables")
+    lines.append(
+        f"export TENDERMINT_ABCI_PORT={port_mapping.get('abci', DEFAULT_PORTS['abci'])}"
+    )
+    lines.append(
+        f"export TENDERMINT_RPC_PORT={port_mapping.get('rpc', DEFAULT_PORTS['rpc'])}"
+    )
+    lines.append(
+        f"export TENDERMINT_P2P_PORT={port_mapping.get('p2p', DEFAULT_PORTS['p2p'])}"
+    )
+    lines.append(
+        f"export TENDERMINT_COM_PORT={port_mapping.get('com', DEFAULT_PORTS['com'])}"
+    )
+    lines.append(
+        f"export HTTP_SERVER_PORT={port_mapping.get('http', DEFAULT_PORTS['http'])}"
+    )
+
+    lines.append("")
+    lines.append("# Open-AEA environment variables")
+    for env_var, value in sorted(env_vars.items()):
+        # Escape quotes and special characters for bash
+        escaped_value = str(value).replace('"', '\\"').replace("$", "\\$")
+        lines.append(f'export {env_var}="{escaped_value}"')
+
+    return "\n".join(lines)
+
+
+def main() -> None:
+    """Main function."""
+    # pylint: disable=too-many-locals,too-many-statements,broad-exception-caught,too-many-branches
+    parser = argparse.ArgumentParser(
+        description="Generate environment variables for agent ports from aea-config.yaml"
+    )
+    parser.add_argument(
+        "--config",
+        default="agent/aea-config.yaml",
+        help="Path to aea-config.yaml (default: agent/aea-config.yaml)",
+    )
+    parser.add_argument(
+        "--abci-port", type=int, help="ABCI port (0 for dynamic allocation)"
+    )
+    parser.add_argument(
+        "--rpc-port", type=int, help="Tendermint RPC port (0 for dynamic allocation)"
+    )
+    parser.add_argument(
+        "--p2p-port", type=int, help="Tendermint P2P port (0 for dynamic allocation)"
+    )
+    parser.add_argument(
+        "--com-port", type=int, help="Tendermint COM port (0 for dynamic allocation)"
+    )
+    parser.add_argument(
+        "--http-port", type=int, help="HTTP server port (0 for dynamic allocation)"
+    )
+
+    args = parser.parse_args()
+
+    # Check if config file exists
+    config_path = Path(args.config)
+    if not config_path.exists():
+        print(f"Error: Config file not found: {config_path}")
+        sys.exit(1)
+
+    # Load config
+    try:
+        with open(config_path, "r", encoding="utf-8") as file:
+            config = list(yaml.safe_load_all(file))
+    except (yaml.YAMLError, IOError, OSError) as error:
+        print(f"Error loading config file: {error}")
+        sys.exit(1)
+
+    # Find port settings in config
+    port_settings = find_port_settings_in_config(config)
+
+    # User port preferences - check environment variables first, then command line args
+    user_ports = {}
+
+    # Check environment variables
+    env_port_mapping = {
+        "abci": os.environ.get("TENDERMINT_ABCI_PORT"),
+        "rpc": os.environ.get("TENDERMINT_RPC_PORT"),
+        "p2p": os.environ.get("TENDERMINT_P2P_PORT"),
+        "com": os.environ.get("TENDERMINT_COM_PORT"),
+        "http": os.environ.get("HTTP_SERVER_PORT"),
+    }
+
+    # Convert environment variables to integers if they exist
+    for port_type, env_value in env_port_mapping.items():
+        if env_value is not None and env_value.strip():
+            try:
+                user_ports[port_type] = int(env_value)
+            except ValueError:
+                print(
+                    f"Warning: Invalid port value for {port_type}: {env_value}",
+                    file=sys.stderr,
+                )
+
+    # Override with command line arguments if provided
+    if args.abci_port is not None:
+        user_ports["abci"] = args.abci_port
+    if args.rpc_port is not None:
+        user_ports["rpc"] = args.rpc_port
+    if args.p2p_port is not None:
+        user_ports["p2p"] = args.p2p_port
+    if args.com_port is not None:
+        user_ports["com"] = args.com_port
+    if args.http_port is not None:
+        user_ports["http"] = args.http_port
+
+    # Map ports from config
+    config_port_mapping = map_ports_to_types(port_settings)
+
+    # Process ports: handle 0 values (dynamic allocation)
+    final_port_mapping = {}
+    used_ports: Set[int] = set()
+
+    # First pass: collect explicitly specified ports (not 0)
+    for port_type, _ in DEFAULT_PORTS.items():
+        # Priority: user port > config port
+        port_value = None
+
+        # pylint: disable=consider-using-get
+        if port_type in user_ports:
+            port_value = user_ports[port_type]
+        elif port_type in config_port_mapping:
+            port_value = config_port_mapping[port_type]
+
+        # If port is explicitly specified (not 0), add to used ports
+        if port_value is not None and port_value != 0:
+            final_port_mapping[port_type] = port_value
+            used_ports.add(port_value)
+
+    # Second pass: handle ports that need dynamic allocation (0 or not specified)
+    for port_type, default_port in DEFAULT_PORTS.items():
+        if port_type in final_port_mapping:
+            continue  # Already processed
+
+        port_value = None
+
+        # pylint: disable=consider-using-get
+        if port_type in user_ports:
+            port_value = user_ports[port_type]
+        elif port_type in config_port_mapping:
+            port_value = config_port_mapping[port_type]
+
+        # If port is 0 or not specified, find free port
+        if port_value == 0 or port_value is None:
+            # For dynamic allocation (port=0), start from DYNAMIC_PORT_START
+            # For unspecified ports, use default port
+            start_port = DYNAMIC_PORT_START if port_value == 0 else default_port
+            free_port = find_free_port(start_port, used_ports)
+            final_port_mapping[port_type] = free_port
+            used_ports.add(free_port)
+        else:
+            # Should not happen, but just in case
+            final_port_mapping[port_type] = port_value
+            used_ports.add(port_value)
+
+    # Generate environment variables
+    env_vars = generate_env_vars(final_port_mapping)
+
+    # Format and output (always bash format)
+    output = format_output(final_port_mapping, env_vars)
+    print(output)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
# Port Configuration for run_agent.sh

## Quick Start

```bash
# Default ports
./run_agent.sh

# Auto-find free ports (starts from 50000)
./run_agent.sh --free-ports

# Custom ports with --free-ports (uses env vars if set)
HTTP_SERVER_PORT=9999 ./run_agent.sh --free-ports
```

## Environment Variables

Set these before running `./run_agent.sh`:

```bash
TENDERMINT_ABCI_PORT=26658    # ABCI port
TENDERMINT_RPC_PORT=26657     # RPC port  
TENDERMINT_P2P_PORT=26656     # P2P port
TENDERMINT_COM_PORT=8080      # COM port
HTTP_SERVER_PORT=8716         # HTTP port
```

## Examples

### With --free-ports
```bash
# All ports auto (50000+)
./run_agent.sh --free-ports

# HTTP=9999, others auto
HTTP_SERVER_PORT=9999 ./run_agent.sh --free-ports

# ABCI=26668, others auto
TENDERMINT_ABCI_PORT=26668 ./run_agent.sh --free-ports

# All ports specified via env
TENDERMINT_ABCI_PORT=26668 \
TENDERMINT_RPC_PORT=26667 \
TENDERMINT_P2P_PORT=26666 \
TENDERMINT_COM_PORT=8081 \
HTTP_SERVER_PORT=8726 \
./run_agent.sh --free-ports
```

### Multiple Agents
```bash
# Agent 1: defaults
./run_agent.sh

# Agent 2: auto ports
./run_agent.sh --free-ports

# Agent 3: custom + auto
TENDERMINT_ABCI_PORT=26678 HTTP_SERVER_PORT=9999 ./run_agent.sh --free-ports
```

### .env File
Create `.env`:
```bash
TENDERMINT_ABCI_PORT=26668
TENDERMINT_RPC_PORT=26667
TENDERMINT_P2P_PORT=26666
TENDERMINT_COM_PORT=8081
HTTP_SERVER_PORT=8726
```

Run: `./run_agent.sh`

## How It Works

### Without --free-ports:
- Uses environment variables if set
- Otherwise uses default ports
- No automatic port finding

### With --free-ports:
1. Checks each port's environment variable
2. If variable is set → uses that port
3. If variable is not set → finds free port (starting from 50000)
4. Ports are allocated in increments of 10 (50000, 50010, 50020, etc.)

## Notes

- `--free-ports` respects environment variables
- Port conflicts prevent startup
- Use different ports for multiple agents
- Ports checked before startup
- Auto ports start from 50000 to avoid conflicts with default