### PR TITLE
chore(trader): drop irrelevant_tools, collapse to valid_tools as single allowlist

### DIFF
--- a/packages/packages.json
+++ b/packages/packages.json
@@ -11,16 +11,16 @@
         "contract/valory/market_maker/0.1.0": "bafybeifknz35yxpfjzw3ivyk4ixdancnpuc74cziucruerxutvpcemi75m",
         "connection/valory/polymarket_client/0.1.0": "bafybeib4gnficoo23kwlfwcuaefzqwf5p7m2vuflg5oekimkwctcd6e3pm",
         "skill/valory/market_manager_abci/0.1.0": "bafybeia7nohjn3ela6epm6tlgqwdvezws2e2n2mbo27xhnxwp366vlqovq",
-        "skill/valory/decision_maker_abci/0.1.0": "bafybeibcp2ntfxpswi6pcbysj3wwqxwsvf2ylpsnoloyf43kg6em264mmu",
-        "skill/valory/trader_abci/0.1.0": "bafybeic3gbfmz255xnxm2z3pra5ed73azay4zhjvsuit5cn6yrh6wmf4vm",
-        "skill/valory/tx_settlement_multiplexer_abci/0.1.0": "bafybeied2ks2fbbzj6xlrziup6g5pmuhoqqv6m53f3c32l57yzdk5y4t5q",
+        "skill/valory/decision_maker_abci/0.1.0": "bafybeidnsqqlii35pgh2aeztydwbvyfbcgsrmky46mqwjpzsdukvyx6bmm",
+        "skill/valory/trader_abci/0.1.0": "bafybeihbxhqmnezkhpdv24le52buht2kj5cbspkvnaui7jptni7klg5t7q",
+        "skill/valory/tx_settlement_multiplexer_abci/0.1.0": "bafybeiejygkljdo7gscnmzsnzw2dxyweycvf63vudgnmjez3bv6fq54ugy",
         "skill/valory/staking_abci/0.1.0": "bafybeifr5puvjn722l6f5gngpsrpyb4xkcxiecbfhpewcnbuzr7hgp5ezu",
         "skill/valory/agent_performance_summary_abci/0.1.0": "bafybeihqm5ebfwdbcc7zan66ffv7lsp6jeyz6ydrj65lizm7rtzoyy6s3i",
         "skill/valory/check_stop_trading_abci/0.1.0": "bafybeib5gbqteso35q5lb3sgbgrafntnut775flbcgl6brwiktpouckba4",
         "skill/valory/chatui_abci/0.1.0": "bafybeicgoq2rdq3uzvjxoxny3hiis4i23eyq7v7vahd7wrwhxwl645agde",
-        "agent/valory/trader/0.1.0": "bafybeidsong7f3jfkmy4uvvm5xjzsz6ao5wa5x6eewnjc2x6mmluih3o6u",
-        "service/valory/trader_pearl/0.1.0": "bafybeice227fjlr6ylywbzfgblrzn5hxuwequ4hubnxkw2kcm4wx5xddc4",
-        "service/valory/polymarket_trader/0.1.0": "bafybeia25ns4gkamzlzdilkd7fu6y7utxa6moxnx3yzjzfvdply5cfbnjm"
+        "agent/valory/trader/0.1.0": "bafybeihb3zu3jimdibqnslscdn6zdt2a3orhe6avqt35yxqvfpajmftcii",
+        "service/valory/trader_pearl/0.1.0": "bafybeia7tgq2u4care2tifsjuaufnrffs675xbt3egnjpeeduo2ok4d6vi",
+        "service/valory/polymarket_trader/0.1.0": "bafybeigdfaporeg7ltoacy7jesxcbpxelmqmcmi6fr2fh5f6dyfgz5bloe"
     },
     "third_party": {
         "protocol/valory/acn_data_share/0.1.0": "bafybeieqisfr6lhaaesq37lk7vyaxza2h6nucshksgyo2djqfyf2saqo4i",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -11,16 +11,16 @@
         "contract/valory/market_maker/0.1.0": "bafybeifknz35yxpfjzw3ivyk4ixdancnpuc74cziucruerxutvpcemi75m",
         "connection/valory/polymarket_client/0.1.0": "bafybeib4gnficoo23kwlfwcuaefzqwf5p7m2vuflg5oekimkwctcd6e3pm",
         "skill/valory/market_manager_abci/0.1.0": "bafybeia7nohjn3ela6epm6tlgqwdvezws2e2n2mbo27xhnxwp366vlqovq",
-        "skill/valory/decision_maker_abci/0.1.0": "bafybeicjdnlu5cyzhby5vzkqkkrpqbcte5zh6cudjbsbkbla3uzxyvsmuy",
-        "skill/valory/trader_abci/0.1.0": "bafybeidnoxlnpzkbenaowtvkjttdmqvut4gtdqaiint47u3jtmueeakrri",
-        "skill/valory/tx_settlement_multiplexer_abci/0.1.0": "bafybeidhdqd2f7tgip43nqbsctik2jjz2jeioifr4xybb5a4x5tcn4kez4",
+        "skill/valory/decision_maker_abci/0.1.0": "bafybeibcp2ntfxpswi6pcbysj3wwqxwsvf2ylpsnoloyf43kg6em264mmu",
+        "skill/valory/trader_abci/0.1.0": "bafybeic3gbfmz255xnxm2z3pra5ed73azay4zhjvsuit5cn6yrh6wmf4vm",
+        "skill/valory/tx_settlement_multiplexer_abci/0.1.0": "bafybeied2ks2fbbzj6xlrziup6g5pmuhoqqv6m53f3c32l57yzdk5y4t5q",
         "skill/valory/staking_abci/0.1.0": "bafybeifr5puvjn722l6f5gngpsrpyb4xkcxiecbfhpewcnbuzr7hgp5ezu",
         "skill/valory/agent_performance_summary_abci/0.1.0": "bafybeihqm5ebfwdbcc7zan66ffv7lsp6jeyz6ydrj65lizm7rtzoyy6s3i",
-        "skill/valory/check_stop_trading_abci/0.1.0": "bafybeiajpixuxyvmtdai2ibw3caeu2xv2ie6ag5l7ifjptecyk47yz52oy",
+        "skill/valory/check_stop_trading_abci/0.1.0": "bafybeib5gbqteso35q5lb3sgbgrafntnut775flbcgl6brwiktpouckba4",
         "skill/valory/chatui_abci/0.1.0": "bafybeicgoq2rdq3uzvjxoxny3hiis4i23eyq7v7vahd7wrwhxwl645agde",
-        "agent/valory/trader/0.1.0": "bafybeievjf77mhhzpeygewbyfvvo2roa5xgz74l2gkism6lw4wxqi6w4a4",
-        "service/valory/trader_pearl/0.1.0": "bafybeifh44ipsuj6hwsypowltgjteg47za3awgz7forz4fmomooy27nouu",
-        "service/valory/polymarket_trader/0.1.0": "bafybeif3cbntynset73hkant7wwncrdcatkctjdausvj5rbroqxqxf2nxu"
+        "agent/valory/trader/0.1.0": "bafybeidsong7f3jfkmy4uvvm5xjzsz6ao5wa5x6eewnjc2x6mmluih3o6u",
+        "service/valory/trader_pearl/0.1.0": "bafybeice227fjlr6ylywbzfgblrzn5hxuwequ4hubnxkw2kcm4wx5xddc4",
+        "service/valory/polymarket_trader/0.1.0": "bafybeia25ns4gkamzlzdilkd7fu6y7utxa6moxnx3yzjzfvdply5cfbnjm"
     },
     "third_party": {
         "protocol/valory/acn_data_share/0.1.0": "bafybeieqisfr6lhaaesq37lk7vyaxza2h6nucshksgyo2djqfyf2saqo4i",
@@ -68,7 +68,7 @@
         "skill/valory/registration_abci/0.1.0": "bafybeietlh4pq5wjsb6srpsqehcq3gwsod5c6gs4jdiwpzkgrwyxhbbbvq",
         "skill/valory/reset_pause_abci/0.1.0": "bafybeifdzwzz5byan3ytsi46n4n2svtqme6475hk5z77sopymyzqszcpoa",
         "skill/valory/termination_abci/0.1.0": "bafybeiadbtzcvzkwbrosshlsubilj7mwzdqfni6dr75wsd3vawhslpwqeu",
-        "skill/valory/mech_interact_abci/0.1.0": "bafybeibcr5ifxkkeb4q3jbyxhri2yrydiunh5csifermqdcboa2ydybu6m",
+        "skill/valory/mech_interact_abci/0.1.0": "bafybeihds6vqk3gsevtsdsowz56jdnbbhc6gnswwd25opm6rrj32dhsmou",
         "skill/valory/funds_manager/0.1.0": "bafybeihuwnkgrhqixl4zj55fz2awptmpmdnmub2uzkgbx7rve7bnhkkl5i"
     }
 }

