### PR TITLE
chore(release): drop dead APPLE_ID env vars from macOS signing step

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -236,8 +236,6 @@ jobs:
         env:
           CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
           CSC_LINK: ${{ secrets.CSC_LINK }}
-          APPLE_ID: ${{ secrets.APPLE_ID }} # Apple ID email
-          APPLE_ID_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }} # App-specific password
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }} # Team ID из Apple Dev Account
           SIGN_ID: "Developer ID Application: Valory AG (${{ secrets.APPLE_TEAM_ID }})"
         run: |


### PR DESCRIPTION
## Summary
- Remove the `APPLE_ID:` and `APPLE_ID_PASSWORD:` env-var lines from the macOS signing step in the release workflow.
- They reference secrets that no command in this workflow reads — pyinstaller code-signs via `SIGN_ID` (built from `APPLE_TEAM_ID`); there is no `notarytool` call here.
- `APPLE_TEAM_ID:` and `SIGN_ID:` are kept; macOS code-signing behavior is unchanged.

## Context
Notarization of agent binaries is currently deferred (binaries are downloaded by Pearl at runtime and do not receive the `com.apple.quarantine` xattr, so Gatekeeper does not enforce notarization). If that ever changes, the proper fix is to add an `xcrun notarytool submit … --wait` step — not to keep dead env vars around.

## Test plan
- [ ] Trigger the next release; the macOS signing step still succeeds.
- [ ] Confirm `codesign -dv` output on the produced `agent_runner_macos_*` binary still shows a valid Developer ID signature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
