### PR TITLE
chore(trader): extend valid_tools allowlist

### DIFF
--- a/packages/packages.json
+++ b/packages/packages.json
@@ -19,8 +19,8 @@
         "skill/valory/check_stop_trading_abci/0.1.0": "bafybeib5gbqteso35q5lb3sgbgrafntnut775flbcgl6brwiktpouckba4",
         "skill/valory/chatui_abci/0.1.0": "bafybeicgoq2rdq3uzvjxoxny3hiis4i23eyq7v7vahd7wrwhxwl645agde",
         "agent/valory/trader/0.1.0": "bafybeihb3zu3jimdibqnslscdn6zdt2a3orhe6avqt35yxqvfpajmftcii",
-        "service/valory/trader_pearl/0.1.0": "bafybeia7tgq2u4care2tifsjuaufnrffs675xbt3egnjpeeduo2ok4d6vi",
-        "service/valory/polymarket_trader/0.1.0": "bafybeigdfaporeg7ltoacy7jesxcbpxelmqmcmi6fr2fh5f6dyfgz5bloe"
+        "service/valory/trader_pearl/0.1.0": "bafybeidfzde2wzf6rwe2gpiz22te4spbpct6cig3csjivmvawbmz72yzhe",
+        "service/valory/polymarket_trader/0.1.0": "bafybeigittuyu3fsib6msndniwomuusknboatp2s5jgp5uoe73ywpsehr4"
     },
     "third_party": {
         "protocol/valory/acn_data_share/0.1.0": "bafybeieqisfr6lhaaesq37lk7vyaxza2h6nucshksgyo2djqfyf2saqo4i",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -18,9 +18,9 @@
         "skill/valory/agent_performance_summary_abci/0.1.0": "bafybeihqm5ebfwdbcc7zan66ffv7lsp6jeyz6ydrj65lizm7rtzoyy6s3i",
         "skill/valory/check_stop_trading_abci/0.1.0": "bafybeib5gbqteso35q5lb3sgbgrafntnut775flbcgl6brwiktpouckba4",
         "skill/valory/chatui_abci/0.1.0": "bafybeicgoq2rdq3uzvjxoxny3hiis4i23eyq7v7vahd7wrwhxwl645agde",
-        "agent/valory/trader/0.1.0": "bafybeihb3zu3jimdibqnslscdn6zdt2a3orhe6avqt35yxqvfpajmftcii",
-        "service/valory/trader_pearl/0.1.0": "bafybeidfzde2wzf6rwe2gpiz22te4spbpct6cig3csjivmvawbmz72yzhe",
-        "service/valory/polymarket_trader/0.1.0": "bafybeigittuyu3fsib6msndniwomuusknboatp2s5jgp5uoe73ywpsehr4"
+        "agent/valory/trader/0.1.0": "bafybeigmuysbq2w4aj5felnq7mm2c5qizltmopnhaswb5w6faad5c5bswe",
+        "service/valory/trader_pearl/0.1.0": "bafybeiainycevlg2xajfdds22pfvpnuazvyqss26xyp2lm7eu7pjs45fpi",
+        "service/valory/polymarket_trader/0.1.0": "bafybeihtjok3mtkt2mqq2v2mpnxjywkhcwysuh4vc73r6upmuw6omrmxaq"
     },
     "third_party": {
         "protocol/valory/acn_data_share/0.1.0": "bafybeieqisfr6lhaaesq37lk7vyaxza2h6nucshksgyo2djqfyf2saqo4i",

--- a/packages/valory/agents/trader/aea-config.yaml
+++ b/packages/valory/agents/trader/aea-config.yaml
@@ -282,7 +282,7 @@ models:
       polymarket_neg_risk_ctf_exchange_address: ${str:0xe2222d279d744050d28e00520010520000310F59}
       polymarket_neg_risk_adapter_address: ${str:0xd91E80cF2E7be2e162c6513ceD06f1dD0dA35296}
       valid_mechs: ${list:["0xc05e7412439bd7e91730a6880e18d5d5873f632c","0x601024e27f1c67b28209e24272ced8a31fc8151f","0xb3c6319962484602b00d5587e965946890b82101","0xdb78159e9246ec738f51c2c9cb1169b5c0e45fee","0x818df8dcd43d716a7263798c99a2fc8e27010711","0x11c4389bf449991d69f89f941c3e79d5d828f1bc"]}
-      valid_tools: ${list:["prediction-offline","superforcaster","factual_research"]}
+      valid_tools: ${list:["superforcaster","factual_research","prediction-request-reasoning-claude"]}
       penalize_mech_time_window: ${int:1800}
       pol_threshold_for_swap: ${int:2000000000000000000}
       slippages_for_swap: ${dict:{"xDAI-USDC":0.003,"POL-USDC":0.004}}

--- a/packages/valory/services/polymarket_trader/service.yaml
+++ b/packages/valory/services/polymarket_trader/service.yaml
@@ -8,7 +8,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeichoh5tnk4qctaazcjcrxvpwc5yasodleqoeapnfapwrrdh3tm5gu
 fingerprint_ignore_patterns: []
-agent: valory/trader:0.1.0:bafybeihb3zu3jimdibqnslscdn6zdt2a3orhe6avqt35yxqvfpajmftcii
+agent: valory/trader:0.1.0:bafybeigmuysbq2w4aj5felnq7mm2c5qizltmopnhaswb5w6faad5c5bswe
 number_of_agents: 1
 deployment:
   agent:

--- a/packages/valory/services/polymarket_trader/service.yaml
+++ b/packages/valory/services/polymarket_trader/service.yaml
@@ -161,7 +161,7 @@ models:
       polymarket_builder_program_enabled: ${POLYMARKET_BUILDER_PROGRAM_ENABLED:bool:false}
       pol_threshold_for_swap: ${POL_THRESHOLD_FOR_SWAP:int:2000000000000000000}
       valid_mechs: ${VALID_MECHS:list:["0x45f25db135e83d7a010b05ffc1202f8473e3ae7d","0xe7f818513a48d74c99b8bde153bee0b70dbb300b","0x76a9a29441c7acd072b03e63911f0e177de56ab7"]}
-      valid_tools: ${VALID_TOOLS:list:["superforcaster"]}
+      valid_tools: ${VALID_TOOLS:list:["superforcaster","factual_research"]}
       slippages_for_swap: ${SLIPPAGES_FOR_SWAP:dict:{"xDAI-USDC":0.003,"POL-USDC":0.004}}
       is_outcome_side_threshold_filter_enabled: ${IS_OUTCOME_SIDE_THRESHOLD_FILTER_ENABLED:bool:true}
       outcome_side_threshold_filter_threshold: ${OUTCOME_SIDE_THRESHOLD_FILTER_THRESHOLD:float:0.8}

--- a/packages/valory/services/trader_pearl/service.yaml
+++ b/packages/valory/services/trader_pearl/service.yaml
@@ -158,7 +158,7 @@ models:
       is_agent_performance_summary_enabled: ${IS_AGENT_PERFORMANCE_SUMMARY_ENABLED:bool:true}
       is_achievement_checker_enabled: ${IS_ACHIEVEMENT_CHECKER_ENABLED:bool:false}
       valid_mechs: ${VALID_MECHS:list:["0xc05e7412439bd7e91730a6880e18d5d5873f632c","0x601024e27f1c67b28209e24272ced8a31fc8151f","0xb3c6319962484602b00d5587e965946890b82101","0xdb78159e9246ec738f51c2c9cb1169b5c0e45fee","0x818df8dcd43d716a7263798c99a2fc8e27010711","0x11c4389bf449991d69f89f941c3e79d5d828f1bc"]}
-      valid_tools: ${VALID_TOOLS:list:["prediction-offline","superforcaster","factual_research"]}
+      valid_tools: ${VALID_TOOLS:list:["superforcaster","factual_research","prediction-request-reasoning-claude"]}
       penalize_mech_time_window: ${PENALIZE_MECH_TIME_WINDOW:int:1800}
       is_outcome_side_threshold_filter_enabled: ${IS_OUTCOME_SIDE_THRESHOLD_FILTER_ENABLED:bool:false}
       outcome_side_threshold_filter_threshold: ${OUTCOME_SIDE_THRESHOLD_FILTER_THRESHOLD:float:0.8}

--- a/packages/valory/services/trader_pearl/service.yaml
+++ b/packages/valory/services/trader_pearl/service.yaml
@@ -8,7 +8,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeibg7bdqpioh4lmvknw3ygnllfku32oca4eq5pqtvdrdsgw6buko7e
 fingerprint_ignore_patterns: []
-agent: valory/trader:0.1.0:bafybeihb3zu3jimdibqnslscdn6zdt2a3orhe6avqt35yxqvfpajmftcii
+agent: valory/trader:0.1.0:bafybeigmuysbq2w4aj5felnq7mm2c5qizltmopnhaswb5w6faad5c5bswe
 number_of_agents: 1
 deployment:
   agent:


### PR DESCRIPTION
## Summary

Extends the `valid_tools` mech-tool allowlist defaults introduced in #954:

- **Polystrat** (`polymarket_trader/service.yaml`): adds `factual_research` -> `["superforcaster", "factual_research"]`
- **Omenstrat** (`trader_pearl/service.yaml`): adds `prediction-request-reasoning-claude` -> `[ "superforcaster", "factual_research", "prediction-request-reasoning-claude"]`
- `packages.json`: service hashes re-locked

Stacked on top of `chore/drop-irrelevant-tools` (#954) — merge that first.

## Test plan

- [ ] Service yaml diffs read correctly
- [ ] `packages.json` hashes match the locked services
- [ ] CI: package-hash + dependency checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)