--- a/packages/valory/agents/trader/aea-config.yaml
+++ b/packages/valory/agents/trader/aea-config.yaml
@@ -65,13 +65,13 @@ skills:
 - valory/reset_pause_abci:0.1.0:bafybeifdzwzz5byan3ytsi46n4n2svtqme6475hk5z77sopymyzqszcpoa
 - valory/termination_abci:0.1.0:bafybeiadbtzcvzkwbrosshlsubilj7mwzdqfni6dr75wsd3vawhslpwqeu
 - valory/transaction_settlement_abci:0.1.0:bafybeigiojqgbi54jhree3sqrzaudbmjxb7y2ete74bbliryi3t7ztwi5q
-- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeidhdqd2f7tgip43nqbsctik2jjz2jeioifr4xybb5a4x5tcn4kez4
+- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeied2ks2fbbzj6xlrziup6g5pmuhoqqv6m53f3c32l57yzdk5y4t5q
 - valory/market_manager_abci:0.1.0:bafybeia7nohjn3ela6epm6tlgqwdvezws2e2n2mbo27xhnxwp366vlqovq
-- valory/decision_maker_abci:0.1.0:bafybeicjdnlu5cyzhby5vzkqkkrpqbcte5zh6cudjbsbkbla3uzxyvsmuy
-- valory/trader_abci:0.1.0:bafybeidnoxlnpzkbenaowtvkjttdmqvut4gtdqaiint47u3jtmueeakrri
+- valory/decision_maker_abci:0.1.0:bafybeibcp2ntfxpswi6pcbysj3wwqxwsvf2ylpsnoloyf43kg6em264mmu
+- valory/trader_abci:0.1.0:bafybeic3gbfmz255xnxm2z3pra5ed73azay4zhjvsuit5cn6yrh6wmf4vm
 - valory/staking_abci:0.1.0:bafybeifr5puvjn722l6f5gngpsrpyb4xkcxiecbfhpewcnbuzr7hgp5ezu
-- valory/check_stop_trading_abci:0.1.0:bafybeiajpixuxyvmtdai2ibw3caeu2xv2ie6ag5l7ifjptecyk47yz52oy
-- valory/mech_interact_abci:0.1.0:bafybeibcr5ifxkkeb4q3jbyxhri2yrydiunh5csifermqdcboa2ydybu6m
+- valory/check_stop_trading_abci:0.1.0:bafybeib5gbqteso35q5lb3sgbgrafntnut775flbcgl6brwiktpouckba4
+- valory/mech_interact_abci:0.1.0:bafybeihds6vqk3gsevtsdsowz56jdnbbhc6gnswwd25opm6rrj32dhsmou
 - valory/chatui_abci:0.1.0:bafybeicgoq2rdq3uzvjxoxny3hiis4i23eyq7v7vahd7wrwhxwl645agde
 - valory/agent_performance_summary_abci:0.1.0:bafybeihqm5ebfwdbcc7zan66ffv7lsp6jeyz6ydrj65lizm7rtzoyy6s3i
 - valory/funds_manager:0.1.0:bafybeihuwnkgrhqixl4zj55fz2awptmpmdnmub2uzkgbx7rve7bnhkkl5i
@@ -233,10 +233,6 @@ models:
       redeem_round_timeout: ${float:3600.0}
       policy_epsilon: ${float:0.25}
       store_path: ${str:/data/}
-      irrelevant_tools: ${list:["openai-text-davinci-002", "openai-text-davinci-003",
-        "openai-gpt-3.5-turbo", "openai-gpt-4", "stabilityai-stable-diffusion-v1-5",
-        "stabilityai-stable-diffusion-xl-beta-v2-2-2", "stabilityai-stable-diffusion-512-v2-1",
-        "stabilityai-stable-diffusion-768-v2-1"]}
       staking_contract_address: ${str:0x2Ef503950Be67a98746F484DA0bBAdA339DF3326}
       staking_interaction_sleep_time: ${int:5}
       disable_trading: ${bool:false}
@@ -286,7 +282,7 @@ models:
       polymarket_neg_risk_ctf_exchange_address: ${str:0xe2222d279d744050d28e00520010520000310F59}
       polymarket_neg_risk_adapter_address: ${str:0xd91E80cF2E7be2e162c6513ceD06f1dD0dA35296}
       valid_mechs: ${list:["0xc05e7412439bd7e91730a6880e18d5d5873f632c","0x601024e27f1c67b28209e24272ced8a31fc8151f","0xb3c6319962484602b00d5587e965946890b82101","0xdb78159e9246ec738f51c2c9cb1169b5c0e45fee","0x818df8dcd43d716a7263798c99a2fc8e27010711","0x11c4389bf449991d69f89f941c3e79d5d828f1bc"]}
-      valid_tools: ${list:["prediction-offline","prediction-online","claude-prediction-online","claude-prediction-offline","prediction-online-sme","prediction-offline-sme","resolve-market-reasoning-gpt-4.1","resolve-market-jury-v1","prediction-request-rag","prediction-request-rag-claude","prediction-request-reasoning","prediction-request-reasoning-claude","superforcaster","factual_research"]}
+      valid_tools: ${list:["prediction-offline","superforcaster","factual_research"]}
       penalize_mech_time_window: ${int:1800}
       pol_threshold_for_swap: ${int:2000000000000000000}
       slippages_for_swap: ${dict:{"xDAI-USDC":0.003,"POL-USDC":0.004}}

--- a/packages/valory/agents/trader/aea-config.yaml
+++ b/packages/valory/agents/trader/aea-config.yaml
@@ -65,10 +65,10 @@ skills:
 - valory/reset_pause_abci:0.1.0:bafybeifdzwzz5byan3ytsi46n4n2svtqme6475hk5z77sopymyzqszcpoa
 - valory/termination_abci:0.1.0:bafybeiadbtzcvzkwbrosshlsubilj7mwzdqfni6dr75wsd3vawhslpwqeu
 - valory/transaction_settlement_abci:0.1.0:bafybeigiojqgbi54jhree3sqrzaudbmjxb7y2ete74bbliryi3t7ztwi5q
-- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeied2ks2fbbzj6xlrziup6g5pmuhoqqv6m53f3c32l57yzdk5y4t5q
+- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeiejygkljdo7gscnmzsnzw2dxyweycvf63vudgnmjez3bv6fq54ugy
 - valory/market_manager_abci:0.1.0:bafybeia7nohjn3ela6epm6tlgqwdvezws2e2n2mbo27xhnxwp366vlqovq
-- valory/decision_maker_abci:0.1.0:bafybeibcp2ntfxpswi6pcbysj3wwqxwsvf2ylpsnoloyf43kg6em264mmu
-- valory/trader_abci:0.1.0:bafybeic3gbfmz255xnxm2z3pra5ed73azay4zhjvsuit5cn6yrh6wmf4vm
+- valory/decision_maker_abci:0.1.0:bafybeidnsqqlii35pgh2aeztydwbvyfbcgsrmky46mqwjpzsdukvyx6bmm
+- valory/trader_abci:0.1.0:bafybeihbxhqmnezkhpdv24le52buht2kj5cbspkvnaui7jptni7klg5t7q
 - valory/staking_abci:0.1.0:bafybeifr5puvjn722l6f5gngpsrpyb4xkcxiecbfhpewcnbuzr7hgp5ezu
 - valory/check_stop_trading_abci:0.1.0:bafybeib5gbqteso35q5lb3sgbgrafntnut775flbcgl6brwiktpouckba4
 - valory/mech_interact_abci:0.1.0:bafybeihds6vqk3gsevtsdsowz56jdnbbhc6gnswwd25opm6rrj32dhsmou

--- a/packages/valory/services/polymarket_trader/service.yaml
+++ b/packages/valory/services/polymarket_trader/service.yaml
@@ -8,7 +8,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeichoh5tnk4qctaazcjcrxvpwc5yasodleqoeapnfapwrrdh3tm5gu
 fingerprint_ignore_patterns: []
-agent: valory/trader:0.1.0:bafybeievjf77mhhzpeygewbyfvvo2roa5xgz74l2gkism6lw4wxqi6w4a4
+agent: valory/trader:0.1.0:bafybeidsong7f3jfkmy4uvvm5xjzsz6ao5wa5x6eewnjc2x6mmluih3o6u
 number_of_agents: 1
 deployment:
   agent:
@@ -116,8 +116,6 @@ models:
       dust_epsilon_wxdai: ${DUST_EPSILON_WXDAI:int:10000000000000000}
       policy_epsilon: ${POLICY_EPSILON:float:0.25}
       store_path: ${STORE_PATH:str:/data/}
-      irrelevant_tools: ${IRRELEVANT_TOOLS:list:["native-transfer","prediction-online-lite","claude-prediction-online-lite","prediction-online-sme-lite","prediction-request-reasoning-lite","prediction-request-reasoning-claude-lite","prediction-offline-sme","deepmind-optimization",
-        "deepmind-optimization-strong","openai-gpt-3.5-turbo","openai-gpt-3.5-turbo-instruct","openai-gpt-4","openai-text-davinci-002","openai-text-davinci-003","prediction-online-sum-url-content","prediction-online-summarized-info","stabilityai-stable-diffusion-512-v2-1","stabilityai-stable-diffusion-768-v2-1","stabilityai-stable-diffusion-v1-5","stabilityai-stable-diffusion-xl-beta-v2-2-2"]}
       staking_contract_address: ${STAKING_CONTRACT_ADDRESS:str:0x0000000000000000000000000000000000000000}
       staking_interaction_sleep_time: ${STAKING_INTERACTION_SLEEP_TIME:int:5}
       disable_trading: ${DISABLE_TRADING:bool:false}
@@ -163,7 +161,7 @@ models:
       polymarket_builder_program_enabled: ${POLYMARKET_BUILDER_PROGRAM_ENABLED:bool:false}
       pol_threshold_for_swap: ${POL_THRESHOLD_FOR_SWAP:int:2000000000000000000}
       valid_mechs: ${VALID_MECHS:list:["0x45f25db135e83d7a010b05ffc1202f8473e3ae7d","0xe7f818513a48d74c99b8bde153bee0b70dbb300b","0x76a9a29441c7acd072b03e63911f0e177de56ab7"]}
-      valid_tools: ${VALID_TOOLS:list:["prediction-offline","prediction-online","claude-prediction-online","claude-prediction-offline","prediction-online-sme","prediction-offline-sme","resolve-market-reasoning-gpt-4.1","prediction-request-rag","prediction-request-rag-claude","prediction-request-reasoning","prediction-request-reasoning-claude","superforcaster"]}
+      valid_tools: ${VALID_TOOLS:list:["superforcaster"]}
       slippages_for_swap: ${SLIPPAGES_FOR_SWAP:dict:{"xDAI-USDC":0.003,"POL-USDC":0.004}}
       is_outcome_side_threshold_filter_enabled: ${IS_OUTCOME_SIDE_THRESHOLD_FILTER_ENABLED:bool:true}
       outcome_side_threshold_filter_threshold: ${OUTCOME_SIDE_THRESHOLD_FILTER_THRESHOLD:float:0.8}

--- a/packages/valory/services/polymarket_trader/service.yaml
+++ b/packages/valory/services/polymarket_trader/service.yaml
@@ -8,7 +8,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeichoh5tnk4qctaazcjcrxvpwc5yasodleqoeapnfapwrrdh3tm5gu
 fingerprint_ignore_patterns: []
-agent: valory/trader:0.1.0:bafybeidsong7f3jfkmy4uvvm5xjzsz6ao5wa5x6eewnjc2x6mmluih3o6u
+agent: valory/trader:0.1.0:bafybeihb3zu3jimdibqnslscdn6zdt2a3orhe6avqt35yxqvfpajmftcii
 number_of_agents: 1
 deployment:
   agent:

--- a/packages/valory/services/trader_pearl/service.yaml
+++ b/packages/valory/services/trader_pearl/service.yaml
@@ -8,7 +8,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeibg7bdqpioh4lmvknw3ygnllfku32oca4eq5pqtvdrdsgw6buko7e
 fingerprint_ignore_patterns: []
-agent: valory/trader:0.1.0:bafybeidsong7f3jfkmy4uvvm5xjzsz6ao5wa5x6eewnjc2x6mmluih3o6u
+agent: valory/trader:0.1.0:bafybeihb3zu3jimdibqnslscdn6zdt2a3orhe6avqt35yxqvfpajmftcii
 number_of_agents: 1
 deployment:
   agent:

--- a/packages/valory/services/trader_pearl/service.yaml
+++ b/packages/valory/services/trader_pearl/service.yaml
@@ -8,7 +8,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeibg7bdqpioh4lmvknw3ygnllfku32oca4eq5pqtvdrdsgw6buko7e
 fingerprint_ignore_patterns: []
-agent: valory/trader:0.1.0:bafybeievjf77mhhzpeygewbyfvvo2roa5xgz74l2gkism6lw4wxqi6w4a4
+agent: valory/trader:0.1.0:bafybeidsong7f3jfkmy4uvvm5xjzsz6ao5wa5x6eewnjc2x6mmluih3o6u
 number_of_agents: 1
 deployment:
   agent:
@@ -116,8 +116,6 @@ models:
       dust_epsilon_wxdai: ${DUST_EPSILON_WXDAI:int:10000000000000000}
       policy_epsilon: ${POLICY_EPSILON:float:0.25}
       store_path: ${STORE_PATH:str:/data/}
