### PR TITLE
chore: update trader_pearl strategies_kwargs defaults

### DIFF
--- a/packages/packages.json
+++ b/packages/packages.json
@@ -19,7 +19,7 @@
         "skill/valory/check_stop_trading_abci/0.1.0": "bafybeigkjhx3lsefh43d5vaphjrsxdc4oskws535rsc6ap7lun4vjre7ae",
         "skill/valory/chatui_abci/0.1.0": "bafybeibshnto5jg7iym7lgue76x2wcb4z4twogov3njvk3sjfskke5wm6y",
         "agent/valory/trader/0.1.0": "bafybeifurop5izz6hcw3fszdmddxanyigljajsekyeydwwnvz4fj2vwbfu",
-        "service/valory/trader_pearl/0.1.0": "bafybeifletikritktzbapc7yrfzao3kv2ctly7mdl4ado7exwmiuak22ea",
+        "service/valory/trader_pearl/0.1.0": "bafybeiapylikbz2uyrhmbflm2e47tasxksbemzlmocho2f5syv6khpwbyi",
         "service/valory/polymarket_trader/0.1.0": "bafybeiaz6avxczo4zh3v566i2iwherq3qjromc5veabp4rygzy7nhq7pdi"
     },
     "third_party": {

--- a/packages/valory/services/trader_pearl/service.yaml
+++ b/packages/valory/services/trader_pearl/service.yaml
@@ -93,7 +93,7 @@ models:
       mech_wrapped_native_token_address: ${MECH_WRAPPED_NATIVE_TOKEN_ADDRESS:str:0xe91D153E0b41518A2Ce8Dd3D7944Fa863463a97d}
       sample_bets_closing_days: ${SAMPLE_BETS_CLOSING_DAYS:int:10}
       trading_strategy: ${TRADING_STRATEGY:str:kelly_criterion}
-      use_fallback_strategy: ${USE_FALLBACK_STRATEGY:bool:true}
+      use_fallback_strategy: ${USE_FALLBACK_STRATEGY:bool:false}
       mech_activity_checker_contract: ${MECH_ACTIVITY_CHECKER_CONTRACT:str:0x0000000000000000000000000000000000000000}
       ipfs_address: ${IPFS_ADDRESS:str:https://gateway.autonolas.tech/ipfs/}
       tools_accuracy_hash: ${TOOLS_ACCURACY_HASH:str:QmR8etyW3TPFadNtNrW54vfnFqmh8vBrMARWV76EmxCZyk}
@@ -126,7 +126,7 @@ models:
       redeem_round_timeout: ${REDEEM_ROUND_TIMEOUT:float:3600.0}
       contract_timeout: ${CONTRACT_TIMEOUT:float:300.0}
       file_hash_to_strategies: ${FILE_HASH_TO_STRATEGIES:dict:{"bafybeididlcixparvundh76gajplac2ab4ftzcom4cyaeli2ofl5dkdhaa":["kelly_criterion"],"bafybeigp65doxrfukxdndsyflukyf6tjigvobig42334e2gfncczteujvm":["fixed_bet"]}}
-      strategies_kwargs: ${STRATEGIES_KWARGS:dict:{"floor_balance":500000000000000000,"default_max_bet_size":2000000000000000000,"absolute_min_bet_size":25000000000000000,"absolute_max_bet_size":2000000000000000000,"n_bets":5,"min_edge":0.03,"min_oracle_prob":0.5,"fee_per_trade":10000000000000000,"grid_points":500}}
+      strategies_kwargs: ${STRATEGIES_KWARGS:dict:{"floor_balance":0,"default_max_bet_size":2000000000000000000,"absolute_min_bet_size":25000000000000000,"absolute_max_bet_size":2000000000000000000,"n_bets":1,"min_edge":0.03,"min_oracle_prob":0.5,"fee_per_trade":10000000000000000,"grid_points":500}}
       use_subgraph_for_redeeming: ${USE_SUBGRAPH_FOR_REDEEMING:bool:true}
       use_mech_marketplace: ${USE_MECH_MARKETPLACE:bool:false}
       mech_marketplace_config: ${MECH_MARKETPLACE_CONFIG:dict:{"mech_marketplace_address":"0x4554fE75c1f5576c1d7F765B2A036c199Adae329","priority_mech_address":"0x0000000000000000000000000000000000000000","priority_mech_staking_instance_address":"0x998dEFafD094817EF329f6dc79c703f1CF18bC90","priority_mech_service_id":975,"requester_staking_instance_address":"0x0000000000000000000000000000000000000000","response_timeout":300}}


### PR DESCRIPTION
## Summary
- Set `floor_balance` to 0 (from 0.5 USDC)
- Set `n_bets` to 1 (from 5)
- Disable `use_fallback_strategy` (set to false)

## Test plan
- [ ] Verify trader_pearl service starts with updated defaults
- [ ] Confirm betting behaviour with new parameters

🤖 Generated with [Claude Code](https://claude.com/claude-code)