### PR TITLE
fix: replace addnab/docker-run-action with maintained fork

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,16 +11,9 @@ jobs:
   publish-packages:
     name: Push Packages
     runs-on: ubuntu-24.04
-    strategy:
-      matrix:
-        os: [ubuntu-24.04]
-        python-version: ["3.10"]
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
-        with:
-          python-version: ${{ matrix.python-versions }}
-      - uses: addnab/docker-run-action@v3
+      - uses: maus007/docker-run-action-fork@v3
         with:
           image: valory/open-autonomy-user:0.21.16
           options: -v ${{ github.workspace }}:/work
@@ -45,7 +38,7 @@ jobs:
           fetch-depth: 0
       - uses: docker/setup-buildx-action@v3
       - name: Set up tag and vars
-        uses: addnab/docker-run-action@v3
+        uses: maus007/docker-run-action-fork@v3
         with:
           image: valory/open-autonomy-user:0.21.16
           options: -v ${{ github.workspace }}:/work
@@ -69,7 +62,7 @@ jobs:
             echo DEFAULT_IMAGE_TAG=$(cat packages/packages.json | grep agent/ | awk -F: '{print $2}' | tr -d '", ' | head -n 1) >> env.sh
             cat env.sh
 
-      - uses: addnab/docker-run-action@v3
+      - uses: maus007/docker-run-action-fork@v3
         name: Build Images
         with:
           image: valory/open-autonomy-user:0.21.16
@@ -101,7 +94,7 @@ jobs:
           fetch-depth: 0
       - uses: docker/setup-buildx-action@v3
       - name: Set up tag and vars
-        uses: addnab/docker-run-action@v3
+        uses: maus007/docker-run-action-fork@v3
         with:
           image: valory/open-autonomy-user:0.21.16
           options: -v ${{ github.workspace }}:/work
@@ -125,7 +118,7 @@ jobs:
             echo DEFAULT_IMAGE_TAG=$(cat packages/packages.json | grep agent/ | awk -F: '{print $2}' | tr -d '", ' | head -n 1) >> env.sh
             cat env.sh
 
-      - uses: addnab/docker-run-action@v3
+      - uses: maus007/docker-run-action-fork@v3
         name: Build Images
         with:
           image: valory/open-autonomy-user:0.21.16
@@ -154,7 +147,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Set up tag and vars
-        uses: addnab/docker-run-action@v3
+        uses: maus007/docker-run-action-fork@v3
         with:
           image: valory/open-autonomy-user:0.21.16
           options: -v ${{ github.workspace }}:/work

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -38,29 +38,16 @@ jobs:
           fetch-depth: 0
       - uses: docker/setup-buildx-action@v3
       - name: Set up tag and vars
-        uses: maus007/docker-run-action-fork@v1
-        with:
-          image: valory/open-autonomy-user:0.21.16
-          options: -v ${{ github.workspace }}:/work
-          shell: bash
-          run: |
-            echo "Setting Tag Images"
-            cd /work
-            apt-get update && apt-get install git -y || exit 1
-            git config --global --add safe.directory /work
-            export TAG=$(git describe --exact-match --tags $(git rev-parse HEAD)) || exit 1
-            if [ $? -eq 0 ]; then
-                export TAG=`echo $TAG | sed 's/^v//'`
-            else
-                echo "You are not on a tagged branch"
-                exit 1
-            fi
-            echo VERSION=$TAG > env.sh
-            echo AUTHOR=$(grep 'service/' packages/packages.json | awk -F/ '{print $2}' | head -1) >> env.sh
-            echo SERVICE=$(grep 'service/' packages/packages.json | awk -F/ '{print $3}' | head -1) >> env.sh
-            echo AGENT=$(grep 'agent/' packages/packages.json | awk -F/ '{print $3}' | head -1) >> env.sh
-            echo DEFAULT_IMAGE_TAG=$(cat packages/packages.json | grep agent/ | awk -F: '{print $2}' | tr -d '", ' | head -n 1) >> env.sh
-            cat env.sh
+        run: |
+          echo "Setting Tag Images"
+          TAG=$(git describe --exact-match --tags $(git rev-parse HEAD)) || { echo "You are not on a tagged branch"; exit 1; }
+          TAG=$(echo $TAG | sed 's/^v//')
+          echo VERSION=$TAG > env.sh
+          echo AUTHOR=$(grep 'service/' packages/packages.json | awk -F/ '{print $2}' | head -1) >> env.sh
+          echo SERVICE=$(grep 'service/' packages/packages.json | awk -F/ '{print $3}' | head -1) >> env.sh
+          echo AGENT=$(grep 'agent/' packages/packages.json | awk -F/ '{print $3}' | head -1) >> env.sh
+          echo DEFAULT_IMAGE_TAG=$(cat packages/packages.json | grep agent/ | awk -F: '{print $2}' | tr -d '", ' | head -n 1) >> env.sh
+          cat env.sh
 
       - uses: maus007/docker-run-action-fork@v1
         name: Build Images