-      irrelevant_tools: ${IRRELEVANT_TOOLS:list:["native-transfer","prediction-online-lite","claude-prediction-online-lite","prediction-online-sme-lite","prediction-request-reasoning-lite","prediction-request-reasoning-claude-lite","prediction-offline-sme","deepmind-optimization",
-        "deepmind-optimization-strong","openai-gpt-3.5-turbo","openai-gpt-3.5-turbo-instruct","openai-gpt-4","openai-text-davinci-002","openai-text-davinci-003","prediction-online-sum-url-content","prediction-online-summarized-info","stabilityai-stable-diffusion-512-v2-1","stabilityai-stable-diffusion-768-v2-1","stabilityai-stable-diffusion-v1-5","stabilityai-stable-diffusion-xl-beta-v2-2-2"]}
       staking_contract_address: ${STAKING_CONTRACT_ADDRESS:str:0x0000000000000000000000000000000000000000}
       staking_interaction_sleep_time: ${STAKING_INTERACTION_SLEEP_TIME:int:5}
       disable_trading: ${DISABLE_TRADING:bool:false}
@@ -160,7 +158,7 @@ models:
       is_agent_performance_summary_enabled: ${IS_AGENT_PERFORMANCE_SUMMARY_ENABLED:bool:true}
       is_achievement_checker_enabled: ${IS_ACHIEVEMENT_CHECKER_ENABLED:bool:false}
       valid_mechs: ${VALID_MECHS:list:["0xc05e7412439bd7e91730a6880e18d5d5873f632c","0x601024e27f1c67b28209e24272ced8a31fc8151f","0xb3c6319962484602b00d5587e965946890b82101","0xdb78159e9246ec738f51c2c9cb1169b5c0e45fee","0x818df8dcd43d716a7263798c99a2fc8e27010711","0x11c4389bf449991d69f89f941c3e79d5d828f1bc"]}
-      valid_tools: ${VALID_TOOLS:list:["prediction-offline","prediction-online","claude-prediction-online","claude-prediction-offline","prediction-online-sme","prediction-offline-sme","resolve-market-reasoning-gpt-4.1","resolve-market-jury-v1","prediction-request-rag","prediction-request-rag-claude","prediction-request-reasoning","prediction-request-reasoning-claude","superforcaster","factual_research"]}
+      valid_tools: ${VALID_TOOLS:list:["prediction-offline","superforcaster","factual_research"]}
       penalize_mech_time_window: ${PENALIZE_MECH_TIME_WINDOW:int:1800}
       is_outcome_side_threshold_filter_enabled: ${IS_OUTCOME_SIDE_THRESHOLD_FILTER_ENABLED:bool:false}
       outcome_side_threshold_filter_threshold: ${OUTCOME_SIDE_THRESHOLD_FILTER_THRESHOLD:float:0.8}

--- a/packages/valory/skills/check_stop_trading_abci/skill.yaml
+++ b/packages/valory/skills/check_stop_trading_abci/skill.yaml
@@ -31,7 +31,7 @@ protocols: []
 skills:
 - valory/abstract_round_abci:0.1.0:bafybeidpod4inivvvgzenx46whshq4mzmxgwsxinv6ibdvyemkstam2yz4
 - valory/chatui_abci:0.1.0:bafybeicgoq2rdq3uzvjxoxny3hiis4i23eyq7v7vahd7wrwhxwl645agde
-- valory/mech_interact_abci:0.1.0:bafybeibcr5ifxkkeb4q3jbyxhri2yrydiunh5csifermqdcboa2ydybu6m
+- valory/mech_interact_abci:0.1.0:bafybeihds6vqk3gsevtsdsowz56jdnbbhc6gnswwd25opm6rrj32dhsmou
 - valory/staking_abci:0.1.0:bafybeifr5puvjn722l6f5gngpsrpyb4xkcxiecbfhpewcnbuzr7hgp5ezu
 behaviours:
   main:

--- a/packages/valory/skills/decision_maker_abci/behaviours/storage_manager.py
+++ b/packages/valory/skills/decision_maker_abci/behaviours/storage_manager.py
@@ -212,7 +212,7 @@ class StorageManagerBehaviour(DecisionMakerBaseBehaviour, ABC):
             return False
 
         self.context.logger.info(f"Retrieved the mech agent's tools: {res}.")
-        res = set(res) & self.params.valid_tools
+        res = {str(tool).lower() for tool in res} & self.params.valid_tools
         self.context.logger.info(f"Relevant tools to the prediction task: {res}.")
 
         if len(res) == 0:
@@ -291,8 +291,8 @@ class StorageManagerBehaviour(DecisionMakerBaseBehaviour, ABC):
 
         return True
 
-    def _remove_irrelevant_tools(self) -> None:
-        """Remove irrelevant tools from the accuracy store."""
+    def _prune_accuracy_store_to_current_tools(self) -> None:
+        """Drop accuracy_store entries that are no longer in self.mech_tools."""
         accuracy_store = self.policy.accuracy_store
         for tool in accuracy_store.copy():
             if tool not in self.mech_tools:
@@ -403,7 +403,7 @@ class StorageManagerBehaviour(DecisionMakerBaseBehaviour, ABC):
     def _update_policy_tools(self) -> None:
         """Update the policy's tools and their accuracy with the latest information available if `with_global_info`."""
         self.context.logger.info("Updating information of the policy...")
-        self._remove_irrelevant_tools()
+        self._prune_accuracy_store_to_current_tools()
         global_info = self._parse_global_info()
         self._update_accuracy_store(*global_info)
         self.policy.update_weighted_accuracy()

--- a/packages/valory/skills/decision_maker_abci/behaviours/storage_manager.py
+++ b/packages/valory/skills/decision_maker_abci/behaviours/storage_manager.py
@@ -212,8 +212,7 @@ class StorageManagerBehaviour(DecisionMakerBaseBehaviour, ABC):
             return False
 
         self.context.logger.info(f"Retrieved the mech agent's tools: {res}.")
-        # keep only the relevant mech tools
-        res = set(res) - self.params.irrelevant_tools
+        res = set(res) & self.params.valid_tools
         self.context.logger.info(f"Relevant tools to the prediction task: {res}.")
 
         if len(res) == 0:

--- a/packages/valory/skills/decision_maker_abci/skill.yaml
+++ b/packages/valory/skills/decision_maker_abci/skill.yaml
@@ -36,7 +36,7 @@ fingerprint:
   behaviours/round_behaviour.py: bafybeihauyieaox7d77wz3ofjflvhicsnhzitvcgnysoral5l4m5gluglm
   behaviours/sampling.py: bafybeig3w6bmlivit3sx5adiflq6bclzipfugxzmjn7v7shdq4l7a2q2gu
   behaviours/sell_outcome_tokens.py: bafybeih6xtmqtuasnm63b5u3qau6ssj7dvvgvmwmepll6ydwo3aqc7tzv4
-  behaviours/storage_manager.py: bafybeifuthllbvup2ox2nqotpzpsg7tq53vvbjy4lfcdjlhojeawm57cda
+  behaviours/storage_manager.py: bafybeigv2zkimz4srm2hiud3gwc4rlfz2nfcpxdtni4yzpz34pckoedyva
   behaviours/tool_selection.py: bafybeidkhmz6x32kuz5gkwxuqqou6zq4rgcyc34vg7awhe2bud5s3sc3am
   dialogues.py: bafybeieyicxgks5it6a5llkwithftdv32dosfmwg3zbxgaleltr7yn47ku
   fsm_specification.yaml: bafybeiepnwc2poubqk5tbafcd4id7ly2ngf6htgzglql64y6loau65o3pm
