### PR TITLE
test: guard strategy-pointer↔package consistency + repoint stale fixed_bet

### DIFF
--- a/packages/packages.json
+++ b/packages/packages.json
@@ -9,16 +9,16 @@
         "contract/valory/deposit_wallet/0.1.0": "bafybeidjkryojg7cv4hrjvrd2hm5cv5kdoqrmhdsxyjriwtdpo4v3avoia",
         "connection/valory/polymarket_client/0.1.0": "bafybeid4eo37pka4tfhsjs6rb3knrugmokcvihust2dpfrgob56y77xd44",
         "skill/valory/market_manager_abci/0.1.0": "bafybeic67hypwetzltnuy3a6y3o2o332lxyvn34buq57gy4n6bfqpbpxjm",
-        "skill/valory/decision_maker_abci/0.1.0": "bafybeigterfcylnzjzxpja6u56gvcq2grcgvia2qcj34yr2ksogss33wuu",
-        "skill/valory/trader_abci/0.1.0": "bafybeifepfhwcrbinv22hlltrf2cfacqybzsdnm63knw73yc5yfoer3ks4",
-        "skill/valory/tx_settlement_multiplexer_abci/0.1.0": "bafybeiglvalfzo744cvxvslx4vo42r4tcozn7hzsn3aa2q3hkm77t77xwe",
+        "skill/valory/decision_maker_abci/0.1.0": "bafybeibzvacqutn2jas3nodfn55hmqip4hremewu2xttrs2cjzjgqymzcy",
+        "skill/valory/trader_abci/0.1.0": "bafybeiebxjngqlfdmmatym35fahlisksdwkwyzyf5ivpmmqr4c3u3gn4we",
+        "skill/valory/tx_settlement_multiplexer_abci/0.1.0": "bafybeidzf7ldzfqzcpbvbjso23pxaa42dtwyse7snrvmgfyqlpf77wbhee",
         "skill/valory/staking_abci/0.1.0": "bafybeihwyron2bv7ierrgxke7xofwjy7x6wtglg5vopon7i7lfdiivweaq",
         "skill/valory/agent_performance_summary_abci/0.1.0": "bafybeigmmvpncem6i6t57nwjqzajrbnf6rnqgp43mlo6jf6uziq6lrhlca",
         "skill/valory/check_stop_trading_abci/0.1.0": "bafybeifbiko6p3sqqg2q6qemmcig432s5djcsxm44j35ejittlpyr5f6z4",
         "skill/valory/chatui_abci/0.1.0": "bafybeie2kmgihgk3rwpzelaa76ypvchsyg2vy3me4vxlbjttaq4frs3ipa",
