### PR TITLE
chore(ci): add aggregate `All checks passed` gate

### DIFF
--- a/.github/workflows/common_checks.yaml
+++ b/.github/workflows/common_checks.yaml
@@ -252,3 +252,19 @@ jobs:
           files: ./coverage.xml
           flags: unittests
           fail_ci_if_error: false
+
+  all_checks_passed:
+    name: All checks passed
+    if: always()
+    needs:
+      - lock_check
+      - copyright_and_dependencies_check
+      - linter_checks
+      - scan
+      - test
+      - coverage
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Fail if any required job failed or was cancelled
+        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
+        run: exit 1


### PR DESCRIPTION
## Summary
- Adds a single `all_checks_passed` meta job in `common_checks.yaml` whose `needs` enumerate every mandatory job (`lock_check`, `copyright_and_dependencies_check`, `linter_checks`, `scan`, `test`, `coverage`).
- The job uses `if: always()` and fails if any dependency `failure` or `cancelled`, so it accurately reflects the aggregate status.
- Lets branch protection require a single stable context (`All checks passed`) instead of the full matrix. Adding/removing mandatory jobs is then a code change — update the `needs` list — rather than a branch-protection edit.

Once this lands, branch protection on `main` will be updated to require the `All checks passed` context with `strict: true`.

## Test plan
- [ ] CI runs all jobs as before
- [ ] `All checks passed` reports success when all upstream jobs pass
- [ ] `All checks passed` reports failure if any upstream job fails or is cancelled

🤖 Generated with [Claude Code](https://claude.com/claude-code)