### PR TITLE
fix(staking): declare activity_target in trader_abci composed skill

### DIFF
--- a/packages/packages.json
+++ b/packages/packages.json
@@ -10,15 +10,15 @@
         "connection/valory/polymarket_client/0.1.0": "bafybeibqdhwczb7pbz7mp4n62mlysdhgig4waf2nmka6y5qmx7procd5ru",
         "skill/valory/market_manager_abci/0.1.0": "bafybeibo5xuvhzkvwz6ug7sslrdkgqqoaf5bjpg5slgznzp6knfxwb4qpm",
         "skill/valory/decision_maker_abci/0.1.0": "bafybeic2nklj26lboesncvts2x6ea42wcmzblteb3oj3hzsjp45efvffbu",
-        "skill/valory/trader_abci/0.1.0": "bafybeiezeea753qrgjcnae7bpt3tbngnmp4vvdg2ghlnmmgr6yhahy3fci",
+        "skill/valory/trader_abci/0.1.0": "bafybeifjiwl3cn5te3ndrbeblqhls3bfl5dgqinui4rd3j3qmgapbh6hsm",
         "skill/valory/tx_settlement_multiplexer_abci/0.1.0": "bafybeicvp7m55a6gayaau4dwhcsjzgmtg6so4qx7gn4cvabyohrdjb6u4y",
         "skill/valory/staking_abci/0.1.0": "bafybeihwyron2bv7ierrgxke7xofwjy7x6wtglg5vopon7i7lfdiivweaq",
         "skill/valory/agent_performance_summary_abci/0.1.0": "bafybeifqyvxwfnocgcp6pd6gv72xfosmq22oa4gstdn5qlzzlqpw4g7a6i",
         "skill/valory/check_stop_trading_abci/0.1.0": "bafybeicn7jh4yecq3k7bsp7cbmaprb7yzqp2ud44mq2u72lpnbv2lb2hci",
         "skill/valory/chatui_abci/0.1.0": "bafybeibe4xosp4gpbn4p3vgqjcgmulqcqtaregwkfcoqezxvdr5iidv3ru",
