### PR TITLE
fix: align funds_manager rpc_urls and mechs subgraph with agent-runner env vars

### DIFF
--- a/packages/packages.json
+++ b/packages/packages.json
@@ -10,15 +10,15 @@
         "connection/valory/polymarket_client/0.1.0": "bafybeid4eo37pka4tfhsjs6rb3knrugmokcvihust2dpfrgob56y77xd44",
         "skill/valory/market_manager_abci/0.1.0": "bafybeic67hypwetzltnuy3a6y3o2o332lxyvn34buq57gy4n6bfqpbpxjm",
         "skill/valory/decision_maker_abci/0.1.0": "bafybeicedj5dtoheq4y5ez4ttw72vzdrpouhwxjgth42eyerpneykkejka",
-        "skill/valory/trader_abci/0.1.0": "bafybeihzu6zmblk4c77dv3z53pz3lyawwdpm3i7yu3czrhr6hdzeowzzyq",
+        "skill/valory/trader_abci/0.1.0": "bafybeidyiphgc3u4x6fn3ghq2fatwgu5khtwnfch5hz6wnlbodn3jdz2rm",
         "skill/valory/tx_settlement_multiplexer_abci/0.1.0": "bafybeidj2k4sgfgrz6tzaslvygawqfmnop7sqcsboaedqnmyzu7qqs4nkm",
         "skill/valory/staking_abci/0.1.0": "bafybeihwyron2bv7ierrgxke7xofwjy7x6wtglg5vopon7i7lfdiivweaq",
         "skill/valory/agent_performance_summary_abci/0.1.0": "bafybeigmmvpncem6i6t57nwjqzajrbnf6rnqgp43mlo6jf6uziq6lrhlca",
         "skill/valory/check_stop_trading_abci/0.1.0": "bafybeifbiko6p3sqqg2q6qemmcig432s5djcsxm44j35ejittlpyr5f6z4",
         "skill/valory/chatui_abci/0.1.0": "bafybeie2kmgihgk3rwpzelaa76ypvchsyg2vy3me4vxlbjttaq4frs3ipa",
