### PR TITLE
chore(deps): bump web3 7.14.1 -> 7.15.0 (GHSA-5hr4-253g-cpx2)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "requests==2.32.5",
     "aiohttp==3.13.4",
     "asn1crypto==1.4.0",
-    "web3==7.14.1",
+    "web3==7.15.0",
     "protobuf==5.29.6",
     "jsonschema==4.23.0",
     "openapi-spec-validator==0.7.2",

--- a/uv.lock
+++ b/uv.lock
@@ -3742,7 +3742,7 @@ requires-dist = [
     { name = "setuptools", specifier = "==81.0.0" },
     { name = "typing-extensions", specifier = "==4.15.0" },
     { name = "w3multicall", specifier = "==0.3.1" },
-    { name = "web3", specifier = "==7.14.1" },
+    { name = "web3", specifier = "==7.15.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -3836,7 +3836,7 @@ wheels = [
 
 [[package]]
 name = "web3"
-version = "7.14.1"
+version = "7.15.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -3854,9 +3854,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/26/41/435cb36d36fc5142428292b876d0553d35af95e1582ecb7d8bcb64039d18/web3-7.14.1.tar.gz", hash = "sha256:856dc8517f362aefa75fdc298d975894055565dc866f21279f27fe060b7fb2c3", size = 2208998, upload-time = "2026-02-03T22:56:41.426Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/93/84/1516ee335e89e4d7d0837895d21091244ee3189d1ffe76fa435d2bd15f4e/web3-7.15.0.tar.gz", hash = "sha256:2a2bcbab8fcf120c2256ddbdc88fcc80a47c100ad758659a980e9fab66609171", size = 2211838, upload-time = "2026-04-02T18:20:40.355Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7f/d1/862bbf48867685de1a563de20a9bad2b8c5c5678b3f08adc0e06797783f5/web3-7.14.1-py3-none-any.whl", hash = "sha256:bec367ba44261f874662aed9b5e138aa7bb907700a30a7580b2264534e88ce12", size = 1371268, upload-time = "2026-02-03T22:56:36.577Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/f0/ef9b82557b22b1cdb95ec7863d1d9897ed3b9e096a1af5e046fb892efdc0/web3-7.15.0-py3-none-any.whl", hash = "sha256:bbeba510aaa4eb3c99662d911db9d2a648ab40f608cf0269065f7db1d1d0b0c0", size = 1373052, upload-time = "2026-04-02T18:20:36.757Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Bumps `web3` from 7.14.1 to 7.15.0 in `pyproject.toml` + `uv.lock`.
- 7.15.0 is the patched release for advisory **GHSA-5hr4-253g-cpx2** (CCIP Read / EIP-3668 destination validation). The previous pin sat in the affected range `>=6.0.0b3, <7.15.0`.
- Package YAML constraints already permit `<8,>=7.0.0`, so no contract or connection YAML changes are required and no package hashes shift.

Closes #967.

## Test plan

- [ ] CI: `tox -e py3.10-linux` (and matrix variants)
- [ ] CI: lint / type / security suites
- [ ] CI: `autonomy packages lock --check`
- [ ] Smoke: `make run-agent` boots without import / RPC regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)