@@ -94,29 +81,16 @@ jobs:
           fetch-depth: 0
       - uses: docker/setup-buildx-action@v3
       - name: Set up tag and vars
-        uses: maus007/docker-run-action-fork@v1
-        with:
-          image: valory/open-autonomy-user:0.21.16
-          options: -v ${{ github.workspace }}:/work
-          shell: bash
-          run: |
-            echo "Setting Tag Images"
-            cd /work
-            apt-get update && apt-get install git -y || exit 1
-            git config --global --add safe.directory /work
-            export TAG=$(git describe --exact-match --tags $(git rev-parse HEAD)) || exit 1
-            if [ $? -eq 0 ]; then
-                export TAG=`echo $TAG | sed 's/^v//'`
-            else
-                echo "You are not on a tagged branch"
-                exit 1
-            fi
-            echo VERSION=$TAG > env.sh
-            echo AUTHOR=$(grep 'service/' packages/packages.json | awk -F/ '{print $2}' | head -1) >> env.sh
-            echo SERVICE=$(grep 'service/' packages/packages.json | awk -F/ '{print $3}' | head -1) >> env.sh
-            echo AGENT=$(grep 'agent/' packages/packages.json | awk -F/ '{print $3}' | head -1) >> env.sh
-            echo DEFAULT_IMAGE_TAG=$(cat packages/packages.json | grep agent/ | awk -F: '{print $2}' | tr -d '", ' | head -n 1) >> env.sh
-            cat env.sh
+        run: |
+          echo "Setting Tag Images"
+          TAG=$(git describe --exact-match --tags $(git rev-parse HEAD)) || { echo "You are not on a tagged branch"; exit 1; }
+          TAG=$(echo $TAG | sed 's/^v//')
+          echo VERSION=$TAG > env.sh
+          echo AUTHOR=$(grep 'service/' packages/packages.json | awk -F/ '{print $2}' | head -1) >> env.sh
+          echo SERVICE=$(grep 'service/' packages/packages.json | awk -F/ '{print $3}' | head -1) >> env.sh
+          echo AGENT=$(grep 'agent/' packages/packages.json | awk -F/ '{print $3}' | head -1) >> env.sh
+          echo DEFAULT_IMAGE_TAG=$(cat packages/packages.json | grep agent/ | awk -F: '{print $2}' | tr -d '", ' | head -n 1) >> env.sh
+          cat env.sh
 
       - uses: maus007/docker-run-action-fork@v1
         name: Build Images
@@ -147,28 +121,15 @@ jobs:
         with:
           fetch-depth: 0
       - name: Set up tag and vars