-        "agent/valory/trader/0.1.0": "bafybeidiwl354xj2opoe6n4l7e2d5or2thavaohpxdxhqdypt7r7on6iae",
-        "service/valory/trader_pearl/0.1.0": "bafybeib77mnuixonl54u2d23ilvah67n2svenmu76b6mn7wkg3emgg5ity",
-        "service/valory/polymarket_trader/0.1.0": "bafybeiap63bhbkiu7lyqjxejolu7ltfxnyfeupebyio7z6fz7o5v7t5wae"
+        "agent/valory/trader/0.1.0": "bafybeiayum4h7migc6vzgfne2ahcp47hyk5iy5ladhmuz2fmipr6ob5i6y",
+        "service/valory/trader_pearl/0.1.0": "bafybeiagwo2qykidwf3hcboff5kqcwtqeg32gkb5x6rmwrtxqaulrpk62i",
+        "service/valory/polymarket_trader/0.1.0": "bafybeibsp25xqtvlu3wse2rgg5uku3c53tf7j2q3xjd5jadiyudv5fx6om"
     },
     "third_party": {
         "protocol/valory/acn_data_share/0.1.0": "bafybeieqisfr6lhaaesq37lk7vyaxza2h6nucshksgyo2djqfyf2saqo4i",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -16,9 +16,9 @@
         "skill/valory/agent_performance_summary_abci/0.1.0": "bafybeigmmvpncem6i6t57nwjqzajrbnf6rnqgp43mlo6jf6uziq6lrhlca",
         "skill/valory/check_stop_trading_abci/0.1.0": "bafybeifbiko6p3sqqg2q6qemmcig432s5djcsxm44j35ejittlpyr5f6z4",
         "skill/valory/chatui_abci/0.1.0": "bafybeie2kmgihgk3rwpzelaa76ypvchsyg2vy3me4vxlbjttaq4frs3ipa",
-        "agent/valory/trader/0.1.0": "bafybeiayum4h7migc6vzgfne2ahcp47hyk5iy5ladhmuz2fmipr6ob5i6y",
-        "service/valory/trader_pearl/0.1.0": "bafybeiagwo2qykidwf3hcboff5kqcwtqeg32gkb5x6rmwrtxqaulrpk62i",
-        "service/valory/polymarket_trader/0.1.0": "bafybeibsp25xqtvlu3wse2rgg5uku3c53tf7j2q3xjd5jadiyudv5fx6om"
+        "agent/valory/trader/0.1.0": "bafybeidh3bszukpqma73tjko5ngyysly76oh4ohfas3vqexsv4stwco46a",
+        "service/valory/trader_pearl/0.1.0": "bafybeifuphhsarhdvymixytqmndwj4cwzs7azkgytvrzrkllgc4zqq3qoq",
+        "service/valory/polymarket_trader/0.1.0": "bafybeiapvnpaw3gw342263wcngsrvoldf5bf7ovrl4n3ljybhapk4qlism"
     },
     "third_party": {
         "protocol/valory/acn_data_share/0.1.0": "bafybeieqisfr6lhaaesq37lk7vyaxza2h6nucshksgyo2djqfyf2saqo4i",

--- a/packages/valory/agents/trader/aea-config.yaml
+++ b/packages/valory/agents/trader/aea-config.yaml
@@ -69,7 +69,7 @@ skills:
 - valory/tx_settlement_multiplexer_abci:0.1.0:bafybeidj2k4sgfgrz6tzaslvygawqfmnop7sqcsboaedqnmyzu7qqs4nkm
 - valory/market_manager_abci:0.1.0:bafybeic67hypwetzltnuy3a6y3o2o332lxyvn34buq57gy4n6bfqpbpxjm
 - valory/decision_maker_abci:0.1.0:bafybeicedj5dtoheq4y5ez4ttw72vzdrpouhwxjgth42eyerpneykkejka
-- valory/trader_abci:0.1.0:bafybeihzu6zmblk4c77dv3z53pz3lyawwdpm3i7yu3czrhr6hdzeowzzyq
+- valory/trader_abci:0.1.0:bafybeidyiphgc3u4x6fn3ghq2fatwgu5khtwnfch5hz6wnlbodn3jdz2rm
 - valory/staking_abci:0.1.0:bafybeihwyron2bv7ierrgxke7xofwjy7x6wtglg5vopon7i7lfdiivweaq
 - valory/check_stop_trading_abci:0.1.0:bafybeifbiko6p3sqqg2q6qemmcig432s5djcsxm44j35ejittlpyr5f6z4
 - valory/mech_interact_abci:0.1.0:bafybeidnmszufszq3ro4ebgrqzmhqgctrsc6sykeanfsbvotghvt2cgfsy
@@ -474,7 +474,7 @@ models:
       error_index: ${int:0}
       error_type: ${str:dict}
       retries: ${int:5}
-      url: ${MECHS_SUBGRAPH_URL:str:https://api.subgraph.autonolas.tech/api/proxy/marketplace-gnosis}
+      url: ${str:https://api.subgraph.autonolas.tech/api/proxy/marketplace-gnosis}
       delivery_rate_cap: ${int:10000000000000000}
   polymarket_agents_subgraph:
     args:
@@ -576,7 +576,9 @@ models:
   params:
     args:
       fund_requirements: ${FUND_REQUIREMENTS:dict:{"gnosis":{"agent":{"0x0000000000000000000000000000000000000000":{"topup":2000000000000000000,"threshold":210000000000000000}},"safe":{"0x0000000000000000000000000000000000000000":{"topup":5000000000000000000,"threshold":1000000000000000000},"0xe91D153E0b41518A2Ce8Dd3D7944Fa863463a97d":{"topup":0,"threshold":0}}}}}
-      rpc_urls: ${RPC_URLS:dict:{"gnosis":"https://rpc.gnosischain.com"}}
+      rpc_urls:
+        gnosis: ${GNOSIS_LEDGER_RPC:str:https://rpc.gnosischain.com}
+        polygon: ${POLYGON_LEDGER_RPC:str:https://1rpc.io/matic}
       safe_contract_addresses: ${SAFE_CONTRACT_ADDRESSES:dict:{"gnosis":"0x0000000000000000000000000000000000000000"}}
 ---
 public_id: valory/polymarket_client:0.1.0:bafybeicblltx7ha3ulthg7bzfccuqqyjmihhrvfeztlgrlcoxhr7kf6nbq

--- a/packages/valory/agents/trader/aea-config.yaml
+++ b/packages/valory/agents/trader/aea-config.yaml
@@ -268,7 +268,7 @@ models:
       genai_api_key: ${GENAI_API_KEY:str:""}
       x402_payment_requirements: ${dict:{"threshold":200000,"top_up":250000}}
       gnosis_ledger_rpc: ${str:https://rpc.gnosischain.com/}
-      polygon_ledger_rpc: ${POLYGON_LEDGER_RPC:str:https://1rpc.io/matic}
+      polygon_ledger_rpc: ${POLYGON_LEDGER_RPC:str:https://polygon.drpc.org}
       lifi_quote_to_amount_url: ${str:https://li.quest/v1/quote/toAmount}
       use_x402: ${USE_X402:bool:false}
       is_agent_performance_summary_enabled: ${IS_AGENT_PERFORMANCE_SUMMARY_ENABLED:bool:true}
@@ -544,7 +544,7 @@ config:
       poa_chain: ${bool:false}
       default_gas_price_strategy: ${str:eip1559}
     polygon:
-      address: ${POLYGON_LEDGER_RPC:str:https://1rpc.io/matic}
+      address: ${POLYGON_LEDGER_RPC:str:https://polygon.drpc.org}
       chain_id: ${int:137}
       poa_chain: ${bool:true}
       default_gas_price_strategy: ${str:eip1559}
@@ -578,7 +578,7 @@ models:
       fund_requirements: ${FUND_REQUIREMENTS:dict:{"gnosis":{"agent":{"0x0000000000000000000000000000000000000000":{"topup":2000000000000000000,"threshold":210000000000000000}},"safe":{"0x0000000000000000000000000000000000000000":{"topup":5000000000000000000,"threshold":1000000000000000000},"0xe91D153E0b41518A2Ce8Dd3D7944Fa863463a97d":{"topup":0,"threshold":0}}}}}
       rpc_urls:
         gnosis: ${GNOSIS_LEDGER_RPC:str:https://rpc.gnosischain.com}
-        polygon: ${POLYGON_LEDGER_RPC:str:https://1rpc.io/matic}
+        polygon: ${POLYGON_LEDGER_RPC:str:https://polygon.drpc.org}
       safe_contract_addresses: ${SAFE_CONTRACT_ADDRESSES:dict:{"gnosis":"0x0000000000000000000000000000000000000000"}}
 ---
 public_id: valory/polymarket_client:0.1.0:bafybeicblltx7ha3ulthg7bzfccuqqyjmihhrvfeztlgrlcoxhr7kf6nbq
@@ -597,5 +597,5 @@ config:
   ctf_exchange: ${POLYMARKET_CTF_EXCHANGE:str:0xE111180000d2663C0091e4f400237545B87B996B}
   neg_risk_ctf_exchange: ${POLYMARKET_NEG_RISK_CTF_EXCHANGE:str:0xe2222d279d744050d28e00520010520000310F59}
   neg_risk_adapter: ${POLYMARKET_NEG_RISK_ADAPTER:str:0xd91E80cF2E7be2e162c6513ceD06f1dD0dA35296}
-  polygon_ledger_rpc: ${POLYGON_LEDGER_RPC:str:https://1rpc.io/matic}
+  polygon_ledger_rpc: ${POLYGON_LEDGER_RPC:str:https://polygon.drpc.org}
   is_running_on_polymarket: ${IS_RUNNING_ON_POLYMARKET:bool:false}

--- a/packages/valory/services/polymarket_trader/service.yaml
+++ b/packages/valory/services/polymarket_trader/service.yaml
@@ -8,7 +8,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeichoh5tnk4qctaazcjcrxvpwc5yasodleqoeapnfapwrrdh3tm5gu
 fingerprint_ignore_patterns: []
-agent: valory/trader:0.1.0:bafybeidiwl354xj2opoe6n4l7e2d5or2thavaohpxdxhqdypt7r7on6iae
+agent: valory/trader:0.1.0:bafybeiayum4h7migc6vzgfne2ahcp47hyk5iy5ladhmuz2fmipr6ob5i6y
 number_of_agents: 1
 deployment:
   agent:

--- a/packages/valory/services/polymarket_trader/service.yaml
+++ b/packages/valory/services/polymarket_trader/service.yaml
@@ -8,7 +8,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeichoh5tnk4qctaazcjcrxvpwc5yasodleqoeapnfapwrrdh3tm5gu
 fingerprint_ignore_patterns: []
-agent: valory/trader:0.1.0:bafybeiayum4h7migc6vzgfne2ahcp47hyk5iy5ladhmuz2fmipr6ob5i6y
+agent: valory/trader:0.1.0:bafybeidh3bszukpqma73tjko5ngyysly76oh4ohfas3vqexsv4stwco46a
 number_of_agents: 1
 deployment:
   agent:
@@ -153,7 +153,7 @@ models:
       coingecko_pol_in_usd_price_url: ${COINGECKO_POL_IN_USD_PRICE_URL:str:https://api.coingecko.com/api/v3/simple/token_price/polygon-pos?contract_addresses=0x0000000000000000000000000000000000001010&vs_currencies=usd}
       genai_api_key: ${GENAI_API_KEY:str:""}
       x402_payment_requirements: ${X402_PAYMENT_REQUIREMENTS:dict:{"threshold":200000,"top_up":250000}}
-      polygon_ledger_rpc: ${POLYGON_LEDGER_RPC:str:https://1rpc.io/matic}
+      polygon_ledger_rpc: ${POLYGON_LEDGER_RPC:str:https://polygon.drpc.org}
       lifi_quote_to_amount_url: ${LIFI_QUOTE_TO_AMOUNT_URL:str:https://li.quest/v1/quote/toAmount}
       use_x402: ${USE_X402:bool:false}
       is_agent_performance_summary_enabled: ${IS_AGENT_PERFORMANCE_SUMMARY_ENABLED:bool:true}
@@ -338,7 +338,7 @@ type: connection
 config:
   ledger_apis:
     polygon:
-      address: ${POLYGON_LEDGER_RPC:str:https://1rpc.io/matic}
+      address: ${POLYGON_LEDGER_RPC:str:https://polygon.drpc.org}
       chain_id: ${POLYGON_LEDGER_CHAIN_ID:int:137}
       poa_chain: ${POLYGON_LEDGER_IS_POA_CHAIN:bool:true}
       default_gas_price_strategy: ${POLYGON_LEDGER_PRICING:str:eip1559}
@@ -387,7 +387,7 @@ models:
     args:
       fund_requirements: ${FUND_REQUIREMENTS:dict:{"polygon":{"agent":{"0x0000000000000000000000000000000000000000":{"topup":30000000000000000000,"threshold":3200000000000000000}},"safe":{"0x0000000000000000000000000000000000000000":{"topup":40000000000000000000,"threshold":10000000000000000000},"0xC011a7E12a19f7B1f670d46F03B03f3342E82DFB":{"topup":65000000,"threshold":16000000},"0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174":{"topup":0,"threshold":0},"0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359":{"topup":0,"threshold":0}}}}}
       rpc_urls:
-        polygon: ${POLYGON_LEDGER_RPC:str:https://1rpc.io/matic}
+        polygon: ${POLYGON_LEDGER_RPC:str:https://polygon.drpc.org}
       safe_contract_addresses: ${SAFE_CONTRACT_ADDRESSES:dict:{"polygon":"0x0000000000000000000000000000000000000000"}}
 ---
 public_id: valory/polymarket_client:0.1.0:bafybeicblltx7ha3ulthg7bzfccuqqyjmihhrvfeztlgrlcoxhr7kf6nbq

--- a/packages/valory/services/trader_pearl/service.yaml
+++ b/packages/valory/services/trader_pearl/service.yaml
@@ -8,7 +8,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeibg7bdqpioh4lmvknw3ygnllfku32oca4eq5pqtvdrdsgw6buko7e
 fingerprint_ignore_patterns: []
-agent: valory/trader:0.1.0:bafybeiayum4h7migc6vzgfne2ahcp47hyk5iy5ladhmuz2fmipr6ob5i6y
+agent: valory/trader:0.1.0:bafybeidh3bszukpqma73tjko5ngyysly76oh4ohfas3vqexsv4stwco46a
 number_of_agents: 1
 deployment:
   agent:

--- a/packages/valory/services/trader_pearl/service.yaml
+++ b/packages/valory/services/trader_pearl/service.yaml
@@ -8,7 +8,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeibg7bdqpioh4lmvknw3ygnllfku32oca4eq5pqtvdrdsgw6buko7e
 fingerprint_ignore_patterns: []
-agent: valory/trader:0.1.0:bafybeidiwl354xj2opoe6n4l7e2d5or2thavaohpxdxhqdypt7r7on6iae
+agent: valory/trader:0.1.0:bafybeiayum4h7migc6vzgfne2ahcp47hyk5iy5ladhmuz2fmipr6ob5i6y
 number_of_agents: 1
 deployment:
   agent:

--- a/packages/valory/skills/trader_abci/skill.yaml
+++ b/packages/valory/skills/trader_abci/skill.yaml
@@ -15,6 +15,7 @@ fingerprint:
   handlers.py: bafybeidefu2bxiadnxbnlaiz2e4ntrcrraxhrvmvyd7uce3e274lfdodti
   models.py: bafybeiai3vxuyl2ydfxocaygnhbno2ef3lw4ag63turmd7fqpaleixc2xy
   tests/__init__.py: bafybeiadatapyjh3e7ucg2ehz77oms3ihrbutwb2cs2tkjehy54utwvuyi
+  tests/test_agent_config_resolution.py: bafybeiflcotz6gq2dgtnzptlyyhu5fryg3c6z7gosoqmln2tlci3v4odqa
   tests/test_behaviours.py: bafybeicovtjruufnh2yd5lhfvc6pgcletuyj2s3jaz5sz55wsdo2w22xle
   tests/test_composition.py: bafybeie54kpq3hzxnqegeyswbg7upae3bi25p7xucaco36zzkekt7ivleq
   tests/test_dialogues.py: bafybeibatogwoj6ieapcbiwonij6vskhogc65vfv53tyauqzeyiwmnd2im

--- a/packages/valory/skills/trader_abci/tests/test_agent_config_resolution.py
+++ b/packages/valory/skills/trader_abci/tests/test_agent_config_resolution.py
@@ -1,0 +1,155 @@
+# -*- coding: utf-8 -*-
+# ------------------------------------------------------------------------------
+#
+#   Copyright 2026 Valory AG
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ------------------------------------------------------------------------------
+
+"""Regression tests for the agent-level ``aea-config.yaml`` env-var wiring.
+
+These guard against the class of bug introduced by renaming anonymous
+``${type:default}`` placeholders to named ``${NAME:type:default}`` ones.
+open-aea only applies the auto-derived component-path env var (e.g.
+``SKILL_..._ARGS_URL``) for *anonymous* placeholders; a *named* placeholder
+resolves solely against a bare env var of that exact name and otherwise
+silently falls back to its default. When the chosen name does not match what
+the runtime actually exports, the agent boots with the wrong (typically
+Omen/gnosis-flavored or ``0x``) default.
+
+The agent-runner path resolves ``aea-config.yaml`` (not ``service.yaml``), so
+these mismatches only surface there. We resolve the real ``aea-config.yaml``
+with open-aea's own resolver against a representative per-chain environment
+and assert the result is internally consistent for both deployment flavors.
+"""
+
+import io
+import json
+from pathlib import Path
+from typing import Any, Dict, List
+from unittest import mock
+
+import pytest
+from aea.helpers.env_vars import apply_env_variables_on_agent_config
+from aea.helpers.yaml_utils import yaml_load_all
+
+from packages.valory.skills.funds_manager.models import Params
+
+# packages/valory/skills/trader_abci/tests/ -> packages/valory/
+_VALORY_DIR = Path(__file__).resolve().parents[3]
+AEA_CONFIG_PATH = _VALORY_DIR / "agents" / "trader" / "aea-config.yaml"
+
+# The path-derived env var the middleware exports for the (anonymous) mechs
+# marketplace subgraph url; open-aea derives this name from the config path.
+MECHS_SUBGRAPH_PATH_KEY = "SKILL_TRADER_ABCI_MODELS_MECHS_SUBGRAPH_ARGS_URL"
+
+SAFE = "0x318bF3775A8DE43ac803cfeDE45F62e256e3a7EC"
+
+# A minimal, valid per-chain fund requirement (chain key is added per test).
+_FUND_REQUIREMENT = {
+    "agent": {
+        "0x0000000000000000000000000000000000000000": {
+            "topup": 100000000000000000,
+            "threshold": 50000000000000000,
+        }
+    },
+    "safe": {
+        "0x0000000000000000000000000000000000000000": {
+            "topup": 5000000000000000000,
+            "threshold": 2500000000000000000,
+        }
+    },
+}
+
+
+def _resolve(env: Dict[str, str]) -> List[Dict[str, Any]]:
+    """Resolve the real aea-config.yaml against ``env`` with open-aea's resolver.
+
+    :param env: the environment variables to apply during resolution.
+    :return: the agent config documents with env vars substituted.
+    """
+    docs = list(yaml_load_all(io.StringIO(AEA_CONFIG_PATH.read_text(encoding="utf-8"))))
+    return apply_env_variables_on_agent_config(docs, env)
+
+
+def _override(docs: List[Dict[str, Any]], component: str) -> Dict[str, Any]:
+    """Return the resolved override doc whose public id contains ``component``.
+
+    :param docs: the resolved agent config documents.
+    :param component: substring to match against each override's public id.
+    :return: the matching resolved override document.
+    :raises AssertionError: if no override matches ``component``.
+    """
+    for doc in docs:
+        if component in str(doc.get("public_id", "")):
+            return doc
+    raise AssertionError(f"override for {component!r} not found in aea-config.yaml")
+
+
+@pytest.mark.parametrize(
+    "chain, rpc_var, rpc_url",
+    [
+        ("polygon", "POLYGON_LEDGER_RPC", "https://polygon.example/rpc"),
+        ("gnosis", "GNOSIS_LEDGER_RPC", "https://gnosis.example/rpc"),
+    ],
+)
+def test_agent_config_resolves_consistently_per_chain(
+    chain: str, rpc_var: str, rpc_url: str
+) -> None:
+    """The resolved agent config is chain-consistent for both flavors.
+
+    Reproduces the failure modes fixed for the polymarket Safe,
+    ``funds_manager.rpc_urls`` and the mechs marketplace subgraph: each must
+    resolve to the active chain rather than a stale gnosis/``0x`` default.
+
+    :param chain: the active deployment chain (e.g. ``polygon``/``gnosis``).
+    :param rpc_var: the bare env var name carrying that chain's ledger RPC.
+    :param rpc_url: the RPC url injected via ``rpc_var`` for the run.
+    """
+    marketplace_url = (
+        f"https://api.subgraph.autonolas.tech/api/proxy/marketplace-{chain}"
+    )
+    env = {
+        "SAFE_CONTRACT_ADDRESSES": json.dumps({chain: SAFE}),
+        rpc_var: rpc_url,
+        MECHS_SUBGRAPH_PATH_KEY: marketplace_url,
+    }
+    docs = _resolve(env)
+
+    # funds_manager: rpc_urls / safe must cover the active chain with real values.
+    fm_args = _override(docs, "funds_manager")["models"]["params"]["args"]
+    assert fm_args["rpc_urls"].get(chain) == rpc_url
+    assert fm_args["safe_contract_addresses"].get(chain) == SAFE
+
+    # The exact invariant that crashed the agent runner: fund_requirements'
+    # chains must be a subset of rpc_urls and safe_contract_addresses. Drive
+    # the real validation (Params.__init__ -> _validate_chain_keys).
+    Params(
+        name="params",
+        skill_context=mock.MagicMock(skill_id="valory/funds_manager:0.1.0"),
+        fund_requirements={chain: _FUND_REQUIREMENT},
+        rpc_urls=fm_args["rpc_urls"],
+        safe_contract_addresses=fm_args["safe_contract_addresses"],
+    )
+
+    # polymarket_client Safe must resolve to the provided address, never "0x".
+    pm_safe = _override(docs, "polymarket_client")["config"]["safe_contract_addresses"]
+    assert pm_safe.get(chain) == SAFE
+
+    # mechs marketplace subgraph must follow the active chain (anonymous
+    # placeholder -> path-key), not the gnosis default baked into the yaml.
+    mechs_url = _override(docs, "trader_abci")["models"]["mechs_subgraph"]["args"][
+        "url"
+    ]
+    assert mechs_url == marketplace_url


### PR DESCRIPTION
Follow-up to #997. Two more agent-runner env-var mismatches from the named-env-vars refactor (#982), same root cause as the polymarket Safe fix, surfaced by the Polystrat middleware QA run.

## Root cause

On the **agent-runner** path open-aea resolves the agent-level `aea-config.yaml` (not `service.yaml`). open-aea's `replace_with_env_var` only applies the auto-derived component-path env var (e.g. `SKILL_..._ARGS_URL`) for **anonymous** `${type:default}` placeholders; giving a placeholder an explicit **name** (`${NAME:type:default}`) disables that path-key fallback, so it resolves *only* against a bare env var of that exact name and otherwise silently uses its default. #982 named several fields whose names don't match what the runtime exports, dropping them to gnosis/`0x` defaults on Polystrat.

## Fixes (`aea-config.yaml`)

- **`funds_manager.rpc_urls`** used `${RPC_URLS:dict:{"gnosis":...}}`, but the middleware exports per-chain `POLYGON_LEDGER_RPC` / `GNOSIS_LEDGER_RPC` scalars — never a bare `RPC_URLS` dict. On Polystrat it fell back to gnosis-only and `_validate_chain_keys` raised:
  ```
  ValueError: rpc_urls is missing chains declared in fund_requirements: ['polygon']
  ```
  Rebuilt from the per-chain scalars (both chains), matching `service.yaml`.
- **mechs marketplace subgraph `url`** was over-named to `${MECHS_SUBGRAPH_URL:...}` (no such bare var exists), pinning it to `marketplace-gnosis` on every chain. Reverted to the anonymous `${str:...}` form so it resolves via the path-key the middleware provides (`marketplace-polygon` on Polystrat), consistent with its already-anonymous block siblings.

## Regression test

`packages/valory/skills/trader_abci/tests/test_agent_config_resolution.py` resolves the real `aea-config.yaml` with open-aea's own resolver against a representative per-chain env and asserts the result is internally consistent for **both** flavors: `funds_manager` validation passes, the polymarket Safe resolves (never `0x`), and the mechs subgraph follows the active chain. It fails on the pre-fix config and guards against future #982-style name mismatches.

## Verification

- New test passes (polygon + gnosis); fails on the pre-fix config (reproduces the exact `agent_runner.log` error).
- Resolved against the actual middleware `agent.json`: `rpc_urls` now `{gnosis, polygon: <provisioned rpc>}`, mechs `marketplace-polygon`, Safe `0x318b…`.
- All 165 `trader_abci` tests collect; `flake8`/`black`/`isort` clean.
- Hashes refreshed via `autonomy packages lock` (idempotent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)