### PR TITLE
fix: align polymarket_client Safe address with SAFE_CONTRACT_ADDRESSES env var

### DIFF
--- a/packages/packages.json
+++ b/packages/packages.json
@@ -16,9 +16,9 @@
         "skill/valory/agent_performance_summary_abci/0.1.0": "bafybeigmmvpncem6i6t57nwjqzajrbnf6rnqgp43mlo6jf6uziq6lrhlca",
         "skill/valory/check_stop_trading_abci/0.1.0": "bafybeifbiko6p3sqqg2q6qemmcig432s5djcsxm44j35ejittlpyr5f6z4",
         "skill/valory/chatui_abci/0.1.0": "bafybeie2kmgihgk3rwpzelaa76ypvchsyg2vy3me4vxlbjttaq4frs3ipa",
-        "agent/valory/trader/0.1.0": "bafybeico4rr7filqfzfg564b6gxtksfd3bgkt74upko6brueqao4qjt7fq",
-        "service/valory/trader_pearl/0.1.0": "bafybeidjkz5vzts3sneeq5bs73djyus65yzsv7nmom766wivxhkfonjnhy",
-        "service/valory/polymarket_trader/0.1.0": "bafybeieen4mng2rchxscfyqakmty42jyngojvhj54r572htle5g4qqteyy"
+        "agent/valory/trader/0.1.0": "bafybeidiwl354xj2opoe6n4l7e2d5or2thavaohpxdxhqdypt7r7on6iae",
+        "service/valory/trader_pearl/0.1.0": "bafybeib77mnuixonl54u2d23ilvah67n2svenmu76b6mn7wkg3emgg5ity",
+        "service/valory/polymarket_trader/0.1.0": "bafybeiap63bhbkiu7lyqjxejolu7ltfxnyfeupebyio7z6fz7o5v7t5wae"
     },
     "third_party": {
         "protocol/valory/acn_data_share/0.1.0": "bafybeieqisfr6lhaaesq37lk7vyaxza2h6nucshksgyo2djqfyf2saqo4i",

--- a/packages/valory/agents/trader/aea-config.yaml
+++ b/packages/valory/agents/trader/aea-config.yaml
@@ -584,8 +584,7 @@ type: connection
 config:
   host: https://clob.polymarket.com
   chain_id: 137
-  safe_contract_addresses:
-    polygon: ${SAFE_CONTRACT_ADDRESS:str:0x}
+  safe_contract_addresses: ${SAFE_CONTRACT_ADDRESSES:dict:{"polygon":"0x0000000000000000000000000000000000000000"}}
   polymarket_builder_program_enabled: ${POLYMARKET_BUILDER_PROGRAM_ENABLED:bool:false}
   builder_code: ${POLYMARKET_BUILDER_CODE:str:0x0000000000000000000000000000000000000000000000000000000000000000}
   clob_version: ${CLOB_VERSION:str:v2}

--- a/packages/valory/services/polymarket_trader/service.yaml
+++ b/packages/valory/services/polymarket_trader/service.yaml
@@ -8,7 +8,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeichoh5tnk4qctaazcjcrxvpwc5yasodleqoeapnfapwrrdh3tm5gu
 fingerprint_ignore_patterns: []
-agent: valory/trader:0.1.0:bafybeico4rr7filqfzfg564b6gxtksfd3bgkt74upko6brueqao4qjt7fq
+agent: valory/trader:0.1.0:bafybeidiwl354xj2opoe6n4l7e2d5or2thavaohpxdxhqdypt7r7on6iae
 number_of_agents: 1
 deployment:
   agent:

--- a/packages/valory/services/trader_pearl/service.yaml
+++ b/packages/valory/services/trader_pearl/service.yaml
@@ -8,7 +8,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeibg7bdqpioh4lmvknw3ygnllfku32oca4eq5pqtvdrdsgw6buko7e
 fingerprint_ignore_patterns: []
-agent: valory/trader:0.1.0:bafybeico4rr7filqfzfg564b6gxtksfd3bgkt74upko6brueqao4qjt7fq
+agent: valory/trader:0.1.0:bafybeidiwl354xj2opoe6n4l7e2d5or2thavaohpxdxhqdypt7r7on6iae
 number_of_agents: 1
 deployment:
   agent:


### PR DESCRIPTION
## Problem

The Polystrat agent crashes at startup while instantiating `valory/polymarket_client`:

```
Error: An error occurred during instantiation of connection valory/polymarket_client:0.1.0/PolymarketClientConnection:
ValueError: Unknown format '0x', attempted to normalize to '0x'
```

The CLOB-client bootstrap normalizes the Polygon Safe address first (`connection.py:308-312` → `to_checksum_address(funder)` at `connection.py:377`), and it received the bare placeholder `0x`.

## Root cause

The agent-level `aea-config.yaml` override for `polymarket_client` fed a **singular scalar** placeholder into a **dict** field:

```yaml
safe_contract_addresses:
  polygon: ${SAFE_CONTRACT_ADDRESS:str:0x}
```

But the deployment generates `agent.json` from `service.yaml` (`autonomy ... generate_agent` → `process_component_overrides`), and both `service.yaml` and the middleware emit the **plural dict** `SAFE_CONTRACT_ADDRESSES = {"polygon":"0x..."}` — there is no singular `SAFE_CONTRACT_ADDRESS` in the env for the connection. At runtime the agent's `aea-config.yaml` placeholder `${SAFE_CONTRACT_ADDRESS:str:0x}` found nothing and fell back to `0x`, crashing the connection.

This field was the only place in the config that piped the singular scalar var into a plural dict field; every other dict consumer (`funds_manager`, both `service.yaml` files) already used the plural form.

## Fix

Align the override with `service.yaml:398` and the `funds_manager` override:

```yaml
safe_contract_addresses: ${SAFE_CONTRACT_ADDRESSES:dict:{"polygon":"0x0000000000000000000000000000000000000000"}}
```

Now the middleware-provisioned Polygon Safe reaches the connection on the agent-runner path, matching `autonomy deploy`.

### No code change needed
- The connection reads the resolved config field (`config.get("safe_contract_addresses").get("polygon")`), not the env var by name — only the placeholder feeding it changed.
- The singular `SAFE_CONTRACT_ADDRESS` var is still consumed by the **separate** consensus `setup.safe_contract_address` scalar (`service.yaml:28`), which is unchanged.
- Connection tests already mock the dict shape (`{"polygon": ...}`).

## Changes
- `aea-config.yaml`: scalar → dict placeholder for `polymarket_client.safe_contract_addresses`
- Package hashes refreshed via `autonomy packages lock` (agent + both services + `packages.json`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)