### PR TITLE
Activate edge + spread gate values (forward-test) — companion to #999

### DIFF
--- a/packages/packages.json
+++ b/packages/packages.json
@@ -18,7 +18,7 @@
         "skill/valory/chatui_abci/0.1.0": "bafybeie2kmgihgk3rwpzelaa76ypvchsyg2vy3me4vxlbjttaq4frs3ipa",
         "agent/valory/trader/0.1.0": "bafybeihaauhf7dtd2uo54yyyoyu42nktesdpkwhw3blhjzfjm6qpuzuchu",
         "service/valory/trader_pearl/0.1.0": "bafybeid6kmwirdx7tl6nz3fu3ajz5svcnni5tpfjoq6btbei3wun3xy5ia",
-        "service/valory/polymarket_trader/0.1.0": "bafybeibg2n2z74rvknrgdjfvarovnowfjfzr4xmxhmfoaatkyzuscx4e64"
+        "service/valory/polymarket_trader/0.1.0": "bafybeicpqinymuerbf2cjg3hvcgjmowoly5jg4wyyr6acmat5xcaj5puvq"
     },
     "third_party": {
         "protocol/valory/acn_data_share/0.1.0": "bafybeieqisfr6lhaaesq37lk7vyaxza2h6nucshksgyo2djqfyf2saqo4i",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -18,7 +18,7 @@
         "skill/valory/chatui_abci/0.1.0": "bafybeie2kmgihgk3rwpzelaa76ypvchsyg2vy3me4vxlbjttaq4frs3ipa",
         "agent/valory/trader/0.1.0": "bafybeihaauhf7dtd2uo54yyyoyu42nktesdpkwhw3blhjzfjm6qpuzuchu",
         "service/valory/trader_pearl/0.1.0": "bafybeid6kmwirdx7tl6nz3fu3ajz5svcnni5tpfjoq6btbei3wun3xy5ia",
-        "service/valory/polymarket_trader/0.1.0": "bafybeigeonp7nfxmnhdld4micicz3iwo2klebkf6yz5engerceih7lunma"
+        "service/valory/polymarket_trader/0.1.0": "bafybeihzzssgs3bvenqubk52q3gp7tngt2qpde4mzrm6g2iimqe42gr6h4"
     },
     "third_party": {
         "protocol/valory/acn_data_share/0.1.0": "bafybeieqisfr6lhaaesq37lk7vyaxza2h6nucshksgyo2djqfyf2saqo4i",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -16,9 +16,9 @@
         "skill/valory/agent_performance_summary_abci/0.1.0": "bafybeigmmvpncem6i6t57nwjqzajrbnf6rnqgp43mlo6jf6uziq6lrhlca",
         "skill/valory/check_stop_trading_abci/0.1.0": "bafybeifbiko6p3sqqg2q6qemmcig432s5djcsxm44j35ejittlpyr5f6z4",
         "skill/valory/chatui_abci/0.1.0": "bafybeie2kmgihgk3rwpzelaa76ypvchsyg2vy3me4vxlbjttaq4frs3ipa",
-        "agent/valory/trader/0.1.0": "bafybeihaauhf7dtd2uo54yyyoyu42nktesdpkwhw3blhjzfjm6qpuzuchu",
-        "service/valory/trader_pearl/0.1.0": "bafybeid6kmwirdx7tl6nz3fu3ajz5svcnni5tpfjoq6btbei3wun3xy5ia",
-        "service/valory/polymarket_trader/0.1.0": "bafybeicpqinymuerbf2cjg3hvcgjmowoly5jg4wyyr6acmat5xcaj5puvq"
+        "agent/valory/trader/0.1.0": "bafybeifdcmuilvxj5gf3d7dumlgcab3qwsp2xkmhqfnfxef3zxulpbthxy",
+        "service/valory/trader_pearl/0.1.0": "bafybeigqqgmku426wk2pr2344s4347qmxozppwuexdup3ugwj36aasdq64",
+        "service/valory/polymarket_trader/0.1.0": "bafybeign7qvajyzxojpd2iokvitfil2ygnazpn5w6uyq2u7aex4s5hf5za"
     },
     "third_party": {
         "protocol/valory/acn_data_share/0.1.0": "bafybeieqisfr6lhaaesq37lk7vyaxza2h6nucshksgyo2djqfyf2saqo4i",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -18,7 +18,7 @@
         "skill/valory/chatui_abci/0.1.0": "bafybeie2kmgihgk3rwpzelaa76ypvchsyg2vy3me4vxlbjttaq4frs3ipa",
         "agent/valory/trader/0.1.0": "bafybeihaauhf7dtd2uo54yyyoyu42nktesdpkwhw3blhjzfjm6qpuzuchu",
         "service/valory/trader_pearl/0.1.0": "bafybeid6kmwirdx7tl6nz3fu3ajz5svcnni5tpfjoq6btbei3wun3xy5ia",
-        "service/valory/polymarket_trader/0.1.0": "bafybeihzzssgs3bvenqubk52q3gp7tngt2qpde4mzrm6g2iimqe42gr6h4"
+        "service/valory/polymarket_trader/0.1.0": "bafybeibg2n2z74rvknrgdjfvarovnowfjfzr4xmxhmfoaatkyzuscx4e64"
     },
     "third_party": {
         "protocol/valory/acn_data_share/0.1.0": "bafybeieqisfr6lhaaesq37lk7vyaxza2h6nucshksgyo2djqfyf2saqo4i",

--- a/packages/valory/agents/trader/aea-config.yaml
+++ b/packages/valory/agents/trader/aea-config.yaml
@@ -245,7 +245,7 @@ models:
       refill_check_interval: ${int:10}
       tool_punishment_multiplier: ${int:1}
       contract_timeout: ${float:300.0}
-      file_hash_to_strategies: ${dict:{"bafybeididlcixparvundh76gajplac2ab4ftzcom4cyaeli2ofl5dkdhaa":["kelly_criterion"],"bafybeigp65doxrfukxdndsyflukyf6tjigvobig42334e2gfncczteujvm":["fixed_bet"]}}
+      file_hash_to_strategies: ${dict:{"bafybeidme2uybzyzagky3jtosheqmpgc6b6w4rum7cdxw2fc35nnpwblfe":["kelly_criterion"],"bafybeigp65doxrfukxdndsyflukyf6tjigvobig42334e2gfncczteujvm":["fixed_bet"]}}
       strategies_kwargs: ${STRATEGIES_KWARGS:dict:{"floor_balance":500000000000000000,"default_max_bet_size":2000000000000000000,"absolute_min_bet_size":25000000000000000,"absolute_max_bet_size":2000000000000000000,"n_bets":1,"min_edge":0.03,"min_oracle_prob":0.5,"fee_per_trade":10000000000000000,"grid_points":500}}
       service_endpoint: ${str:https://trader.autonolas.tech/}
       rpc_sleep_time: ${int:10}

--- a/packages/valory/services/polymarket_trader/service.yaml
+++ b/packages/valory/services/polymarket_trader/service.yaml
@@ -8,7 +8,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeichoh5tnk4qctaazcjcrxvpwc5yasodleqoeapnfapwrrdh3tm5gu
 fingerprint_ignore_patterns: []
-agent: valory/trader:0.1.0:bafybeihaauhf7dtd2uo54yyyoyu42nktesdpkwhw3blhjzfjm6qpuzuchu
+agent: valory/trader:0.1.0:bafybeifdcmuilvxj5gf3d7dumlgcab3qwsp2xkmhqfnfxef3zxulpbthxy
 number_of_agents: 1
 deployment:
   agent:
@@ -133,7 +133,7 @@ models:
       redeem_round_timeout: ${REDEEM_ROUND_TIMEOUT:float:3600.0}
       withdrawal_round_timeout: ${WITHDRAWAL_ROUND_TIMEOUT:float:1800.0}
       contract_timeout: ${CONTRACT_TIMEOUT:float:300.0}
-      file_hash_to_strategies: ${FILE_HASH_TO_STRATEGIES:dict:{"bafybeididlcixparvundh76gajplac2ab4ftzcom4cyaeli2ofl5dkdhaa":["kelly_criterion"],"bafybeigp65doxrfukxdndsyflukyf6tjigvobig42334e2gfncczteujvm":["fixed_bet"]}}
+      file_hash_to_strategies: ${FILE_HASH_TO_STRATEGIES:dict:{"bafybeidme2uybzyzagky3jtosheqmpgc6b6w4rum7cdxw2fc35nnpwblfe":["kelly_criterion"],"bafybeigp65doxrfukxdndsyflukyf6tjigvobig42334e2gfncczteujvm":["fixed_bet"]}}
       strategies_kwargs: ${STRATEGIES_KWARGS:dict:{"floor_balance":0,"default_max_bet_size":2500000,"absolute_min_bet_size":1000000,"absolute_max_bet_size":2500000,"n_bets":1,"min_edge":0.01,"max_edge":0.15,"min_oracle_prob":0.1,"fee_per_trade":10000,"grid_points":500}}
       use_subgraph_for_redeeming: ${USE_SUBGRAPH_FOR_REDEEMING:bool:true}
       use_mech_marketplace: ${USE_MECH_MARKETPLACE:bool:true}

--- a/packages/valory/services/polymarket_trader/service.yaml
+++ b/packages/valory/services/polymarket_trader/service.yaml
@@ -93,7 +93,7 @@ models:
       mech_chain_id: ${MECH_CHAIN_ID:str:polygon}
       mech_wrapped_native_token_address: ${MECH_WRAPPED_NATIVE_TOKEN_ADDRESS:str:0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270}
       sample_bets_closing_days: ${SAMPLE_BETS_CLOSING_DAYS:int:10}
-      polymarket_spread_min: ${POLYMARKET_SPREAD_MIN:float:0.02}
+      polymarket_spread_min: ${POLYMARKET_SPREAD_MIN:float:0.0}
       polymarket_spread_max: ${POLYMARKET_SPREAD_MAX:float:0.05}
       trading_strategy: ${TRADING_STRATEGY:str:kelly_criterion}
       use_fallback_strategy: ${USE_FALLBACK_STRATEGY:bool:false}
@@ -134,7 +134,7 @@ models:
       withdrawal_round_timeout: ${WITHDRAWAL_ROUND_TIMEOUT:float:1800.0}
       contract_timeout: ${CONTRACT_TIMEOUT:float:300.0}
       file_hash_to_strategies: ${FILE_HASH_TO_STRATEGIES:dict:{"bafybeididlcixparvundh76gajplac2ab4ftzcom4cyaeli2ofl5dkdhaa":["kelly_criterion"],"bafybeigp65doxrfukxdndsyflukyf6tjigvobig42334e2gfncczteujvm":["fixed_bet"]}}
-      strategies_kwargs: ${STRATEGIES_KWARGS:dict:{"floor_balance":0,"default_max_bet_size":2500000,"absolute_min_bet_size":1000000,"absolute_max_bet_size":2500000,"n_bets":1,"min_edge":0.05,"max_edge":0.1,"min_oracle_prob":0.1,"fee_per_trade":10000,"grid_points":500}}
+      strategies_kwargs: ${STRATEGIES_KWARGS:dict:{"floor_balance":0,"default_max_bet_size":2500000,"absolute_min_bet_size":1000000,"absolute_max_bet_size":2500000,"n_bets":1,"min_edge":0.01,"max_edge":0.1,"min_oracle_prob":0.1,"fee_per_trade":10000,"grid_points":500}}
       use_subgraph_for_redeeming: ${USE_SUBGRAPH_FOR_REDEEMING:bool:true}
       use_mech_marketplace: ${USE_MECH_MARKETPLACE:bool:true}
       mech_marketplace_config: ${MECH_MARKETPLACE_CONFIG:dict:{"mech_marketplace_address":"0x343F2B005cF6D70bA610CD9F1F1927049414B582","priority_mech_address":"0x1DCbC9368327776F8B20Dc041D40b8076C8AC173","priority_mech_staking_instance_address":"0x0000000000000000000000000000000000000000","priority_mech_service_id":25,"requester_staking_instance_address":"0x0000000000000000000000000000000000000000","response_timeout":300}}

--- a/packages/valory/services/polymarket_trader/service.yaml
+++ b/packages/valory/services/polymarket_trader/service.yaml
@@ -93,8 +93,8 @@ models:
       mech_chain_id: ${MECH_CHAIN_ID:str:polygon}
       mech_wrapped_native_token_address: ${MECH_WRAPPED_NATIVE_TOKEN_ADDRESS:str:0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270}
       sample_bets_closing_days: ${SAMPLE_BETS_CLOSING_DAYS:int:10}
-      polymarket_spread_min: ${POLYMARKET_SPREAD_MIN:float:0.0}
-      polymarket_spread_max: ${POLYMARKET_SPREAD_MAX:float:1.0}
+      polymarket_spread_min: ${POLYMARKET_SPREAD_MIN:float:0.02}
+      polymarket_spread_max: ${POLYMARKET_SPREAD_MAX:float:0.05}
       trading_strategy: ${TRADING_STRATEGY:str:kelly_criterion}
       use_fallback_strategy: ${USE_FALLBACK_STRATEGY:bool:false}
       mech_activity_checker_contract: ${MECH_ACTIVITY_CHECKER_CONTRACT:str:0x0000000000000000000000000000000000000000}
@@ -134,7 +134,7 @@ models:
       withdrawal_round_timeout: ${WITHDRAWAL_ROUND_TIMEOUT:float:1800.0}
       contract_timeout: ${CONTRACT_TIMEOUT:float:300.0}
       file_hash_to_strategies: ${FILE_HASH_TO_STRATEGIES:dict:{"bafybeididlcixparvundh76gajplac2ab4ftzcom4cyaeli2ofl5dkdhaa":["kelly_criterion"],"bafybeigp65doxrfukxdndsyflukyf6tjigvobig42334e2gfncczteujvm":["fixed_bet"]}}
-      strategies_kwargs: ${STRATEGIES_KWARGS:dict:{"floor_balance":0,"default_max_bet_size":2500000,"absolute_min_bet_size":1000000,"absolute_max_bet_size":2500000,"n_bets":1,"min_edge":0.01,"min_oracle_prob":0.1,"fee_per_trade":10000,"grid_points":500}}
+      strategies_kwargs: ${STRATEGIES_KWARGS:dict:{"floor_balance":0,"default_max_bet_size":2500000,"absolute_min_bet_size":1000000,"absolute_max_bet_size":2500000,"n_bets":1,"min_edge":0.05,"max_edge":0.1,"min_oracle_prob":0.1,"fee_per_trade":10000,"grid_points":500}}
       use_subgraph_for_redeeming: ${USE_SUBGRAPH_FOR_REDEEMING:bool:true}
       use_mech_marketplace: ${USE_MECH_MARKETPLACE:bool:true}
       mech_marketplace_config: ${MECH_MARKETPLACE_CONFIG:dict:{"mech_marketplace_address":"0x343F2B005cF6D70bA610CD9F1F1927049414B582","priority_mech_address":"0x1DCbC9368327776F8B20Dc041D40b8076C8AC173","priority_mech_staking_instance_address":"0x0000000000000000000000000000000000000000","priority_mech_service_id":25,"requester_staking_instance_address":"0x0000000000000000000000000000000000000000","response_timeout":300}}

--- a/packages/valory/services/polymarket_trader/service.yaml
+++ b/packages/valory/services/polymarket_trader/service.yaml
@@ -94,7 +94,7 @@ models:
       mech_wrapped_native_token_address: ${MECH_WRAPPED_NATIVE_TOKEN_ADDRESS:str:0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270}
       sample_bets_closing_days: ${SAMPLE_BETS_CLOSING_DAYS:int:10}
       polymarket_spread_min: ${POLYMARKET_SPREAD_MIN:float:0.0}
-      polymarket_spread_max: ${POLYMARKET_SPREAD_MAX:float:0.05}
+      polymarket_spread_max: ${POLYMARKET_SPREAD_MAX:float:0.1}
       trading_strategy: ${TRADING_STRATEGY:str:kelly_criterion}
       use_fallback_strategy: ${USE_FALLBACK_STRATEGY:bool:false}
       mech_activity_checker_contract: ${MECH_ACTIVITY_CHECKER_CONTRACT:str:0x0000000000000000000000000000000000000000}
@@ -134,7 +134,7 @@ models:
       withdrawal_round_timeout: ${WITHDRAWAL_ROUND_TIMEOUT:float:1800.0}
       contract_timeout: ${CONTRACT_TIMEOUT:float:300.0}
       file_hash_to_strategies: ${FILE_HASH_TO_STRATEGIES:dict:{"bafybeididlcixparvundh76gajplac2ab4ftzcom4cyaeli2ofl5dkdhaa":["kelly_criterion"],"bafybeigp65doxrfukxdndsyflukyf6tjigvobig42334e2gfncczteujvm":["fixed_bet"]}}
-      strategies_kwargs: ${STRATEGIES_KWARGS:dict:{"floor_balance":0,"default_max_bet_size":2500000,"absolute_min_bet_size":1000000,"absolute_max_bet_size":2500000,"n_bets":1,"min_edge":0.01,"max_edge":0.1,"min_oracle_prob":0.1,"fee_per_trade":10000,"grid_points":500}}
+      strategies_kwargs: ${STRATEGIES_KWARGS:dict:{"floor_balance":0,"default_max_bet_size":2500000,"absolute_min_bet_size":1000000,"absolute_max_bet_size":2500000,"n_bets":1,"min_edge":0.01,"max_edge":0.15,"min_oracle_prob":0.1,"fee_per_trade":10000,"grid_points":500}}
       use_subgraph_for_redeeming: ${USE_SUBGRAPH_FOR_REDEEMING:bool:true}
       use_mech_marketplace: ${USE_MECH_MARKETPLACE:bool:true}
       mech_marketplace_config: ${MECH_MARKETPLACE_CONFIG:dict:{"mech_marketplace_address":"0x343F2B005cF6D70bA610CD9F1F1927049414B582","priority_mech_address":"0x1DCbC9368327776F8B20Dc041D40b8076C8AC173","priority_mech_staking_instance_address":"0x0000000000000000000000000000000000000000","priority_mech_service_id":25,"requester_staking_instance_address":"0x0000000000000000000000000000000000000000","response_timeout":300}}

--- a/packages/valory/services/trader_pearl/service.yaml
+++ b/packages/valory/services/trader_pearl/service.yaml
@@ -8,7 +8,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeibg7bdqpioh4lmvknw3ygnllfku32oca4eq5pqtvdrdsgw6buko7e
 fingerprint_ignore_patterns: []
-agent: valory/trader:0.1.0:bafybeihaauhf7dtd2uo54yyyoyu42nktesdpkwhw3blhjzfjm6qpuzuchu
+agent: valory/trader:0.1.0:bafybeifdcmuilvxj5gf3d7dumlgcab3qwsp2xkmhqfnfxef3zxulpbthxy
 number_of_agents: 1
 deployment:
   agent:
@@ -131,7 +131,7 @@ models:
       redeem_round_timeout: ${REDEEM_ROUND_TIMEOUT:float:3600.0}
       withdrawal_round_timeout: ${WITHDRAWAL_ROUND_TIMEOUT:float:1800.0}
       contract_timeout: ${CONTRACT_TIMEOUT:float:300.0}
-      file_hash_to_strategies: ${FILE_HASH_TO_STRATEGIES:dict:{"bafybeididlcixparvundh76gajplac2ab4ftzcom4cyaeli2ofl5dkdhaa":["kelly_criterion"],"bafybeigp65doxrfukxdndsyflukyf6tjigvobig42334e2gfncczteujvm":["fixed_bet"]}}
+      file_hash_to_strategies: ${FILE_HASH_TO_STRATEGIES:dict:{"bafybeidme2uybzyzagky3jtosheqmpgc6b6w4rum7cdxw2fc35nnpwblfe":["kelly_criterion"],"bafybeigp65doxrfukxdndsyflukyf6tjigvobig42334e2gfncczteujvm":["fixed_bet"]}}
       strategies_kwargs: ${STRATEGIES_KWARGS:dict:{"floor_balance":0,"default_max_bet_size":2000000000000000000,"absolute_min_bet_size":25000000000000000,"absolute_max_bet_size":2000000000000000000,"n_bets":1,"min_edge":0.03,"min_oracle_prob":0.5,"fee_per_trade":10000000000000000,"grid_points":500}}
       use_subgraph_for_redeeming: ${USE_SUBGRAPH_FOR_REDEEMING:bool:true}
       use_mech_marketplace: ${USE_MECH_MARKETPLACE:bool:false}


### PR DESCRIPTION
Ships the Polymarket **edge + spread caps** as committed defaults **and wires them in at runtime** (companion to #999, which added the gate machinery default-OFF). The backing analysis was re-run on the live execution measure (`edge_ask = p_side − best_ask`, 100% coverage) and independently re-verified by 5 agents; the rationale is summarized inline below. **Decision: ship as a monitored production trial** (reversible, KPI-safe) — see Rollout below.

## Changes

### (a) The caps — `polymarket_trader/service.yaml`, pure caps, no floors raised

The analysis is explicit that the `min_edge` / `spread_min` **floors are dead knobs**; the ROI lever is the **upper cap**. So this PR only adds caps:

| param | value | change? |
|---|---|---|
| `strategies_kwargs.min_edge` | 0.01 | **unchanged** (floor stays low — lowering it is a no-op) |
| `strategies_kwargs.max_edge` | **0.15** | added (cap on overconfident high-edge bets) |
| `POLYMARKET_SPREAD_MIN` | 0.0 | **unchanged** |
| `POLYMARKET_SPREAD_MAX` | **0.10** | added (cap — reject the widest/most illiquid books) |

### (b) Runtime activation — repoint the `kelly_criterion` strategy CID (resolves the P1 from review)

The `max_edge` cap is enforced inside `kelly_criterion`, which the agent loads **at runtime by the CID in `file_hash_to_strategies`** — *not* from the repo file. That map still pointed `kelly_criterion` at the **pre-999** CID `bafybeididlci…` (whose strategy ignores `max_edge`), so the new cap was **inert in deployment** — a CLOB bet with edge > 0.15 would still pass. Repointed `kelly_criterion` → the #999 CID `bafybeidme2u…`:

- **`polymarket_trader/service.yaml`** — functional: activates the `max_edge` cap.
- **`trader_pearl/service.yaml`** (Omen) — **consistency only, behaviour unchanged**: Omen is FPMM, `max_edge` is CLOB-only and unset there, and #999 did not touch the FPMM edge path. This just stops Omen deploying the stale pre-999 strategy.
- **`aea-config.yaml`** (agent default) — the merged #999 left this stale too; now aligned.

Re-locked agent + both services; `autonomy packages lock --check` passes. The spread gate itself lives in the agent-package behaviour (`decision_receive.py`, runs from the repo), so it was already live — only the kelly *strategy* needed repointing. Caps remain env-overridable (`STRATEGIES_KWARGS`, `POLYMARKET_SPREAD_MAX`) for instant rollback.

## Why this wasn't caught in #999 or the pre-merge smoke tests

Honest postmortem, because the gap is subtle and worth recording:

**#999.** It added the `max_edge` machinery to `kelly_criterion.py` and re-locked (new CID), but shipped it **default-OFF** (`max_edge=1.0`, inert) and **never repointed `file_hash_to_strategies`**. The strategy runs at runtime from the configured CID, so #999's new code — correct and fully unit-tested — was never wired into any deployment. Because the default was inert there was **zero observable behaviour change**, so nothing (CI, unit tests, reviewers) had a signal to expose the dangling wiring: by design, #999 changed nothing at runtime.

**The local smoke tests** all ran blind to it, for compounding reasons:

1. **Strategy code runs from an IPFS CID, not the repo.** Even `make run-agent` loads whatever CID `file_hash_to_strategies` names (the *old* kelly) — the new code never executed in any run.
2. **The edge-reject test used the wrong knob.** The forced reject used `min_edge=0.99`; `min_edge` is read by **both** the old and new kelly, so it rejected regardless — proving nothing about the new path. `max_edge` (the only discriminating knob) was never exercised with a gating value.
3. **Default `max_edge=1.0` is inert** — a defaults-based smoke run can't engage the cap regardless of which kelly loads.
4. **The Polymarket smoke run never reached the strategy** — it stalled at the unrelated `mech_information` marketplace-enumeration step.
5. **The Omen smoke "confirmation" was false.** It reached a decision, but Omen is FPMM (`max_edge` is CLOB-only), and the `max_edge=1.0` line in the BET-DECISION log is printed by the `decision_receive` **behaviour** (which *does* run from the repo) — not the kelly **strategy** (which runs from IPFS). It looked like confirmation; it wasn't.
6. **100% unit coverage** tests the repo `kelly_criterion.py` by direct import — orthogonal to which CID the runtime loads.

**Root cause / takeaway:** strategy customs are **deployment-decoupled** from the repo — loaded by hash. A strategy-code change isn't live until its CID is (i) published to IPFS *and* (ii) referenced by `file_hash_to_strategies`; and it must be validated against the **runtime** strategy with a value that actually gates, not just unit-tested. This PR adds the repoint; the outstanding validation is the forward-test below.

## Outstanding validation

A live forward-test (run with `max_edge` **below** the live edge and confirm the *strategy* rejects, reading kelly's `info`/rejection lines — not the behaviour's print) is still pending. It needs the new CID published to IPFS (on release) and a Polymarket run that reaches the decision (the `mech_information` enumeration was intermittently empty during testing). The wiring is verified by the lock; runtime gating is unit-tested.

## What the analysis found

1. **Edge holds on the execution measure.** The gate filters `p_oracle − best_ask`; re-deriving on exactly that (`edge_ask = p_side − fill`, 100% coverage) reproduces the band — [0.05,0.10] is the best, only positive-ROI bucket (+0.6%).
2. **The lever is the CAP, not the floor.** Raising `min_edge` does nothing (ROI stays −5.4%). Capping high edge helps because **high-edge bets are overconfident**: the gap between `p_side` and realized win-rate rises monotonically to +0.52 (adverse selection, not a price artifact — independently verified).
3. **Ceiling is break-even, not profit.** Best gate ≈ +0.6% ROI; bootstrap CI **straddles 0**; one of five whole-market folds reverses −9.85pp. The *mechanism* is robust; the *dollar* effect is not statistically established.
4. **Selection caveat.** ~10% of bets carry negative execution edge, placed only under old configs — a forward gate never faces those.

## Volume / supply (on LIVE Polymarket data)

Checked the live candidate universe (Gamma `/events/keyset`, ≤4-day window, + per-market CLOB book — not fleet bets): **675** markets, **294** with a 2-sided book, **median live CLOB spread 0.02**, **~215 pass `spread ≤ 0.10`** (~193 at ≤ 0.05). The **spread gate is not supply-constraining**. The **edge** cap is forecast-dependent (`p_side` per market), so its bet-volume effect is forward-test only. **Staking KPI is unaffected** — edge/spread are *post-mech* gates; the agent still makes every prediction, only bet volume changes.

## Rollout — monitored production trial (not a validated profit claim)

This is **not** a "fixes ROI" change; it caps bets where the forecaster is *provably* overconfident, with an expected loss-reducing-to-break-even effect. Ship it as a live forward-test with a safety net:

- **Baseline**: trailing Polymarket capital-weighted ROI + bets/day before activation (≈ −5.4%).
- **Monitor weekly**: ROI, bets/day, win-rate vs baseline.
- **Rollback**: depends on channel — an *operated* deployment reverts in seconds via env (`POLYMARKET_SPREAD_MAX` / `STRATEGIES_KWARGS`), but a **Pearl release reaches all end-user instances, so its rollback is a follow-up release (days)**. Ship to Pearl knowing the safety net is a release cycle. (Defensive change → bounded downside, so all-users is still acceptable.)
- **Power note**: weeks of bets catch a *regression* (rollback safety); confirming a *positive* effect needs months given the small, noisy edge — so read interim results as "not worse," not "it works."

The durable ROI fix remains **upstream** — calibrate the forecaster so a high `p_side` is actually right.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