@@ -80,7 +80,7 @@ fingerprint:
   tests/behaviours/data/.gitkeep: bafybeiekl43sjsyqfgl6y27ve5ydo4svcngrptgtffblokmspfezroxvvi
   tests/behaviours/dummy_strategy/__init__.py: bafybeiep5w5yckjzy724v63qd5cmzfn3uxytmnizynomxggfobbysfcttq
   tests/behaviours/dummy_strategy/dummy_strategy.py: bafybeih6fpzt2674zd43dpmncnxkm4wnzqe5zpty5a2upqsf5qcooasiwm
-  tests/behaviours/test_base.py: bafybeic6nivbuwjihj2hwvyrmq6daflaw4mulogiamsawrnc75ikmcndkm
+  tests/behaviours/test_base.py: bafybeig752otpqlnqiplhz6mupbcqzzo6izuuxbbho4qtjmwlilbf6te5y
   tests/behaviours/test_bet_placement.py: bafybeifum6ilmcohsdci2z447kr7jnlw2hhicjdpxg5y2pr7gwul4rogy4
   tests/behaviours/test_blacklisting.py: bafybeic2jcfxujhto6khwrobnfxx43wh42hx2fmn4xo2hxzlynmavqvbqa
   tests/behaviours/test_check_benchmarking.py: bafybeihfdlrjliykbuwfqsv3snkgzge3jfug3dezp7uan5qooufoevtbnq
@@ -100,7 +100,7 @@ fingerprint:
   tests/behaviours/test_reedem.py: bafybeibethmzkihznht2g5jptv6sgrb5yh5fdytq5kmhetxsbtbe7acwla
   tests/behaviours/test_sampling.py: bafybeihfb3eke7hmhagkv5tcvpvgj4mljatllnjauiae5hfaaoxlffqhfy
   tests/behaviours/test_sell_outcome_tokens.py: bafybeiej3ci4irissz45kk5ooy4notxcjl2dtbxioljqlzqtwex3elrqqq
-  tests/behaviours/test_storage_manager.py: bafybeieytnqhqkdskzr35cod6a7b7gew57ndzsc67v66hxl2yik2ej5on4
+  tests/behaviours/test_storage_manager.py: bafybeibh47wpmkgzkxdhpkhushnt7usxvm5w4p7z5r754vidlhgij4r2lm
   tests/behaviours/test_tool_selection.py: bafybeig2ynzrtml73kmv4hyvbrmvptrket2pji45pcy44uzkpkjviscwcq
   tests/conftest.py: bafybeicr4ldri2z6easpewnwzxeh2rbxgt7mbgrahrmoilo75o2m6lzc2m
   tests/io_/__init__.py: bafybeieix5jroitmrjfpwakoywslzq3b3cwsfnx6z2ij7ahy4plmntzgqm
@@ -159,7 +159,7 @@ skills:
 - valory/abstract_round_abci:0.1.0:bafybeidpod4inivvvgzenx46whshq4mzmxgwsxinv6ibdvyemkstam2yz4
 - valory/market_manager_abci:0.1.0:bafybeia7nohjn3ela6epm6tlgqwdvezws2e2n2mbo27xhnxwp366vlqovq
 - valory/transaction_settlement_abci:0.1.0:bafybeigiojqgbi54jhree3sqrzaudbmjxb7y2ete74bbliryi3t7ztwi5q
-- valory/mech_interact_abci:0.1.0:bafybeibcr5ifxkkeb4q3jbyxhri2yrydiunh5csifermqdcboa2ydybu6m
+- valory/mech_interact_abci:0.1.0:bafybeihds6vqk3gsevtsdsowz56jdnbbhc6gnswwd25opm6rrj32dhsmou
 - valory/staking_abci:0.1.0:bafybeifr5puvjn722l6f5gngpsrpyb4xkcxiecbfhpewcnbuzr7hgp5ezu
 - valory/agent_performance_summary_abci:0.1.0:bafybeihqm5ebfwdbcc7zan66ffv7lsp6jeyz6ydrj65lizm7rtzoyy6s3i
 - valory/chatui_abci:0.1.0:bafybeicgoq2rdq3uzvjxoxny3hiis4i23eyq7v7vahd7wrwhxwl645agde

--- a/packages/valory/skills/decision_maker_abci/skill.yaml
+++ b/packages/valory/skills/decision_maker_abci/skill.yaml
@@ -36,7 +36,7 @@ fingerprint:
   behaviours/round_behaviour.py: bafybeihauyieaox7d77wz3ofjflvhicsnhzitvcgnysoral5l4m5gluglm
   behaviours/sampling.py: bafybeig3w6bmlivit3sx5adiflq6bclzipfugxzmjn7v7shdq4l7a2q2gu
   behaviours/sell_outcome_tokens.py: bafybeih6xtmqtuasnm63b5u3qau6ssj7dvvgvmwmepll6ydwo3aqc7tzv4
-  behaviours/storage_manager.py: bafybeigv2zkimz4srm2hiud3gwc4rlfz2nfcpxdtni4yzpz34pckoedyva
+  behaviours/storage_manager.py: bafybeid7r45kniqbcbtw57kapegfujzjyqd55pgnbylzaqgyanmbqjeo4a
   behaviours/tool_selection.py: bafybeidkhmz6x32kuz5gkwxuqqou6zq4rgcyc34vg7awhe2bud5s3sc3am
   dialogues.py: bafybeieyicxgks5it6a5llkwithftdv32dosfmwg3zbxgaleltr7yn47ku
   fsm_specification.yaml: bafybeiepnwc2poubqk5tbafcd4id7ly2ngf6htgzglql64y6loau65o3pm
@@ -100,7 +100,7 @@ fingerprint:
   tests/behaviours/test_reedem.py: bafybeibethmzkihznht2g5jptv6sgrb5yh5fdytq5kmhetxsbtbe7acwla
   tests/behaviours/test_sampling.py: bafybeihfb3eke7hmhagkv5tcvpvgj4mljatllnjauiae5hfaaoxlffqhfy
   tests/behaviours/test_sell_outcome_tokens.py: bafybeiej3ci4irissz45kk5ooy4notxcjl2dtbxioljqlzqtwex3elrqqq
-  tests/behaviours/test_storage_manager.py: bafybeibh47wpmkgzkxdhpkhushnt7usxvm5w4p7z5r754vidlhgij4r2lm
+  tests/behaviours/test_storage_manager.py: bafybeifq236dedjc6hrgfrztq3iern55jjjvdvknffemdrb65punwa3b6i
   tests/behaviours/test_tool_selection.py: bafybeig2ynzrtml73kmv4hyvbrmvptrket2pji45pcy44uzkpkjviscwcq
   tests/conftest.py: bafybeicr4ldri2z6easpewnwzxeh2rbxgt7mbgrahrmoilo75o2m6lzc2m
   tests/io_/__init__.py: bafybeieix5jroitmrjfpwakoywslzq3b3cwsfnx6z2ij7ahy4plmntzgqm

