### PR TITLE
fix(ci): align check-agent-runner with STORE_PATH named env var from #982

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -204,11 +204,12 @@ build-agent-runner-mac: uv-install  agent
 
 .PHONY: check-agent-runner
 check-agent-runner:
-	# aea-config.yaml uses an anonymous template ($${str:/data/}) so Pearl's
-	# path-based env-var injection wins at runtime; a named template would
-	# suppress the fallback. See valory-xyz/olas-operate-middleware#424.
+	# aea-config.yaml uses a named env-var template ($${STORE_PATH:str:/data/})
+	# for the skill's store_path, so a single STORE_PATH override drives it.
+	# Path-based env vars like SKILL_..._STORE_PATH are the fallback when the
+	# template lacks an explicit var name and are silently ignored here.
 	uv run aea-helpers check-binary ./dist/agent_runner_bin$(EXE_SUFFIX) ./agent \
-	--env-var SKILL_TRADER_ABCI_MODELS_PARAMS_ARGS_STORE_PATH=$(STORE_PATH_VALUE)
+	--env-var STORE_PATH=$(STORE_PATH_VALUE)
 
 .PHONY: ci-linter-checks
 ci-linter-checks:


### PR DESCRIPTION
## Summary

PR #982 restored the named `${VAR:type:default}` syntax in `aea-config.yaml`, including the skill's store path:

```yaml
store_path: ${STORE_PATH:str:/data/}
```

…but it left the `check-agent-runner` Make target behind. That target dates from the **reverted anonymous-template era** (commit `26a29d13`) and was still:

1. Injecting the path-based fallback name `SKILL_TRADER_ABCI_MODELS_PARAMS_ARGS_STORE_PATH`, which is silently ignored once the template carries an explicit var name — so the binary smoke test no longer actually drove `store_path`.
2. Carrying a comment claiming the template is *anonymous* and that "a named template would suppress the fallback" — the exact inverse of the state #982 restored.

This is what failed the `check agent runner` step on the `v0.40.0-rc1` release run.

## Change

- Switch `--env-var` back to `STORE_PATH=$(STORE_PATH_VALUE)` so the override matches the named template.
- Restore the comment to describe the named template and the path-based fallback semantics.

Makefile-only change — no package contents touched, so no re-lock or Python lint applies. `gitleaks` ran clean on commit.

## Test plan

- [x] **Validated via test release `v0.40.0-test`** ([run 27764556349](https://github.com/valory-xyz/trader/actions/runs/27764556349)) cut from this branch — all jobs green, including `build-agent-runner (ubuntu-22.04-arm)`, whose `check agent runner` step failed on `v0.40.0-rc1`. The named `STORE_PATH` override now resolves `store_path` and the binary smoke test passes on every platform (linux x64/arm, windows, macos x64/arm).

🤖 Generated with [Claude Code](https://claude.com/claude-code)