### PR TITLE
fix: ignore mech with unresolvable IPFS manifest

### DIFF
--- a/packages/packages.json
+++ b/packages/packages.json
@@ -19,7 +19,7 @@
         "skill/valory/check_stop_trading_abci/0.1.0": "bafybeiaawedash74gnujlt7bggjp46ikmemhlyiezwo3a4qbtlgt4ndyue",
         "skill/valory/chatui_abci/0.1.0": "bafybeig5nsxdjettw6wyd2smxaemcmfl7j7r6ki6mjatfa3ufik42jx75a",
         "agent/valory/trader/0.1.0": "bafybeidzckbtodjh5wm2uv4hqcghjnxcq746q7znufxmpbih2ka6jn3wva",
-        "service/valory/trader_pearl/0.1.0": "bafybeic62vtbayo3ijbhd6eswsnkbsuef5aamd76cyorsitzflna2hsxua",
+        "service/valory/trader_pearl/0.1.0": "bafybeic7jcczfxznc6q2erfmrnlbboxh4byjh3iqwmfk7yxbngcczeoxhi",
         "service/valory/polymarket_trader/0.1.0": "bafybeier3ajcxnrivh4robaqotlrbi2oig4udh6soa5htupb6fz33hxcme"
     },
     "third_party": {

--- a/packages/valory/services/trader_pearl/service.yaml
+++ b/packages/valory/services/trader_pearl/service.yaml
@@ -152,7 +152,7 @@ models:
       use_x402: ${USE_X402:bool:false}
       is_agent_performance_summary_enabled: ${IS_AGENT_PERFORMANCE_SUMMARY_ENABLED:bool:true}
       is_achievement_checker_enabled: ${IS_ACHIEVEMENT_CHECKER_ENABLED:bool:false}
-      ignored_mechs: ${IGNORED_MECHS:list:[]}
+      ignored_mechs: ${IGNORED_MECHS:list:["0x33ca1e117c4254b2ee8cd7ef1621739431a37396"]}
       penalize_mech_time_window: ${PENALIZE_MECH_TIME_WINDOW:int:1800}
       is_outcome_side_threshold_filter_enabled: ${IS_OUTCOME_SIDE_THRESHOLD_FILTER_ENABLED:bool:false}
       outcome_side_threshold_filter_threshold: ${OUTCOME_SIDE_THRESHOLD_FILTER_THRESHOLD:float:0.8}


### PR DESCRIPTION
## Summary
- Add mech `0x33ca1e117c4254b2ee8cd7ef1621739431a37396` to default `ignored_mechs` in `trader_pearl` service
- This mech's tools manifest on IPFS (`f017012203085e87c3232820023d7971e2b16c02c351d96435997766611dabc17afd050f0`) returns a corrupt PBNode (`protobuf: (PBNode) invalid wireType, expected 2, got 3`), causing `mech_information_round` to fail the whole batch after retries exhaust, emit `Event.NONE`, and loop back through `mech_version_detection_round` indefinitely
- Lock packages hash

## Test plan
- [x] Agent no longer loops between `mech_version_detection_round` and `mech_information_round`
- [x] `mech_information_round` completes successfully with the remaining mechs

🤖 Generated with [Claude Code](https://claude.com/claude-code)