--- a/packages/valory/skills/decision_maker_abci/tests/behaviours/test_base.py
+++ b/packages/valory/skills/decision_maker_abci/tests/behaviours/test_base.py
@@ -202,7 +202,6 @@ class TestDecisionMakerBaseBehaviour(FSMBehaviourBaseCase):
                     "args": {
                         "use_acn_for_delivers": True,
                         "penalize_mech_time_window": 0,
-                        "irrelevant_tools": [],
                         "valid_mechs": [],
                         "valid_tools": [],
                         "deliveries_lookback_days": 30,

--- a/packages/valory/skills/decision_maker_abci/tests/behaviours/test_storage_manager.py
+++ b/packages/valory/skills/decision_maker_abci/tests/behaviours/test_storage_manager.py
@@ -559,6 +559,57 @@ class TestGetMechTools:
 
         assert result is False
 
+    def test_get_mech_tools_normalizes_case_before_intersect(self) -> None:
+        """Mixed-case manifest tools must match the lowercased valid_tools set.
+
+        The mech IPFS manifest can return tool names in any case, while
+        MechParams.valid_tools is lowercased on load. Without normalization
+        here, e.g. manifest ["Prediction-Offline"] vs config
+        ["prediction-offline"] would intersect to the empty set and the
+        round would fail closed unnecessarily.
+        """
+        behaviour = _make_behaviour()
+        behaviour._mech_hash = "valid_hash"
+
+        mock_api = MagicMock()
+        mock_api.get_spec.return_value = {"method": "GET", "url": "http://test"}
+        mock_api.process_response.return_value = [
+            "Prediction-Offline",
+            "Superforcaster",
+        ]
+        mock_api.is_retries_exceeded.return_value = False
+
+        with patch.object(
+            type(behaviour), "mech_tools_api", new_callable=PropertyMock
+        ) as api_mock:
+            api_mock.return_value = mock_api
+            with patch.object(
+                type(behaviour), "synchronized_data", new_callable=PropertyMock
+            ) as mock_sd:
+                mock_sd.return_value = MagicMock(is_marketplace_v2=True)
+                with patch.object(
+                    type(behaviour), "params", new_callable=PropertyMock
+                ) as mock_params:
+                    mock_params.return_value = MagicMock(
+                        valid_tools={"prediction-offline", "superforcaster"}
+                    )
+                    behaviour.get_http_response = MagicMock(  # type: ignore[method-assign]
+                        return_value=_return_gen(MagicMock())
+                    )
+                    behaviour._check_hash = MagicMock()  # type: ignore[method-assign]
+                    behaviour.set_mech_agent_specs = MagicMock()  # type: ignore[method-assign]
+
+                    gen = behaviour._get_mech_tools()
+                    result = None
+                    try:
+                        while True:
+                            next(gen)
+                    except StopIteration as e:
+                        result = e.value
+
+        assert result is True
+        assert behaviour._mech_tools == {"prediction-offline", "superforcaster"}
+
 
 # Tests for get_tools
 # ---------------------------------------------------------------------------
@@ -819,12 +870,12 @@ class TestFetchAccuracyInfo:
         assert result is False
 
 
-# Tests for remove_irrelevant_tools
+# Tests for prune_accuracy_store_to_current_tools
 # ---------------------------------------------------------------------------
 
 
-class TestRemoveIrrelevantTools:
-    """Tests for _remove_irrelevant_tools."""
+class TestPruneAccuracyStoreToCurrentTools:
+    """Tests for _prune_accuracy_store_to_current_tools."""
 
     def test_removes_tools_not_in_mech_tools(self) -> None:
         """Should remove tools from accuracy_store that are not in mech_tools."""
@@ -838,7 +889,7 @@ class TestRemoveIrrelevantTools:
         )
         behaviour._policy = policy
 
-        behaviour._remove_irrelevant_tools()
+        behaviour._prune_accuracy_store_to_current_tools()
 
         assert "tool1" in policy.accuracy_store
         assert "tool2" not in policy.accuracy_store
@@ -1131,7 +1182,9 @@ class TestUpdatePolicyTools:
         policy = _make_policy()
         behaviour._policy = policy
 
-        with patch.object(behaviour, "_remove_irrelevant_tools") as mock_remove:
+        with patch.object(
+            behaviour, "_prune_accuracy_store_to_current_tools"
+        ) as mock_remove:
             with patch.object(
                 behaviour, "_parse_global_info", return_value=(100, {"tool1": {}})
             ) as mock_parse:

--- a/packages/valory/skills/decision_maker_abci/tests/behaviours/test_storage_manager.py
+++ b/packages/valory/skills/decision_maker_abci/tests/behaviours/test_storage_manager.py
@@ -431,7 +431,7 @@ class TestGetMechTools:
                 with patch.object(
                     type(behaviour), "params", new_callable=PropertyMock
                 ) as mock_params:
-                    mock_params.return_value = MagicMock(irrelevant_tools=set())
+                    mock_params.return_value = MagicMock(valid_tools={"tool1", "tool2"})
                     behaviour.get_http_response = MagicMock(  # type: ignore[method-assign]
                         return_value=_return_gen(mock_response)
                     )
@@ -520,13 +520,13 @@ class TestGetMechTools:
         assert result is False
 
     def test_get_mech_tools_empty_relevant_tools(self) -> None:
-        """Should return False when all tools are irrelevant."""
+        """Should return False when no fetched tool is in the valid_tools allowlist."""
         behaviour = _make_behaviour()
         behaviour._mech_hash = "valid_hash"
 
         mock_api = MagicMock()
         mock_api.get_spec.return_value = {"method": "GET", "url": "http://test"}
