### PR TITLE
fix(release): bump OA 0.21.18 → 0.21.20 in release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: maus007/docker-run-action-fork@v1
         with:
-          image: valory/open-autonomy-user:0.21.18
+          image: valory/open-autonomy-user:0.21.20
           options: -v ${{ github.workspace }}:/work
           shell: bash
           run: |
@@ -52,7 +52,7 @@ jobs:
       - uses: maus007/docker-run-action-fork@v1
         name: Build Images
         with:
-          image: valory/open-autonomy-user:0.21.18
+          image: valory/open-autonomy-user:0.21.20
           options: -v ${{ github.workspace }}:/work -e DOCKER_USER -e DOCKER_PASSWORD
           shell: bash
           run: |
@@ -65,7 +65,7 @@ jobs:
             cd $SERVICE || exit 1
             echo $DOCKER_PASSWORD | docker login -u $DOCKER_USER --password-stdin || exit 1
             docker buildx create --name multiarch-builder --driver docker-container --bootstrap --use
-            autonomy build-image --builder multiarch-builder --platform linux/amd64 --pre-install-command "apt update && apt upgrade -y && apt install -y libffi-dev libssl-dev" -e open-autonomy==0.21.18 --version $VERSION-amd64 --push || exit 1
+            autonomy build-image --builder multiarch-builder --platform linux/amd64 --pre-install-command "apt update && apt upgrade -y && apt install -y libffi-dev libssl-dev" -e open-autonomy==0.21.20 --version $VERSION-amd64 --push || exit 1
 
   publish-images-arm:
     name: Publish Docker Images (arm64 + arm/v7)
@@ -95,7 +95,7 @@ jobs:
       - uses: maus007/docker-run-action-fork@v1
         name: Build Images
         with:
-          image: valory/open-autonomy-user:0.21.18
+          image: valory/open-autonomy-user:0.21.20
           options: -v ${{ github.workspace }}:/work -e DOCKER_USER -e DOCKER_PASSWORD
           shell: bash
           run: |
@@ -108,7 +108,7 @@ jobs:
             cd $SERVICE || exit 1
             echo $DOCKER_PASSWORD | docker login -u $DOCKER_USER --password-stdin || exit 1
             docker buildx create --name multiarch-builder --driver docker-container --bootstrap --use
-            autonomy build-image --builder multiarch-builder --platform linux/arm64,linux/arm/v7 --pre-install-command "apt update && apt install -y libffi-dev libssl-dev && pip config set global.extra-index-url https://www.piwheels.org/simple" -e open-autonomy==0.21.18 --version $VERSION-arm --push || exit 1
+            autonomy build-image --builder multiarch-builder --platform linux/arm64,linux/arm/v7 --pre-install-command "apt update && apt install -y libffi-dev libssl-dev && pip config set global.extra-index-url https://www.piwheels.org/simple" -e open-autonomy==0.21.20 --version $VERSION-arm --push || exit 1
 
   merge-image-manifests:
     name: Merge Multi-arch Image Manifests


### PR DESCRIPTION
## Summary

- Wave-2 PR #925 bumped pyproject + agent YAMLs to **OA 0.21.20 / OAEA 2.2.3** but `release.yaml` was missed and still hardcoded `0.21.18`.
- The breaking ref is `-e open-autonomy==0.21.18` passed to `autonomy build-image` (×2, amd64 + arm). It's `EXTRA_DEPENDENCIES` — pip is forced to install old OA inside the agent container alongside the agent's bundled `open-aea-cli-ipfs==2.2.3` / `open-aea-ledger-cosmos==2.2.3`. OA 0.21.18 pins OAEA 2.2.1, so the Docker publish job fails with `ResolutionImpossible`.
- 3× runner-image refs (`valory/open-autonomy-user:0.21.18`) bumped for consistency too — those weren't strictly broken since the runner only hosts the `autonomy` CLI, but stale.
- Same drift exists in optimus + meme-ooorr (separate PRs to follow).

## Trigger

v0.35.5 release: https://github.com/valory-xyz/trader/actions/runs/25503746701

```
ERROR: Cannot install open-aea-ledger-cosmos==2.2.3 and open-autonomy==0.21.18
because these package versions have conflicting dependencies.
ERROR: ResolutionImpossible
```

## Test plan

- [ ] CI green on this PR
- [ ] After merge, re-tag (or push v0.35.6) and confirm Publish Docker Images (amd64 + arm64) succeed end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)