-        uses: maus007/docker-run-action-fork@v1
-        with:
-          image: valory/open-autonomy-user:0.21.16
-          options: -v ${{ github.workspace }}:/work
-          shell: bash
-          run: |
-            echo "Setting Tag Images"
-            cd /work
-            apt-get update && apt-get install git -y || exit 1
-            git config --global --add safe.directory /work
-            export TAG=$(git describe --exact-match --tags $(git rev-parse HEAD)) || exit 1
-            if [ $? -eq 0 ]; then
-                export TAG=`echo $TAG | sed 's/^v//'`
-            else
-                echo "You are not on a tagged branch"
-                exit 1
-            fi
-            echo VERSION=$TAG > env.sh
-            echo AUTHOR=$(grep 'service/' packages/packages.json | awk -F/ '{print $2}' | head -1) >> env.sh
-            echo AGENT=$(grep 'agent/' packages/packages.json | awk -F/ '{print $3}' | head -1) >> env.sh
-            echo DEFAULT_IMAGE_TAG=$(cat packages/packages.json | grep agent/ | awk -F: '{print $2}' | tr -d '", ' | head -n 1) >> env.sh
-            cat env.sh
+        run: |
+          echo "Setting Tag Images"
+          TAG=$(git describe --exact-match --tags $(git rev-parse HEAD)) || { echo "You are not on a tagged branch"; exit 1; }
+          TAG=$(echo $TAG | sed 's/^v//')
+          echo VERSION=$TAG > env.sh
+          echo AUTHOR=$(grep 'service/' packages/packages.json | awk -F/ '{print $2}' | head -1) >> env.sh
+          echo AGENT=$(grep 'agent/' packages/packages.json | awk -F/ '{print $3}' | head -1) >> env.sh
+          echo DEFAULT_IMAGE_TAG=$(cat packages/packages.json | grep agent/ | awk -F: '{print $2}' | tr -d '", ' | head -n 1) >> env.sh
+          cat env.sh
 
       - name: Merge manifests
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
-      - uses: maus007/docker-run-action-fork@v3
+      - uses: maus007/docker-run-action-fork@v1
         with:
           image: valory/open-autonomy-user:0.21.16
           options: -v ${{ github.workspace }}:/work
@@ -38,7 +38,7 @@ jobs:
           fetch-depth: 0
       - uses: docker/setup-buildx-action@v3
       - name: Set up tag and vars
-        uses: maus007/docker-run-action-fork@v3
+        uses: maus007/docker-run-action-fork@v1
         with:
           image: valory/open-autonomy-user:0.21.16
           options: -v ${{ github.workspace }}:/work
@@ -62,7 +62,7 @@ jobs:
             echo DEFAULT_IMAGE_TAG=$(cat packages/packages.json | grep agent/ | awk -F: '{print $2}' | tr -d '", ' | head -n 1) >> env.sh
             cat env.sh
 
-      - uses: maus007/docker-run-action-fork@v3
+      - uses: maus007/docker-run-action-fork@v1
         name: Build Images
         with:
           image: valory/open-autonomy-user:0.21.16
@@ -94,7 +94,7 @@ jobs:
           fetch-depth: 0
       - uses: docker/setup-buildx-action@v3
       - name: Set up tag and vars
-        uses: maus007/docker-run-action-fork@v3
+        uses: maus007/docker-run-action-fork@v1
         with:
           image: valory/open-autonomy-user:0.21.16
           options: -v ${{ github.workspace }}:/work
@@ -118,7 +118,7 @@ jobs:
             echo DEFAULT_IMAGE_TAG=$(cat packages/packages.json | grep agent/ | awk -F: '{print $2}' | tr -d '", ' | head -n 1) >> env.sh
             cat env.sh
 
-      - uses: maus007/docker-run-action-fork@v3
+      - uses: maus007/docker-run-action-fork@v1
         name: Build Images
         with:
           image: valory/open-autonomy-user:0.21.16
@@ -147,7 +147,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Set up tag and vars
-        uses: maus007/docker-run-action-fork@v3
+        uses: maus007/docker-run-action-fork@v1
         with:
           image: valory/open-autonomy-user:0.21.16
           options: -v ${{ github.workspace }}:/work


### PR DESCRIPTION
## Summary
- Replace `addnab/docker-run-action@v3` with `maus007/docker-run-action-fork@v1` which uses `docker:29` instead of the EOL `docker:20.10` base image that causes Docker Hub auth failures on GitHub Actions runners
- Convert "Set up tag and vars" steps from docker-run-action to plain shell — they only need `git` and `grep`, which are already on the runner
- Remove unused `setup-python` step and `strategy`/`matrix` from `publish-packages` job

## Test plan
- [x] Trigger a release and verify all jobs pass (publish-packages, publish-images, publish-images-arm, merge-image-manifests, build-agent-runner, upload-assets) https://github.com/valory-xyz/trader/actions/runs/23656722056

🤖 Generated with [Claude Code](https://claude.com/claude-code)