-        mock_api.process_response.return_value = ["irrelevant_tool"]
+        mock_api.process_response.return_value = ["unknown_tool"]
         mock_api.is_retries_exceeded.return_value = False
 
         with patch.object(
@@ -541,7 +541,7 @@ class TestGetMechTools:
                     type(behaviour), "params", new_callable=PropertyMock
                 ) as mock_params:
                     mock_params.return_value = MagicMock(
-                        irrelevant_tools={"irrelevant_tool"}
+                        valid_tools={"some_other_tool"}
                     )
                     behaviour.get_http_response = MagicMock(  # type: ignore[method-assign]
                         return_value=_return_gen(MagicMock())

--- a/packages/valory/skills/trader_abci/skill.yaml
+++ b/packages/valory/skills/trader_abci/skill.yaml
@@ -56,11 +56,11 @@ skills:
 - valory/transaction_settlement_abci:0.1.0:bafybeigiojqgbi54jhree3sqrzaudbmjxb7y2ete74bbliryi3t7ztwi5q
 - valory/termination_abci:0.1.0:bafybeiadbtzcvzkwbrosshlsubilj7mwzdqfni6dr75wsd3vawhslpwqeu
 - valory/market_manager_abci:0.1.0:bafybeia7nohjn3ela6epm6tlgqwdvezws2e2n2mbo27xhnxwp366vlqovq
-- valory/decision_maker_abci:0.1.0:bafybeicjdnlu5cyzhby5vzkqkkrpqbcte5zh6cudjbsbkbla3uzxyvsmuy
-- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeidhdqd2f7tgip43nqbsctik2jjz2jeioifr4xybb5a4x5tcn4kez4
+- valory/decision_maker_abci:0.1.0:bafybeibcp2ntfxpswi6pcbysj3wwqxwsvf2ylpsnoloyf43kg6em264mmu
+- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeied2ks2fbbzj6xlrziup6g5pmuhoqqv6m53f3c32l57yzdk5y4t5q
 - valory/staking_abci:0.1.0:bafybeifr5puvjn722l6f5gngpsrpyb4xkcxiecbfhpewcnbuzr7hgp5ezu
-- valory/check_stop_trading_abci:0.1.0:bafybeiajpixuxyvmtdai2ibw3caeu2xv2ie6ag5l7ifjptecyk47yz52oy
-- valory/mech_interact_abci:0.1.0:bafybeibcr5ifxkkeb4q3jbyxhri2yrydiunh5csifermqdcboa2ydybu6m
+- valory/check_stop_trading_abci:0.1.0:bafybeib5gbqteso35q5lb3sgbgrafntnut775flbcgl6brwiktpouckba4
+- valory/mech_interact_abci:0.1.0:bafybeihds6vqk3gsevtsdsowz56jdnbbhc6gnswwd25opm6rrj32dhsmou
 - valory/chatui_abci:0.1.0:bafybeicgoq2rdq3uzvjxoxny3hiis4i23eyq7v7vahd7wrwhxwl645agde
 - valory/agent_performance_summary_abci:0.1.0:bafybeihqm5ebfwdbcc7zan66ffv7lsp6jeyz6ydrj65lizm7rtzoyy6s3i
 - valory/funds_manager:0.1.0:bafybeihuwnkgrhqixl4zj55fz2awptmpmdnmub2uzkgbx7rve7bnhkkl5i
@@ -261,15 +261,6 @@ models:
       store_path: /data/
       policy_store_update_offset: 259200
       use_subgraph_for_redeeming: true
-      irrelevant_tools:
-      - openai-text-davinci-002
-      - openai-text-davinci-003
-      - openai-gpt-3.5-turbo
-      - openai-gpt-4
-      - stabilityai-stable-diffusion-v1-5
-      - stabilityai-stable-diffusion-xl-beta-v2-2-2
-      - stabilityai-stable-diffusion-512-v2-1
-      - stabilityai-stable-diffusion-768-v2-1
       staking_contract_address: '0x2Ef503950Be67a98746F484DA0bBAdA339DF3326'
       staking_interaction_sleep_time: 5
       disable_trading: false

--- a/packages/valory/skills/trader_abci/skill.yaml
+++ b/packages/valory/skills/trader_abci/skill.yaml
@@ -56,8 +56,8 @@ skills:
 - valory/transaction_settlement_abci:0.1.0:bafybeigiojqgbi54jhree3sqrzaudbmjxb7y2ete74bbliryi3t7ztwi5q
 - valory/termination_abci:0.1.0:bafybeiadbtzcvzkwbrosshlsubilj7mwzdqfni6dr75wsd3vawhslpwqeu
 - valory/market_manager_abci:0.1.0:bafybeia7nohjn3ela6epm6tlgqwdvezws2e2n2mbo27xhnxwp366vlqovq
-- valory/decision_maker_abci:0.1.0:bafybeibcp2ntfxpswi6pcbysj3wwqxwsvf2ylpsnoloyf43kg6em264mmu
-- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeied2ks2fbbzj6xlrziup6g5pmuhoqqv6m53f3c32l57yzdk5y4t5q
+- valory/decision_maker_abci:0.1.0:bafybeidnsqqlii35pgh2aeztydwbvyfbcgsrmky46mqwjpzsdukvyx6bmm
+- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeiejygkljdo7gscnmzsnzw2dxyweycvf63vudgnmjez3bv6fq54ugy
 - valory/staking_abci:0.1.0:bafybeifr5puvjn722l6f5gngpsrpyb4xkcxiecbfhpewcnbuzr7hgp5ezu
 - valory/check_stop_trading_abci:0.1.0:bafybeib5gbqteso35q5lb3sgbgrafntnut775flbcgl6brwiktpouckba4
 - valory/mech_interact_abci:0.1.0:bafybeihds6vqk3gsevtsdsowz56jdnbbhc6gnswwd25opm6rrj32dhsmou

--- a/packages/valory/skills/tx_settlement_multiplexer_abci/skill.yaml
+++ b/packages/valory/skills/tx_settlement_multiplexer_abci/skill.yaml
@@ -27,9 +27,9 @@ protocols:
 - valory/ledger_api:1.0.0:bafybeiecq56phjfws36rgrefw6niyo4ezesloodsfis647mpm5ygqo4ysi
 skills:
 - valory/abstract_round_abci:0.1.0:bafybeidpod4inivvvgzenx46whshq4mzmxgwsxinv6ibdvyemkstam2yz4
-- valory/decision_maker_abci:0.1.0:bafybeicjdnlu5cyzhby5vzkqkkrpqbcte5zh6cudjbsbkbla3uzxyvsmuy
+- valory/decision_maker_abci:0.1.0:bafybeibcp2ntfxpswi6pcbysj3wwqxwsvf2ylpsnoloyf43kg6em264mmu
 - valory/staking_abci:0.1.0:bafybeifr5puvjn722l6f5gngpsrpyb4xkcxiecbfhpewcnbuzr7hgp5ezu
-- valory/mech_interact_abci:0.1.0:bafybeibcr5ifxkkeb4q3jbyxhri2yrydiunh5csifermqdcboa2ydybu6m
+- valory/mech_interact_abci:0.1.0:bafybeihds6vqk3gsevtsdsowz56jdnbbhc6gnswwd25opm6rrj32dhsmou
 behaviours:
   main:
     args: {}

--- a/packages/valory/skills/tx_settlement_multiplexer_abci/skill.yaml
+++ b/packages/valory/skills/tx_settlement_multiplexer_abci/skill.yaml
@@ -27,7 +27,7 @@ protocols:
 - valory/ledger_api:1.0.0:bafybeiecq56phjfws36rgrefw6niyo4ezesloodsfis647mpm5ygqo4ysi
 skills:
 - valory/abstract_round_abci:0.1.0:bafybeidpod4inivvvgzenx46whshq4mzmxgwsxinv6ibdvyemkstam2yz4
-- valory/decision_maker_abci:0.1.0:bafybeibcp2ntfxpswi6pcbysj3wwqxwsvf2ylpsnoloyf43kg6em264mmu
+- valory/decision_maker_abci:0.1.0:bafybeidnsqqlii35pgh2aeztydwbvyfbcgsrmky46mqwjpzsdukvyx6bmm
 - valory/staking_abci:0.1.0:bafybeifr5puvjn722l6f5gngpsrpyb4xkcxiecbfhpewcnbuzr7hgp5ezu
 - valory/mech_interact_abci:0.1.0:bafybeihds6vqk3gsevtsdsowz56jdnbbhc6gnswwd25opm6rrj32dhsmou
 behaviours:


### PR DESCRIPTION
## Summary

Companion to mech-interact [#80](https://github.com/valory-xyz/mech-interact/pull/80) (merged, re-released as v0.31.0 with the new hash). On trader's side:

- Bump `mech_interact_abci` hash to the v0.31.0 build that no longer reads `irrelevant_tools`: `bafybeihds6vqk3gsevtsdsowz56jdnbbhc6gnswwd25opm6rrj32dhsmou`.
- Drop `irrelevant_tools` overrides from `aea-config.yaml`, `trader_abci/skill.yaml`, `trader_pearl/service.yaml`, `polymarket_trader/service.yaml`.
- `decision_maker_abci/storage_manager._get_mech_tools` (legacy-mech path) switched from `set(res) - self.params.irrelevant_tools` to `{str(t).lower() for t in res} & self.params.valid_tools` so legacy and v2 use the same allowlist semantics with the same case-folding. Existing tests updated; added one to pin case-insensitivity.
- Renamed `_remove_irrelevant_tools` -> `_prune_accuracy_store_to_current_tools`. The method had nothing to do with the (now-removed) `irrelevant_tools` param; it prunes accuracy_store entries that no longer appear in `self.mech_tools`.
- Narrow seeded `valid_tools` to the prior effective set after both filters: `[prediction-offline, superforcaster, factual_research]` on Gnosis, `[superforcaster]` on Polygon. Same tools the agent picked before this change; just one layer of config now.

## Stack ordering (important)

This PR is stacked on top of [trader #953](https://github.com/valory-xyz/trader/pull/953) and targets `feat/valid-mech-tools-allowlist` as its base branch (not `main`). #953 must land first; then this PR will be rebased onto `main` for the final merge.

## Change of failure mode worth flagging

Pre-existing behaviour: `IRRELEVANT_TOOLS=[]` was a no-op (denylist empty -> nothing blocked). New behaviour: `VALID_TOOLS=[]` fails closed (allowlist empty -> no tool surfaces, the legacy `_get_mech_tools` returns False with the existing "The relevant mech agent's tools are empty!" log; the v2 path warns and short-circuits the subgraph fetch).

In production this only bites if someone overrides `VALID_TOOLS=[]` via env (stale Pearl override, manual clear, etc.). The defaults in `aea-config.yaml` and both service yamls are non-empty, so the production path is safe. Fail-closed is the right direction, just visible to operators.

## How a reviewer can cross-verify the lists

The two configs introduced here (`valid_mechs` and `valid_tools`) are derived from two sources of truth. Recipe to reproduce both:

### `valid_mechs` — directly from [`valory-xyz/mech-deployments`](https://github.com/valory-xyz/mech-deployments/tree/main/deployments)

Open each `.env` in [`mech-deployments/deployments/`](https://github.com/valory-xyz/mech-deployments/tree/main/deployments) and read the `MECH_TO_CONFIG` line. The address inside is the mech address. Group by `DEFAULT_CHAIN_ID`:

**Gnosis** (skip [`nvm_native_mech_mm_predict_2469.env`](https://github.com/valory-xyz/mech-deployments/blob/main/deployments/nvm_native_mech_mm_predict_2469.env) — NVM native mech intentionally excluded):

- [`mech_mm_predict.env`](https://github.com/valory-xyz/mech-deployments/blob/main/deployments/mech_mm_predict.env) → `0xc05e7412439bd7e91730a6880e18d5d5873f632c`
- [`mech_mm_predict_clone.env`](https://github.com/valory-xyz/mech-deployments/blob/main/deployments/mech_mm_predict_clone.env) → `0x601024e27f1c67b28209e24272ced8a31fc8151f`
- [`single_mech_mm_predict.env`](https://github.com/valory-xyz/mech-deployments/blob/main/deployments/single_mech_mm_predict.env) → `0xb3c6319962484602b00d5587e965946890b82101`
- [`single_mech_mm_predict_2340.env`](https://github.com/valory-xyz/mech-deployments/blob/main/deployments/single_mech_mm_predict_2340.env) → `0xdb78159e9246ec738f51c2c9cb1169b5c0e45fee`
- [`single_mech_mm_predict_2359.env`](https://github.com/valory-xyz/mech-deployments/blob/main/deployments/single_mech_mm_predict_2359.env) → `0x818df8dcd43d716a7263798c99a2fc8e27010711`
- [`single_mech_mm_predict_2360.env`](https://github.com/valory-xyz/mech-deployments/blob/main/deployments/single_mech_mm_predict_2360.env) → `0x11c4389bf449991d69f89f941c3e79d5d828f1bc`

These are the 6 addresses in `valid_mechs` for `trader_pearl/service.yaml`.

**Polygon**:

- [`polygon_mech_mm_predict_25.env`](https://github.com/valory-xyz/mech-deployments/blob/main/deployments/polygon_mech_mm_predict_25.env) → `0x45f25db135e83d7a010b05ffc1202f8473e3ae7d`
- [`polygon_mech_mm_predict_44.env`](https://github.com/valory-xyz/mech-deployments/blob/main/deployments/polygon_mech_mm_predict_44.env) → `0xe7f818513a48d74c99b8bde153bee0b70dbb300b`
- [`single_polygon_mech_mm_predict_21.env`](https://github.com/valory-xyz/mech-deployments/blob/main/deployments/single_polygon_mech_mm_predict_21.env) → `0x76a9a29441c7acd072b03e63911f0e177de56ab7`

These are the 3 addresses in `valid_mechs` for `polymarket_trader/service.yaml`.

### `valid_tools` — `(mech-deployments tool union)` minus `(operate-app IRRELEVANT_TOOLS)`

**Step 1**: take the union of `TOOLS_TO_PACKAGE_HASH` keys across every Gnosis `.env` listed above (each file has its `TOOLS_TO_PACKAGE_HASH=...` line, e.g. [here in `mech_mm_predict.env`](https://github.com/valory-xyz/mech-deployments/blob/main/deployments/mech_mm_predict.env)). That gives 14 deployed tools on Gnosis:

```
prediction-offline, prediction-online, claude-prediction-online,
claude-prediction-offline, prediction-online-sme, prediction-offline-sme,
resolve-market-reasoning-gpt-4.1, resolve-market-jury-v1,
prediction-request-rag, prediction-request-rag-claude,
prediction-request-reasoning, prediction-request-reasoning-claude,
superforcaster, factual_research
```

**Step 2**: subtract every tool currently in Pearl's `IRRELEVANT_TOOLS` env template, defined at [operate-app `frontend/constants/serviceTemplates/service/trader.ts:128`](https://github.com/valory-xyz/olas-operate-app/blob/main/frontend/constants/serviceTemplates/service/trader.ts#L128). After that subtraction, the survivors are:

```
prediction-offline, superforcaster, factual_research
```

That's the new Gnosis `valid_tools` default in this PR.

**Polygon**: same recipe with the 3 Polygon env files (`TOOLS_TO_PACKAGE_HASH` from each) for the union (12 tools), then subtract the Polystrat `IRRELEVANT_TOOLS` at [trader.ts:275](https://github.com/valory-xyz/olas-operate-app/blob/main/frontend/constants/serviceTemplates/service/trader.ts#L275). Only `superforcaster` survives. That's the new Polygon `valid_tools` default.

The net effect: the agent's behaviour matches what Pearl produces today (same effective tool set after the prior two-layer filter), but the config now expresses it in one place.

## Test plan

- [x] `make test` / per-skill pytest: 1581 tests pass across decision_maker_abci, chatui_abci, trader_abci.
- [x] `tomte tox -e black-check -e isort-check -e flake8 -e mypy -e pylint -e darglint` clean.
- [x] `autonomy packages lock --check` passes.
- [x] `autonomy push-all` republished services to IPFS.
- [x] Local run on Pearl/Gnosis wallet:
  - happy path: agent picks `superforcaster` / `prediction-offline` from the new 3-tool valid set, sends mech request on-chain.
  - pin via `/chatui-prompt`: pin `0x601024e2...` lands in disk store + chatui_config; next FSM iteration picks tool from that mech only and on-chain `priority_mech` matches.
  - pin persistence: stop agent, restart, verify `Loaded chat UI parameters: selected_mechs=['0x601024e2...']` on boot and the mech request still targets the pinned mech.
- [ ] Operate-app / Pearl follow-up: drop the `IRRELEVANT_TOOLS` env templates (now no-ops); tracked separately.
- [ ] trader-quickstart: drop `IRRELEVANT_TOOLS` from its `.env` template; tracked separately.

## Operate-app follow-up

The Pearl `IRRELEVANT_TOOLS` env template at [trader.ts:124-128](https://github.com/valory-xyz/olas-operate-app/blob/main/frontend/constants/serviceTemplates/service/trader.ts#L124-L128) and [:271-275](https://github.com/valory-xyz/olas-operate-app/blob/main/frontend/constants/serviceTemplates/service/trader.ts#L271-L275) is now a no-op (the new `mech_interact_abci` silently ignores it). Operate-app should drop those templates so the service config stays clean.