-        "agent/valory/trader/0.1.0": "bafybeig72ezovxdxt3w2wvbwa77zr2n7i2pvhvvzd2rxubo7di6k2rlbva",
-        "service/valory/trader_pearl/0.1.0": "bafybeihe674dxubyfptltcfmmq3wfeo4uooawclh53bg4sljgeldjdtvwy",
-        "service/valory/polymarket_trader/0.1.0": "bafybeihlecls3mhnpeackeehjx7n2w3zr7l2ftxfzryvjn2jdktpkfvz2m"
+        "agent/valory/trader/0.1.0": "bafybeibksa6kp2vzds54p6u4s3atsoxypxg376dorg2l2ooksvbj5yim3e",
+        "service/valory/trader_pearl/0.1.0": "bafybeiafmv7rqsl5hwrumsbq7atihnx3afuw7bfalbfmye5rjrapgj2bgm",
+        "service/valory/polymarket_trader/0.1.0": "bafybeid4omxqmjbyy66ye2cqbs2pjvs7lesz7a76hevlb2i6rzritlesxm"
     },
     "third_party": {
         "protocol/valory/acn_data_share/0.1.0": "bafybeieqisfr6lhaaesq37lk7vyaxza2h6nucshksgyo2djqfyf2saqo4i",

--- a/packages/valory/agents/trader/aea-config.yaml
+++ b/packages/valory/agents/trader/aea-config.yaml
@@ -69,7 +69,7 @@ skills:
 - valory/tx_settlement_multiplexer_abci:0.1.0:bafybeicvp7m55a6gayaau4dwhcsjzgmtg6so4qx7gn4cvabyohrdjb6u4y
 - valory/market_manager_abci:0.1.0:bafybeibo5xuvhzkvwz6ug7sslrdkgqqoaf5bjpg5slgznzp6knfxwb4qpm
 - valory/decision_maker_abci:0.1.0:bafybeic2nklj26lboesncvts2x6ea42wcmzblteb3oj3hzsjp45efvffbu
-- valory/trader_abci:0.1.0:bafybeiezeea753qrgjcnae7bpt3tbngnmp4vvdg2ghlnmmgr6yhahy3fci
+- valory/trader_abci:0.1.0:bafybeifjiwl3cn5te3ndrbeblqhls3bfl5dgqinui4rd3j3qmgapbh6hsm
 - valory/staking_abci:0.1.0:bafybeihwyron2bv7ierrgxke7xofwjy7x6wtglg5vopon7i7lfdiivweaq
 - valory/check_stop_trading_abci:0.1.0:bafybeicn7jh4yecq3k7bsp7cbmaprb7yzqp2ud44mq2u72lpnbv2lb2hci
 - valory/mech_interact_abci:0.1.0:bafybeidnmszufszq3ro4ebgrqzmhqgctrsc6sykeanfsbvotghvt2cgfsy

--- a/packages/valory/services/polymarket_trader/service.yaml
+++ b/packages/valory/services/polymarket_trader/service.yaml
@@ -8,7 +8,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeichoh5tnk4qctaazcjcrxvpwc5yasodleqoeapnfapwrrdh3tm5gu
 fingerprint_ignore_patterns: []
-agent: valory/trader:0.1.0:bafybeig72ezovxdxt3w2wvbwa77zr2n7i2pvhvvzd2rxubo7di6k2rlbva
+agent: valory/trader:0.1.0:bafybeibksa6kp2vzds54p6u4s3atsoxypxg376dorg2l2ooksvbj5yim3e
 number_of_agents: 1
 deployment:
   agent:

--- a/packages/valory/services/trader_pearl/service.yaml
+++ b/packages/valory/services/trader_pearl/service.yaml
@@ -8,7 +8,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeibg7bdqpioh4lmvknw3ygnllfku32oca4eq5pqtvdrdsgw6buko7e
 fingerprint_ignore_patterns: []
-agent: valory/trader:0.1.0:bafybeig72ezovxdxt3w2wvbwa77zr2n7i2pvhvvzd2rxubo7di6k2rlbva
+agent: valory/trader:0.1.0:bafybeibksa6kp2vzds54p6u4s3atsoxypxg376dorg2l2ooksvbj5yim3e
 number_of_agents: 1
 deployment:
   agent:

--- a/packages/valory/skills/trader_abci/skill.yaml
+++ b/packages/valory/skills/trader_abci/skill.yaml
@@ -265,6 +265,7 @@ models:
       staking_interaction_sleep_time: 5
       disable_trading: false
       stop_trading_if_staking_kpi_met: true
+      activity_target: 8
       agent_balance_threshold: 10000000000000000
       refill_check_interval: 10
       mech_activity_checker_contract: '0x0000000000000000000000000000000000000000'


### PR DESCRIPTION
## Summary

Fixes a regression introduced by #993 (staking/activity decoupling) that prevents the agent from loading.

#993 added an `activity_target` override to:
- the agent override (`packages/valory/agents/trader/aea-config.yaml`)
- both service YAMLs (`trader_pearl`, `polymarket_trader`)
- the leaf skill `check_stop_trading_abci`

…but **never declared `activity_target` in the composed `trader_abci` skill's `models.params.args`**. AEA validates each override against the *target* skill's declared args, and the agent/service overrides resolve against `trader_abci`. With the key absent there, loading the agent fails at certificate issuance / `run-agent`:

```
ValueError: Attribute `models.params.args.activity_target` is not allowed to be updated!
```

## Fix

Add `activity_target: 8` to `trader_abci/skill.yaml` alongside the existing `stop_trading_if_staking_kpi_met` entry (same pattern, resolved plain default), and relock package hashes.

## Changes
- `packages/valory/skills/trader_abci/skill.yaml` — declare `activity_target: 8` (the one functional line)
- `aea-config.yaml`, both `service.yaml`, `packages.json` — cascading hash bumps from the relock

## Testing
- `autonomy packages lock` — clean
- Re-fetch + run-agent now passes the override validation that previously raised

🤖 Generated with [Claude Code](https://claude.com/claude-code)