-        "agent/valory/trader/0.1.0": "bafybeifdcmuilvxj5gf3d7dumlgcab3qwsp2xkmhqfnfxef3zxulpbthxy",
-        "service/valory/trader_pearl/0.1.0": "bafybeigqqgmku426wk2pr2344s4347qmxozppwuexdup3ugwj36aasdq64",
-        "service/valory/polymarket_trader/0.1.0": "bafybeign7qvajyzxojpd2iokvitfil2ygnazpn5w6uyq2u7aex4s5hf5za"
+        "agent/valory/trader/0.1.0": "bafybeiamyb2jnfpypbqerchzd22qptsefzjjwtkbon7foyjok3idln3eua",
+        "service/valory/trader_pearl/0.1.0": "bafybeiavigextcxrj6locduqmqk355c2xf7zkhuctle44jvelulpj432qi",
+        "service/valory/polymarket_trader/0.1.0": "bafybeicdqlrsszl32xpfi2zao374ktnljqhp5iwznzcjlp4e567rdvyfeq"
     },
     "third_party": {
         "protocol/valory/acn_data_share/0.1.0": "bafybeieqisfr6lhaaesq37lk7vyaxza2h6nucshksgyo2djqfyf2saqo4i",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -9,16 +9,16 @@
         "contract/valory/deposit_wallet/0.1.0": "bafybeidjkryojg7cv4hrjvrd2hm5cv5kdoqrmhdsxyjriwtdpo4v3avoia",
         "connection/valory/polymarket_client/0.1.0": "bafybeid4eo37pka4tfhsjs6rb3knrugmokcvihust2dpfrgob56y77xd44",
         "skill/valory/market_manager_abci/0.1.0": "bafybeic67hypwetzltnuy3a6y3o2o332lxyvn34buq57gy4n6bfqpbpxjm",
-        "skill/valory/decision_maker_abci/0.1.0": "bafybeibzvacqutn2jas3nodfn55hmqip4hremewu2xttrs2cjzjgqymzcy",
-        "skill/valory/trader_abci/0.1.0": "bafybeiebxjngqlfdmmatym35fahlisksdwkwyzyf5ivpmmqr4c3u3gn4we",
-        "skill/valory/tx_settlement_multiplexer_abci/0.1.0": "bafybeidzf7ldzfqzcpbvbjso23pxaa42dtwyse7snrvmgfyqlpf77wbhee",
+        "skill/valory/decision_maker_abci/0.1.0": "bafybeib6b6yvgmcbemgakfysk5w7ttic27xkagoiogm3o4s6tjb2abal44",
+        "skill/valory/trader_abci/0.1.0": "bafybeicqubhbnqpnsmyjls77esitjkuoxv6zdcpatalm323shvc43kkbya",
+        "skill/valory/tx_settlement_multiplexer_abci/0.1.0": "bafybeicb222ntpfwrs333vnbe6thjre7gom4nctbdpnapufxiufu4jkwku",
         "skill/valory/staking_abci/0.1.0": "bafybeihwyron2bv7ierrgxke7xofwjy7x6wtglg5vopon7i7lfdiivweaq",
         "skill/valory/agent_performance_summary_abci/0.1.0": "bafybeigmmvpncem6i6t57nwjqzajrbnf6rnqgp43mlo6jf6uziq6lrhlca",
         "skill/valory/check_stop_trading_abci/0.1.0": "bafybeifbiko6p3sqqg2q6qemmcig432s5djcsxm44j35ejittlpyr5f6z4",
         "skill/valory/chatui_abci/0.1.0": "bafybeie2kmgihgk3rwpzelaa76ypvchsyg2vy3me4vxlbjttaq4frs3ipa",
-        "agent/valory/trader/0.1.0": "bafybeiamyb2jnfpypbqerchzd22qptsefzjjwtkbon7foyjok3idln3eua",
-        "service/valory/trader_pearl/0.1.0": "bafybeiavigextcxrj6locduqmqk355c2xf7zkhuctle44jvelulpj432qi",
-        "service/valory/polymarket_trader/0.1.0": "bafybeicdqlrsszl32xpfi2zao374ktnljqhp5iwznzcjlp4e567rdvyfeq"
+        "agent/valory/trader/0.1.0": "bafybeibpeyfj72t7jiu4cmrtjd25dlpnyq4dok4it7dfbj36slelse3aku",
+        "service/valory/trader_pearl/0.1.0": "bafybeicthfvy7jque7tiqcmb7mbek2qxx5wjuhp3jxop4nxaxronjblnom",
+        "service/valory/polymarket_trader/0.1.0": "bafybeigpguclfpuoulvpeh7rfk5biq7f2glifjna44xwkeddosurjreyoe"
     },
     "third_party": {
         "protocol/valory/acn_data_share/0.1.0": "bafybeieqisfr6lhaaesq37lk7vyaxza2h6nucshksgyo2djqfyf2saqo4i",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -9,16 +9,16 @@
         "contract/valory/deposit_wallet/0.1.0": "bafybeidjkryojg7cv4hrjvrd2hm5cv5kdoqrmhdsxyjriwtdpo4v3avoia",
         "connection/valory/polymarket_client/0.1.0": "bafybeid4eo37pka4tfhsjs6rb3knrugmokcvihust2dpfrgob56y77xd44",
         "skill/valory/market_manager_abci/0.1.0": "bafybeic67hypwetzltnuy3a6y3o2o332lxyvn34buq57gy4n6bfqpbpxjm",
-        "skill/valory/decision_maker_abci/0.1.0": "bafybeib6b6yvgmcbemgakfysk5w7ttic27xkagoiogm3o4s6tjb2abal44",
-        "skill/valory/trader_abci/0.1.0": "bafybeicqubhbnqpnsmyjls77esitjkuoxv6zdcpatalm323shvc43kkbya",
-        "skill/valory/tx_settlement_multiplexer_abci/0.1.0": "bafybeicb222ntpfwrs333vnbe6thjre7gom4nctbdpnapufxiufu4jkwku",
+        "skill/valory/decision_maker_abci/0.1.0": "bafybeiaiy3kutwvr7yon4r6ta32tix4yu4ap4hh7ucu22zlbxrizsrsf3u",
+        "skill/valory/trader_abci/0.1.0": "bafybeia7jry22c66b4jbbns6mwyp7pbbozihxoy6xfcyes4v6kdqryw7tu",
+        "skill/valory/tx_settlement_multiplexer_abci/0.1.0": "bafybeiell7knjekoqtpka5fn33qwjaiceznpz7pvu6neuy2xvpqjmnhjni",
         "skill/valory/staking_abci/0.1.0": "bafybeihwyron2bv7ierrgxke7xofwjy7x6wtglg5vopon7i7lfdiivweaq",
         "skill/valory/agent_performance_summary_abci/0.1.0": "bafybeigmmvpncem6i6t57nwjqzajrbnf6rnqgp43mlo6jf6uziq6lrhlca",
         "skill/valory/check_stop_trading_abci/0.1.0": "bafybeifbiko6p3sqqg2q6qemmcig432s5djcsxm44j35ejittlpyr5f6z4",
         "skill/valory/chatui_abci/0.1.0": "bafybeie2kmgihgk3rwpzelaa76ypvchsyg2vy3me4vxlbjttaq4frs3ipa",
-        "agent/valory/trader/0.1.0": "bafybeibpeyfj72t7jiu4cmrtjd25dlpnyq4dok4it7dfbj36slelse3aku",
-        "service/valory/trader_pearl/0.1.0": "bafybeicthfvy7jque7tiqcmb7mbek2qxx5wjuhp3jxop4nxaxronjblnom",
-        "service/valory/polymarket_trader/0.1.0": "bafybeigpguclfpuoulvpeh7rfk5biq7f2glifjna44xwkeddosurjreyoe"
+        "agent/valory/trader/0.1.0": "bafybeif4no4jmjcfxjhkkaddrlhykv7myq2722ts37czimpggthxi5uwvu",
+        "service/valory/trader_pearl/0.1.0": "bafybeidjlclez7efqjl7a4hbx7a7dofmudgwvs5u4df3bjdrhuxyvb7vra",
+        "service/valory/polymarket_trader/0.1.0": "bafybeidqc5k3irb7vwhnftz5emazqvr5dqmnqqmiggd4usrhlsnpvhbczi"
     },
     "third_party": {
         "protocol/valory/acn_data_share/0.1.0": "bafybeieqisfr6lhaaesq37lk7vyaxza2h6nucshksgyo2djqfyf2saqo4i",

--- a/packages/valory/agents/trader/aea-config.yaml
+++ b/packages/valory/agents/trader/aea-config.yaml
@@ -66,10 +66,10 @@ skills:
 - valory/reset_pause_abci:0.1.0:bafybeihc4ruh25s7wuunfy2b3k2n4eypyhvtry3usgom44wsymagbcr3ki
 - valory/termination_abci:0.1.0:bafybeibnnzry5kknci3z46gcjgutv4jid3ir6xn6a5adq3tx6v2e25augq
 - valory/transaction_settlement_abci:0.1.0:bafybeibv3tycpdhphlblu62zpcbjsj7hnwkutexxqagorkelhjlt4t4fii
-- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeiglvalfzo744cvxvslx4vo42r4tcozn7hzsn3aa2q3hkm77t77xwe
+- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeidzf7ldzfqzcpbvbjso23pxaa42dtwyse7snrvmgfyqlpf77wbhee
 - valory/market_manager_abci:0.1.0:bafybeic67hypwetzltnuy3a6y3o2o332lxyvn34buq57gy4n6bfqpbpxjm
-- valory/decision_maker_abci:0.1.0:bafybeigterfcylnzjzxpja6u56gvcq2grcgvia2qcj34yr2ksogss33wuu
-- valory/trader_abci:0.1.0:bafybeifepfhwcrbinv22hlltrf2cfacqybzsdnm63knw73yc5yfoer3ks4
+- valory/decision_maker_abci:0.1.0:bafybeibzvacqutn2jas3nodfn55hmqip4hremewu2xttrs2cjzjgqymzcy
+- valory/trader_abci:0.1.0:bafybeiebxjngqlfdmmatym35fahlisksdwkwyzyf5ivpmmqr4c3u3gn4we
 - valory/staking_abci:0.1.0:bafybeihwyron2bv7ierrgxke7xofwjy7x6wtglg5vopon7i7lfdiivweaq
 - valory/check_stop_trading_abci:0.1.0:bafybeifbiko6p3sqqg2q6qemmcig432s5djcsxm44j35ejittlpyr5f6z4
 - valory/mech_interact_abci:0.1.0:bafybeidnmszufszq3ro4ebgrqzmhqgctrsc6sykeanfsbvotghvt2cgfsy
@@ -245,7 +245,7 @@ models:
       refill_check_interval: ${int:10}
       tool_punishment_multiplier: ${int:1}
       contract_timeout: ${float:300.0}
-      file_hash_to_strategies: ${dict:{"bafybeidme2uybzyzagky3jtosheqmpgc6b6w4rum7cdxw2fc35nnpwblfe":["kelly_criterion"],"bafybeigp65doxrfukxdndsyflukyf6tjigvobig42334e2gfncczteujvm":["fixed_bet"]}}
+      file_hash_to_strategies: ${dict:{"bafybeidme2uybzyzagky3jtosheqmpgc6b6w4rum7cdxw2fc35nnpwblfe":["kelly_criterion"],"bafybeidahih5c7htr5g5e4nq5wcqfiwse2z6ga27jxsxll7iracehmysim":["fixed_bet"]}}
       strategies_kwargs: ${STRATEGIES_KWARGS:dict:{"floor_balance":500000000000000000,"default_max_bet_size":2000000000000000000,"absolute_min_bet_size":25000000000000000,"absolute_max_bet_size":2000000000000000000,"n_bets":1,"min_edge":0.03,"min_oracle_prob":0.5,"fee_per_trade":10000000000000000,"grid_points":500}}
       service_endpoint: ${str:https://trader.autonolas.tech/}
       rpc_sleep_time: ${int:10}

--- a/packages/valory/agents/trader/aea-config.yaml
+++ b/packages/valory/agents/trader/aea-config.yaml
@@ -66,10 +66,10 @@ skills:
 - valory/reset_pause_abci:0.1.0:bafybeihc4ruh25s7wuunfy2b3k2n4eypyhvtry3usgom44wsymagbcr3ki
 - valory/termination_abci:0.1.0:bafybeibnnzry5kknci3z46gcjgutv4jid3ir6xn6a5adq3tx6v2e25augq
 - valory/transaction_settlement_abci:0.1.0:bafybeibv3tycpdhphlblu62zpcbjsj7hnwkutexxqagorkelhjlt4t4fii
-- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeidzf7ldzfqzcpbvbjso23pxaa42dtwyse7snrvmgfyqlpf77wbhee
+- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeicb222ntpfwrs333vnbe6thjre7gom4nctbdpnapufxiufu4jkwku
 - valory/market_manager_abci:0.1.0:bafybeic67hypwetzltnuy3a6y3o2o332lxyvn34buq57gy4n6bfqpbpxjm
-- valory/decision_maker_abci:0.1.0:bafybeibzvacqutn2jas3nodfn55hmqip4hremewu2xttrs2cjzjgqymzcy
-- valory/trader_abci:0.1.0:bafybeiebxjngqlfdmmatym35fahlisksdwkwyzyf5ivpmmqr4c3u3gn4we
+- valory/decision_maker_abci:0.1.0:bafybeib6b6yvgmcbemgakfysk5w7ttic27xkagoiogm3o4s6tjb2abal44
+- valory/trader_abci:0.1.0:bafybeicqubhbnqpnsmyjls77esitjkuoxv6zdcpatalm323shvc43kkbya
 - valory/staking_abci:0.1.0:bafybeihwyron2bv7ierrgxke7xofwjy7x6wtglg5vopon7i7lfdiivweaq
 - valory/check_stop_trading_abci:0.1.0:bafybeifbiko6p3sqqg2q6qemmcig432s5djcsxm44j35ejittlpyr5f6z4
 - valory/mech_interact_abci:0.1.0:bafybeidnmszufszq3ro4ebgrqzmhqgctrsc6sykeanfsbvotghvt2cgfsy

--- a/packages/valory/agents/trader/aea-config.yaml
+++ b/packages/valory/agents/trader/aea-config.yaml
@@ -66,10 +66,10 @@ skills:
 - valory/reset_pause_abci:0.1.0:bafybeihc4ruh25s7wuunfy2b3k2n4eypyhvtry3usgom44wsymagbcr3ki
 - valory/termination_abci:0.1.0:bafybeibnnzry5kknci3z46gcjgutv4jid3ir6xn6a5adq3tx6v2e25augq
 - valory/transaction_settlement_abci:0.1.0:bafybeibv3tycpdhphlblu62zpcbjsj7hnwkutexxqagorkelhjlt4t4fii
-- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeicb222ntpfwrs333vnbe6thjre7gom4nctbdpnapufxiufu4jkwku
+- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeiell7knjekoqtpka5fn33qwjaiceznpz7pvu6neuy2xvpqjmnhjni
 - valory/market_manager_abci:0.1.0:bafybeic67hypwetzltnuy3a6y3o2o332lxyvn34buq57gy4n6bfqpbpxjm
-- valory/decision_maker_abci:0.1.0:bafybeib6b6yvgmcbemgakfysk5w7ttic27xkagoiogm3o4s6tjb2abal44
-- valory/trader_abci:0.1.0:bafybeicqubhbnqpnsmyjls77esitjkuoxv6zdcpatalm323shvc43kkbya
+- valory/decision_maker_abci:0.1.0:bafybeiaiy3kutwvr7yon4r6ta32tix4yu4ap4hh7ucu22zlbxrizsrsf3u
+- valory/trader_abci:0.1.0:bafybeia7jry22c66b4jbbns6mwyp7pbbozihxoy6xfcyes4v6kdqryw7tu
 - valory/staking_abci:0.1.0:bafybeihwyron2bv7ierrgxke7xofwjy7x6wtglg5vopon7i7lfdiivweaq
 - valory/check_stop_trading_abci:0.1.0:bafybeifbiko6p3sqqg2q6qemmcig432s5djcsxm44j35ejittlpyr5f6z4
 - valory/mech_interact_abci:0.1.0:bafybeidnmszufszq3ro4ebgrqzmhqgctrsc6sykeanfsbvotghvt2cgfsy

--- a/packages/valory/services/polymarket_trader/service.yaml
+++ b/packages/valory/services/polymarket_trader/service.yaml
@@ -8,7 +8,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeichoh5tnk4qctaazcjcrxvpwc5yasodleqoeapnfapwrrdh3tm5gu
 fingerprint_ignore_patterns: []
-agent: valory/trader:0.1.0:bafybeiamyb2jnfpypbqerchzd22qptsefzjjwtkbon7foyjok3idln3eua
+agent: valory/trader:0.1.0:bafybeibpeyfj72t7jiu4cmrtjd25dlpnyq4dok4it7dfbj36slelse3aku
 number_of_agents: 1
 deployment:
   agent:

--- a/packages/valory/services/polymarket_trader/service.yaml
+++ b/packages/valory/services/polymarket_trader/service.yaml
@@ -8,7 +8,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeichoh5tnk4qctaazcjcrxvpwc5yasodleqoeapnfapwrrdh3tm5gu
 fingerprint_ignore_patterns: []
-agent: valory/trader:0.1.0:bafybeibpeyfj72t7jiu4cmrtjd25dlpnyq4dok4it7dfbj36slelse3aku
+agent: valory/trader:0.1.0:bafybeif4no4jmjcfxjhkkaddrlhykv7myq2722ts37czimpggthxi5uwvu
 number_of_agents: 1
 deployment:
   agent:

--- a/packages/valory/services/polymarket_trader/service.yaml
+++ b/packages/valory/services/polymarket_trader/service.yaml
@@ -8,7 +8,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeichoh5tnk4qctaazcjcrxvpwc5yasodleqoeapnfapwrrdh3tm5gu
 fingerprint_ignore_patterns: []
-agent: valory/trader:0.1.0:bafybeifdcmuilvxj5gf3d7dumlgcab3qwsp2xkmhqfnfxef3zxulpbthxy
+agent: valory/trader:0.1.0:bafybeiamyb2jnfpypbqerchzd22qptsefzjjwtkbon7foyjok3idln3eua
 number_of_agents: 1
 deployment:
   agent:
@@ -133,7 +133,7 @@ models:
       redeem_round_timeout: ${REDEEM_ROUND_TIMEOUT:float:3600.0}
       withdrawal_round_timeout: ${WITHDRAWAL_ROUND_TIMEOUT:float:1800.0}
       contract_timeout: ${CONTRACT_TIMEOUT:float:300.0}
-      file_hash_to_strategies: ${FILE_HASH_TO_STRATEGIES:dict:{"bafybeidme2uybzyzagky3jtosheqmpgc6b6w4rum7cdxw2fc35nnpwblfe":["kelly_criterion"],"bafybeigp65doxrfukxdndsyflukyf6tjigvobig42334e2gfncczteujvm":["fixed_bet"]}}
+      file_hash_to_strategies: ${FILE_HASH_TO_STRATEGIES:dict:{"bafybeidme2uybzyzagky3jtosheqmpgc6b6w4rum7cdxw2fc35nnpwblfe":["kelly_criterion"],"bafybeidahih5c7htr5g5e4nq5wcqfiwse2z6ga27jxsxll7iracehmysim":["fixed_bet"]}}
       strategies_kwargs: ${STRATEGIES_KWARGS:dict:{"floor_balance":0,"default_max_bet_size":2500000,"absolute_min_bet_size":1000000,"absolute_max_bet_size":2500000,"n_bets":1,"min_edge":0.01,"max_edge":0.15,"min_oracle_prob":0.1,"fee_per_trade":10000,"grid_points":500}}
       use_subgraph_for_redeeming: ${USE_SUBGRAPH_FOR_REDEEMING:bool:true}
       use_mech_marketplace: ${USE_MECH_MARKETPLACE:bool:true}

--- a/packages/valory/services/trader_pearl/service.yaml
+++ b/packages/valory/services/trader_pearl/service.yaml
@@ -8,7 +8,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeibg7bdqpioh4lmvknw3ygnllfku32oca4eq5pqtvdrdsgw6buko7e
 fingerprint_ignore_patterns: []
-agent: valory/trader:0.1.0:bafybeibpeyfj72t7jiu4cmrtjd25dlpnyq4dok4it7dfbj36slelse3aku
+agent: valory/trader:0.1.0:bafybeif4no4jmjcfxjhkkaddrlhykv7myq2722ts37czimpggthxi5uwvu
 number_of_agents: 1
 deployment:
   agent:

--- a/packages/valory/services/trader_pearl/service.yaml
+++ b/packages/valory/services/trader_pearl/service.yaml
@@ -8,7 +8,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeibg7bdqpioh4lmvknw3ygnllfku32oca4eq5pqtvdrdsgw6buko7e
 fingerprint_ignore_patterns: []
-agent: valory/trader:0.1.0:bafybeiamyb2jnfpypbqerchzd22qptsefzjjwtkbon7foyjok3idln3eua
+agent: valory/trader:0.1.0:bafybeibpeyfj72t7jiu4cmrtjd25dlpnyq4dok4it7dfbj36slelse3aku
 number_of_agents: 1
 deployment:
   agent:

--- a/packages/valory/services/trader_pearl/service.yaml
+++ b/packages/valory/services/trader_pearl/service.yaml
@@ -8,7 +8,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeibg7bdqpioh4lmvknw3ygnllfku32oca4eq5pqtvdrdsgw6buko7e
 fingerprint_ignore_patterns: []
-agent: valory/trader:0.1.0:bafybeifdcmuilvxj5gf3d7dumlgcab3qwsp2xkmhqfnfxef3zxulpbthxy
+agent: valory/trader:0.1.0:bafybeiamyb2jnfpypbqerchzd22qptsefzjjwtkbon7foyjok3idln3eua
 number_of_agents: 1
 deployment:
   agent:
@@ -131,7 +131,7 @@ models:
       redeem_round_timeout: ${REDEEM_ROUND_TIMEOUT:float:3600.0}
       withdrawal_round_timeout: ${WITHDRAWAL_ROUND_TIMEOUT:float:1800.0}
       contract_timeout: ${CONTRACT_TIMEOUT:float:300.0}
-      file_hash_to_strategies: ${FILE_HASH_TO_STRATEGIES:dict:{"bafybeidme2uybzyzagky3jtosheqmpgc6b6w4rum7cdxw2fc35nnpwblfe":["kelly_criterion"],"bafybeigp65doxrfukxdndsyflukyf6tjigvobig42334e2gfncczteujvm":["fixed_bet"]}}
+      file_hash_to_strategies: ${FILE_HASH_TO_STRATEGIES:dict:{"bafybeidme2uybzyzagky3jtosheqmpgc6b6w4rum7cdxw2fc35nnpwblfe":["kelly_criterion"],"bafybeidahih5c7htr5g5e4nq5wcqfiwse2z6ga27jxsxll7iracehmysim":["fixed_bet"]}}
       strategies_kwargs: ${STRATEGIES_KWARGS:dict:{"floor_balance":0,"default_max_bet_size":2000000000000000000,"absolute_min_bet_size":25000000000000000,"absolute_max_bet_size":2000000000000000000,"n_bets":1,"min_edge":0.03,"min_oracle_prob":0.5,"fee_per_trade":10000000000000000,"grid_points":500}}
       use_subgraph_for_redeeming: ${USE_SUBGRAPH_FOR_REDEEMING:bool:true}
       use_mech_marketplace: ${USE_MECH_MARKETPLACE:bool:false}

--- a/packages/valory/skills/decision_maker_abci/skill.yaml
+++ b/packages/valory/skills/decision_maker_abci/skill.yaml
@@ -144,6 +144,7 @@ fingerprint:
   tests/test_polymarket_states.py: bafybeicgu5zbgw67sdnw4bdbmxvm5hjin46a4outwh75zkhgn2psskpjii
   tests/test_redeem_info.py: bafybeihy4raxbco4sj4z4eu6bb3e255n2m5vsfkckvwlft353rhdhlf2ii
   tests/test_rounds.py: bafybeidstlz37mfr6wxe6n6jwox64bbeh2wfqq5ztbcshdsyclrfiz44s4
+  tests/test_strategy_pointer_consistency.py: bafybeihxyvim7pxvkujhlpoycak77vpejbavt2cr2ovnbhfjeul3hfz5hu
   tests/test_withdrawal_rounds.py: bafybeif5kcaihrxnmiiywnx7txtlwv7c35pvli4zmp2ps3mufwpoeqb2uq
   tests/utils/__init__.py: bafybeifksn3c47zjmxyxcppflnmy3oezqa6ikjqejgfj6uewclbrca7ety
   tests/utils/test_general.py: bafybeihlviccbs5276hft722hmoejz4sg7sct2sexn7tfjwvpxnnypun3i

--- a/packages/valory/skills/decision_maker_abci/skill.yaml
+++ b/packages/valory/skills/decision_maker_abci/skill.yaml
@@ -144,7 +144,7 @@ fingerprint:
   tests/test_polymarket_states.py: bafybeicgu5zbgw67sdnw4bdbmxvm5hjin46a4outwh75zkhgn2psskpjii
   tests/test_redeem_info.py: bafybeihy4raxbco4sj4z4eu6bb3e255n2m5vsfkckvwlft353rhdhlf2ii
   tests/test_rounds.py: bafybeidstlz37mfr6wxe6n6jwox64bbeh2wfqq5ztbcshdsyclrfiz44s4
-  tests/test_strategy_pointer_consistency.py: bafybeihxyvim7pxvkujhlpoycak77vpejbavt2cr2ovnbhfjeul3hfz5hu
+  tests/test_strategy_pointer_consistency.py: bafybeiaxovly23d3okzrgqc3zgj5edgw3brwg5vwjnh25ixuky5tp3f5ta
   tests/test_withdrawal_rounds.py: bafybeif5kcaihrxnmiiywnx7txtlwv7c35pvli4zmp2ps3mufwpoeqb2uq
   tests/utils/__init__.py: bafybeifksn3c47zjmxyxcppflnmy3oezqa6ikjqejgfj6uewclbrca7ety
   tests/utils/test_general.py: bafybeihlviccbs5276hft722hmoejz4sg7sct2sexn7tfjwvpxnnypun3i

--- a/packages/valory/skills/decision_maker_abci/skill.yaml
+++ b/packages/valory/skills/decision_maker_abci/skill.yaml
@@ -144,7 +144,7 @@ fingerprint:
   tests/test_polymarket_states.py: bafybeicgu5zbgw67sdnw4bdbmxvm5hjin46a4outwh75zkhgn2psskpjii
   tests/test_redeem_info.py: bafybeihy4raxbco4sj4z4eu6bb3e255n2m5vsfkckvwlft353rhdhlf2ii
   tests/test_rounds.py: bafybeidstlz37mfr6wxe6n6jwox64bbeh2wfqq5ztbcshdsyclrfiz44s4
-  tests/test_strategy_pointer_consistency.py: bafybeiaxovly23d3okzrgqc3zgj5edgw3brwg5vwjnh25ixuky5tp3f5ta
+  tests/test_strategy_pointer_consistency.py: bafybeibeotb6wxwkn66tv4vadwgg5jqdx26m24hqrbs5is4ueyh7r6z5u4
   tests/test_withdrawal_rounds.py: bafybeif5kcaihrxnmiiywnx7txtlwv7c35pvli4zmp2ps3mufwpoeqb2uq
   tests/utils/__init__.py: bafybeifksn3c47zjmxyxcppflnmy3oezqa6ikjqejgfj6uewclbrca7ety
   tests/utils/test_general.py: bafybeihlviccbs5276hft722hmoejz4sg7sct2sexn7tfjwvpxnnypun3i

--- a/packages/valory/skills/decision_maker_abci/tests/test_strategy_pointer_consistency.py
+++ b/packages/valory/skills/decision_maker_abci/tests/test_strategy_pointer_consistency.py
@@ -22,12 +22,14 @@
 The agent downloads its betting strategy at runtime from the CID in the
 ``file_hash_to_strategies`` param, NOT from the packaged ``customs`` code.
 ``autonomy packages lock`` bumps the package CID but never that pointer, so a
-strategy change that forgets to repoint it silently ships the OLD strategy
-(see .claude/reports/strategy-pointer-drift.md for real incidents). This test
-fails when any ``file_hash_to_strategies`` entry disagrees with the
-``packages.json`` CID for that strategy.
+strategy change that forgets to repoint it silently ships the OLD strategy —
+this actually happened: the kelly pointer sat frozen for ~2 months across
+several releases while the packaged code moved on twice. This test fails when
+any ``file_hash_to_strategies`` entry disagrees with the ``packages.json`` CID
+for that strategy.
 """
 
+import functools
 import json
 import re
 from pathlib import Path
@@ -47,20 +49,22 @@ def _repo_root() -> Path:
 ROOT = _repo_root()
 
 # Every config that pins the runtime strategy pointer.
-POINTER_FILES = [
-    p
-    for p in (
-        ROOT / "packages/valory/services/polymarket_trader/service.yaml",
-        ROOT / "packages/valory/services/trader_pearl/service.yaml",
-        ROOT / "packages/valory/agents/trader/aea-config.yaml",
-    )
-    if p.is_file()
-]
+POINTER_FILES = (
+    ROOT / "packages/valory/services/polymarket_trader/service.yaml",
+    ROOT / "packages/valory/services/trader_pearl/service.yaml",
+    ROOT / "packages/valory/agents/trader/aea-config.yaml",
+)
 
 _POINTER_RE = re.compile(r"file_hash_to_strategies:\s*\$\{[^{]*(\{.*\})\}")
 _ENTRY_RE = re.compile(r'"(bafybei[a-z0-9]+)":\s*\[\s*"([a-z_]+)"\s*\]')
 
 
+def _config_id(path: Path) -> str:
+    """Return a disambiguating label, e.g. ``polymarket_trader/service.yaml``."""
+    return f"{path.parent.name}/{path.name}"
+
+
+@functools.lru_cache()
 def _package_cids() -> Dict[str, str]:
     """Return ``{strategy_name: package_cid}`` for every ``custom`` in packages.json."""
     data = json.loads((ROOT / "packages" / "packages.json").read_text())
@@ -77,6 +81,8 @@ def _package_cids() -> Dict[str, str]:
 
 def _pointer_entries(path: Path) -> List[Tuple[str, str]]:
     """Return ``(strategy_name, runtime_cid)`` pairs from a config's pointer."""
+    if not path.is_file():
+        return []
     match = _POINTER_RE.search(path.read_text())
     if match is None:
         return []
@@ -84,16 +90,26 @@ def _pointer_entries(path: Path) -> List[Tuple[str, str]]:
 
 
 _CASES = [
-    (path.name, name, cid)
+    (_config_id(path), name, cid)
     for path in POINTER_FILES
     for name, cid in _pointer_entries(path)
 ]
 
 
-def test_pointer_cases_discovered() -> None:
-    """Guard against a silently-broken parser reporting zero cases to check."""
-    assert POINTER_FILES, "No pointer config files found — paths broke."
-    assert _CASES, "No file_hash_to_strategies entries parsed — parser broke."
+def test_all_pointer_files_present() -> None:
+    """Every expected pointer config must exist (a rename must not silently drop coverage)."""
+    missing = [_config_id(p) for p in POINTER_FILES if not p.is_file()]
+    assert not missing, f"Expected strategy-pointer config(s) missing: {missing}"
+
+
+@pytest.mark.parametrize("path", POINTER_FILES, ids=_config_id)
+def test_each_pointer_file_has_entries(path: Path) -> None:
+    """Each pointer config must parse to at least one strategy entry."""
+    assert _pointer_entries(path), (
+        f"{_config_id(path)}: no file_hash_to_strategies entries parsed. A missing "
+        f"file or a format change would otherwise silently drop this config from the "
+        f"consistency check while the others keep the suite green."
+    )
 
 
 @pytest.mark.parametrize("config, strategy, runtime_cid", _CASES)

--- a/packages/valory/skills/decision_maker_abci/tests/test_strategy_pointer_consistency.py
+++ b/packages/valory/skills/decision_maker_abci/tests/test_strategy_pointer_consistency.py
@@ -1,0 +1,114 @@
+# -*- coding: utf-8 -*-
+# ------------------------------------------------------------------------------
+#
+#   Copyright 2026 Valory AG
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ------------------------------------------------------------------------------
+
+"""The runtime strategy pointer must match the packaged strategy code.
+
+The agent downloads its betting strategy at runtime from the CID in the
+``file_hash_to_strategies`` param, NOT from the packaged ``customs`` code.
+``autonomy packages lock`` bumps the package CID but never that pointer, so a
+strategy change that forgets to repoint it silently ships the OLD strategy
+(see .claude/reports/strategy-pointer-drift.md for real incidents). This test
+fails when any ``file_hash_to_strategies`` entry disagrees with the
+``packages.json`` CID for that strategy.
+"""
+
+import json
+import re
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+import pytest
+
+
+def _repo_root() -> Path:
+    """Return the repo root, i.e. the directory holding ``packages/packages.json``."""
+    for parent in Path(__file__).resolve().parents:
+        if (parent / "packages" / "packages.json").is_file():
+            return parent
+    raise RuntimeError("Could not locate packages/packages.json above this test.")
+
+
+ROOT = _repo_root()
+
+# Every config that pins the runtime strategy pointer.
+POINTER_FILES = [
+    p
+    for p in (
+        ROOT / "packages/valory/services/polymarket_trader/service.yaml",
+        ROOT / "packages/valory/services/trader_pearl/service.yaml",
+        ROOT / "packages/valory/agents/trader/aea-config.yaml",
+    )
+    if p.is_file()
+]
+
+_POINTER_RE = re.compile(r"file_hash_to_strategies:\s*\$\{[^{]*(\{.*\})\}")
+_ENTRY_RE = re.compile(r'"(bafybei[a-z0-9]+)":\s*\[\s*"([a-z_]+)"\s*\]')
+
+
+def _package_cids() -> Dict[str, str]:
+    """Return ``{strategy_name: package_cid}`` for every ``custom`` in packages.json."""
+    data = json.loads((ROOT / "packages" / "packages.json").read_text())
+    out: Dict[str, str] = {}
+    for section in data.values():
+        if not isinstance(section, dict):
+            continue
+        for key, cid in section.items():
+            match = re.match(r"custom/valory/([a-z_]+)/", key)
+            if match:
+                out[match.group(1)] = cid
+    return out
+
+
+def _pointer_entries(path: Path) -> List[Tuple[str, str]]:
+    """Return ``(strategy_name, runtime_cid)`` pairs from a config's pointer."""
+    match = _POINTER_RE.search(path.read_text())
+    if match is None:
+        return []
+    return [(name, cid) for cid, name in _ENTRY_RE.findall(match.group(1))]
+
+
+_CASES = [
+    (path.name, name, cid)
+    for path in POINTER_FILES
+    for name, cid in _pointer_entries(path)
+]
+
+
+def test_pointer_cases_discovered() -> None:
+    """Guard against a silently-broken parser reporting zero cases to check."""
+    assert POINTER_FILES, "No pointer config files found — paths broke."
+    assert _CASES, "No file_hash_to_strategies entries parsed — parser broke."
+
+
+@pytest.mark.parametrize("config, strategy, runtime_cid", _CASES)
+def test_runtime_pointer_matches_packaged_strategy(
+    config: str, strategy: str, runtime_cid: str
+) -> None:
+    """Each file_hash_to_strategies CID must equal the packages.json CID."""
+    packaged = _package_cids().get(strategy)
+    assert packaged is not None, (
+        f"{config}: file_hash_to_strategies references '{strategy}', which is "
+        f"not a custom/valory/* package in packages.json."
+    )
+    assert runtime_cid == packaged, (
+        f"{config}: runtime strategy '{strategy}' is STALE — "
+        f"file_hash_to_strategies -> {runtime_cid} but packages.json -> "
+        f"{packaged}. Repoint file_hash_to_strategies to the packaged CID and "
+        f"re-lock, or the deployed agent will keep running an old strategy."
+    )

--- a/packages/valory/skills/decision_maker_abci/tests/test_strategy_pointer_consistency.py
+++ b/packages/valory/skills/decision_maker_abci/tests/test_strategy_pointer_consistency.py
@@ -33,9 +33,10 @@ import functools
 import json
 import re
 from pathlib import Path
-from typing import Dict, List, Tuple
+from typing import Any, Dict, List, Tuple
 
 import pytest
+import yaml
 
 
 def _repo_root() -> Path:
@@ -55,8 +56,12 @@ POINTER_FILES = (
     ROOT / "packages/valory/agents/trader/aea-config.yaml",
 )
 
-_POINTER_RE = re.compile(r"file_hash_to_strategies:\s*\$\{[^{]*(\{.*\})\}")
-_ENTRY_RE = re.compile(r'"(bafybei[a-z0-9]+)":\s*\[\s*"([a-z_]+)"\s*\]')
+# The pointer is an aea env-var param whose value is a ``${...}`` string with a
+# ``dict:<json>`` payload -- either ``${dict:{...}}`` (agent default) or
+# ``${VAR:dict:{...}}`` (service override). Read the file as YAML (robust to
+# whitespace / line-formatting), locate the value, then peel the ``dict:``
+# wrapper and JSON-parse the mapping.
+_DICT_RE = re.compile(r"dict:(\{.*\})\}\s*$")
 
 
 def _config_id(path: Path) -> str:
@@ -79,14 +84,39 @@ def _package_cids() -> Dict[str, str]:
     return out
 
 
+def _find_pointer_value(node: Any) -> Any:
+    """Return the ``file_hash_to_strategies`` value from a parsed-YAML tree, else None."""
+    if isinstance(node, dict):
+        if "file_hash_to_strategies" in node:
+            return node["file_hash_to_strategies"]
+        for value in node.values():
+            found = _find_pointer_value(value)
+            if found is not None:
+                return found
+    elif isinstance(node, list):
+        for value in node:
+            found = _find_pointer_value(value)
+            if found is not None:
+                return found
+    return None
+
+
 def _pointer_entries(path: Path) -> List[Tuple[str, str]]:
     """Return ``(strategy_name, runtime_cid)`` pairs from a config's pointer."""
     if not path.is_file():
         return []
-    match = _POINTER_RE.search(path.read_text())
+    value = None
+    for document in yaml.safe_load_all(path.read_text()):
+        value = _find_pointer_value(document)
+        if value is not None:
+            break
+    if not isinstance(value, str):
+        return []
+    match = _DICT_RE.search(value)
     if match is None:
         return []
-    return [(name, cid) for cid, name in _ENTRY_RE.findall(match.group(1))]
+    mapping = json.loads(match.group(1))  # {cid: [strategy_name, ...]}
+    return [(name, cid) for cid, names in mapping.items() for name in names]
 
 
 _CASES = [

--- a/packages/valory/skills/trader_abci/skill.yaml
+++ b/packages/valory/skills/trader_abci/skill.yaml
@@ -57,8 +57,8 @@ skills:
 - valory/transaction_settlement_abci:0.1.0:bafybeibv3tycpdhphlblu62zpcbjsj7hnwkutexxqagorkelhjlt4t4fii
 - valory/termination_abci:0.1.0:bafybeibnnzry5kknci3z46gcjgutv4jid3ir6xn6a5adq3tx6v2e25augq
 - valory/market_manager_abci:0.1.0:bafybeic67hypwetzltnuy3a6y3o2o332lxyvn34buq57gy4n6bfqpbpxjm
-- valory/decision_maker_abci:0.1.0:bafybeibzvacqutn2jas3nodfn55hmqip4hremewu2xttrs2cjzjgqymzcy
-- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeidzf7ldzfqzcpbvbjso23pxaa42dtwyse7snrvmgfyqlpf77wbhee
+- valory/decision_maker_abci:0.1.0:bafybeib6b6yvgmcbemgakfysk5w7ttic27xkagoiogm3o4s6tjb2abal44
+- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeicb222ntpfwrs333vnbe6thjre7gom4nctbdpnapufxiufu4jkwku
 - valory/staking_abci:0.1.0:bafybeihwyron2bv7ierrgxke7xofwjy7x6wtglg5vopon7i7lfdiivweaq
 - valory/check_stop_trading_abci:0.1.0:bafybeifbiko6p3sqqg2q6qemmcig432s5djcsxm44j35ejittlpyr5f6z4
 - valory/mech_interact_abci:0.1.0:bafybeidnmszufszq3ro4ebgrqzmhqgctrsc6sykeanfsbvotghvt2cgfsy

--- a/packages/valory/skills/trader_abci/skill.yaml
+++ b/packages/valory/skills/trader_abci/skill.yaml
@@ -57,8 +57,8 @@ skills:
 - valory/transaction_settlement_abci:0.1.0:bafybeibv3tycpdhphlblu62zpcbjsj7hnwkutexxqagorkelhjlt4t4fii
 - valory/termination_abci:0.1.0:bafybeibnnzry5kknci3z46gcjgutv4jid3ir6xn6a5adq3tx6v2e25augq
 - valory/market_manager_abci:0.1.0:bafybeic67hypwetzltnuy3a6y3o2o332lxyvn34buq57gy4n6bfqpbpxjm
-- valory/decision_maker_abci:0.1.0:bafybeigterfcylnzjzxpja6u56gvcq2grcgvia2qcj34yr2ksogss33wuu
-- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeiglvalfzo744cvxvslx4vo42r4tcozn7hzsn3aa2q3hkm77t77xwe
+- valory/decision_maker_abci:0.1.0:bafybeibzvacqutn2jas3nodfn55hmqip4hremewu2xttrs2cjzjgqymzcy
+- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeidzf7ldzfqzcpbvbjso23pxaa42dtwyse7snrvmgfyqlpf77wbhee
 - valory/staking_abci:0.1.0:bafybeihwyron2bv7ierrgxke7xofwjy7x6wtglg5vopon7i7lfdiivweaq
 - valory/check_stop_trading_abci:0.1.0:bafybeifbiko6p3sqqg2q6qemmcig432s5djcsxm44j35ejittlpyr5f6z4
 - valory/mech_interact_abci:0.1.0:bafybeidnmszufszq3ro4ebgrqzmhqgctrsc6sykeanfsbvotghvt2cgfsy

--- a/packages/valory/skills/trader_abci/skill.yaml
+++ b/packages/valory/skills/trader_abci/skill.yaml
@@ -57,8 +57,8 @@ skills:
 - valory/transaction_settlement_abci:0.1.0:bafybeibv3tycpdhphlblu62zpcbjsj7hnwkutexxqagorkelhjlt4t4fii
 - valory/termination_abci:0.1.0:bafybeibnnzry5kknci3z46gcjgutv4jid3ir6xn6a5adq3tx6v2e25augq
 - valory/market_manager_abci:0.1.0:bafybeic67hypwetzltnuy3a6y3o2o332lxyvn34buq57gy4n6bfqpbpxjm
-- valory/decision_maker_abci:0.1.0:bafybeib6b6yvgmcbemgakfysk5w7ttic27xkagoiogm3o4s6tjb2abal44
-- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeicb222ntpfwrs333vnbe6thjre7gom4nctbdpnapufxiufu4jkwku
+- valory/decision_maker_abci:0.1.0:bafybeiaiy3kutwvr7yon4r6ta32tix4yu4ap4hh7ucu22zlbxrizsrsf3u
+- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeiell7knjekoqtpka5fn33qwjaiceznpz7pvu6neuy2xvpqjmnhjni
 - valory/staking_abci:0.1.0:bafybeihwyron2bv7ierrgxke7xofwjy7x6wtglg5vopon7i7lfdiivweaq
 - valory/check_stop_trading_abci:0.1.0:bafybeifbiko6p3sqqg2q6qemmcig432s5djcsxm44j35ejittlpyr5f6z4
 - valory/mech_interact_abci:0.1.0:bafybeidnmszufszq3ro4ebgrqzmhqgctrsc6sykeanfsbvotghvt2cgfsy

--- a/packages/valory/skills/tx_settlement_multiplexer_abci/skill.yaml
+++ b/packages/valory/skills/tx_settlement_multiplexer_abci/skill.yaml
@@ -27,7 +27,7 @@ protocols:
 - valory/ledger_api:1.0.0:bafybeiecq56phjfws36rgrefw6niyo4ezesloodsfis647mpm5ygqo4ysi
 skills:
 - valory/abstract_round_abci:0.1.0:bafybeicioxhbhnsoqyqvkeevd7df7r2vubbiglyf7ucps2el73objazjsq
-- valory/decision_maker_abci:0.1.0:bafybeibzvacqutn2jas3nodfn55hmqip4hremewu2xttrs2cjzjgqymzcy
+- valory/decision_maker_abci:0.1.0:bafybeib6b6yvgmcbemgakfysk5w7ttic27xkagoiogm3o4s6tjb2abal44
 - valory/staking_abci:0.1.0:bafybeihwyron2bv7ierrgxke7xofwjy7x6wtglg5vopon7i7lfdiivweaq
 - valory/mech_interact_abci:0.1.0:bafybeidnmszufszq3ro4ebgrqzmhqgctrsc6sykeanfsbvotghvt2cgfsy
 behaviours:

--- a/packages/valory/skills/tx_settlement_multiplexer_abci/skill.yaml
+++ b/packages/valory/skills/tx_settlement_multiplexer_abci/skill.yaml
@@ -27,7 +27,7 @@ protocols:
 - valory/ledger_api:1.0.0:bafybeiecq56phjfws36rgrefw6niyo4ezesloodsfis647mpm5ygqo4ysi
 skills:
 - valory/abstract_round_abci:0.1.0:bafybeicioxhbhnsoqyqvkeevd7df7r2vubbiglyf7ucps2el73objazjsq
-- valory/decision_maker_abci:0.1.0:bafybeib6b6yvgmcbemgakfysk5w7ttic27xkagoiogm3o4s6tjb2abal44
+- valory/decision_maker_abci:0.1.0:bafybeiaiy3kutwvr7yon4r6ta32tix4yu4ap4hh7ucu22zlbxrizsrsf3u
 - valory/staking_abci:0.1.0:bafybeihwyron2bv7ierrgxke7xofwjy7x6wtglg5vopon7i7lfdiivweaq
 - valory/mech_interact_abci:0.1.0:bafybeidnmszufszq3ro4ebgrqzmhqgctrsc6sykeanfsbvotghvt2cgfsy
 behaviours:

--- a/packages/valory/skills/tx_settlement_multiplexer_abci/skill.yaml
+++ b/packages/valory/skills/tx_settlement_multiplexer_abci/skill.yaml
@@ -27,7 +27,7 @@ protocols:
 - valory/ledger_api:1.0.0:bafybeiecq56phjfws36rgrefw6niyo4ezesloodsfis647mpm5ygqo4ysi
 skills:
 - valory/abstract_round_abci:0.1.0:bafybeicioxhbhnsoqyqvkeevd7df7r2vubbiglyf7ucps2el73objazjsq
-- valory/decision_maker_abci:0.1.0:bafybeigterfcylnzjzxpja6u56gvcq2grcgvia2qcj34yr2ksogss33wuu
+- valory/decision_maker_abci:0.1.0:bafybeibzvacqutn2jas3nodfn55hmqip4hremewu2xttrs2cjzjgqymzcy
 - valory/staking_abci:0.1.0:bafybeihwyron2bv7ierrgxke7xofwjy7x6wtglg5vopon7i7lfdiivweaq
 - valory/mech_interact_abci:0.1.0:bafybeidnmszufszq3ro4ebgrqzmhqgctrsc6sykeanfsbvotghvt2cgfsy
 behaviours:


### PR DESCRIPTION
Adds a CI guard so the trader can't silently ship a **stale betting strategy** again, and fixes a second stale pointer the guard caught.

## Background — the drift

The agent downloads its strategy at runtime from the CID in `file_hash_to_strategies` (a param), **not** from the packaged `customs` code. `autonomy packages lock` bumps the package CID but never that pointer, so any strategy PR that forgets to hand-edit the pointer silently keeps deploying the **old** strategy. This has bitten twice:

- **kelly** — pointer frozen at the March-25 build across `v0.36`→`v0.40` (~7 weeks); #971's depth fix and #999's `max_edge` never ran in production. Fixed in #1001.
- **fixed_bet** — pointer frozen at the March original (`bafybeigp65do…`) while the package moved on 2026-04-30 (`bafybeidahih5c7…`). Harmless (fallback disabled) but real.

## Changes

1. **`test_strategy_pointer_consistency.py`** — parametrized guard asserting `file_hash_to_strategies[strategy] == packages.json CID` for every strategy in `polymarket_trader`, `trader_pearl`, and the agent default. Fails CI with an actionable message on any drift; runs in the existing `test` job (no workflow changes).
2. **Repoint `fixed_bet`** to the packaged CID (`bafybeidahih5c7…`) + re-lock, so both strategies are consistent and the guard is green.

## Notes

- **Stacked on #1001** (which repoints kelly). CI is green because this branch includes #1001's kelly repoint; the diff here is only `fixed_bet` + the test. Once #1001 merges, this retargets to `main` and the diff collapses to exactly those two things.
- Verified: the test passes on the fixed state and **fails with a clear `STALE` message when a pointer is reverted**; `autonomy packages lock --check` passes; black/isort/flake8/darglint/copyright clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
