### PR TITLE
chore(polymarket-trader): widen max_edge 0.15 -> 0.30 (volume trial)

### DIFF
--- a/packages/packages.json
+++ b/packages/packages.json
@@ -18,7 +18,7 @@
         "skill/valory/chatui_abci/0.1.0": "bafybeie2kmgihgk3rwpzelaa76ypvchsyg2vy3me4vxlbjttaq4frs3ipa",
         "agent/valory/trader/0.1.0": "bafybeif4no4jmjcfxjhkkaddrlhykv7myq2722ts37czimpggthxi5uwvu",
         "service/valory/trader_pearl/0.1.0": "bafybeidjlclez7efqjl7a4hbx7a7dofmudgwvs5u4df3bjdrhuxyvb7vra",
-        "service/valory/polymarket_trader/0.1.0": "bafybeidqc5k3irb7vwhnftz5emazqvr5dqmnqqmiggd4usrhlsnpvhbczi"
+        "service/valory/polymarket_trader/0.1.0": "bafybeif4r7ftadt5wz6k3abniud245yiazbmrivd4wr7mrqt2znudwgxpy"
     },
     "third_party": {
         "protocol/valory/acn_data_share/0.1.0": "bafybeieqisfr6lhaaesq37lk7vyaxza2h6nucshksgyo2djqfyf2saqo4i",

--- a/packages/valory/services/polymarket_trader/service.yaml
+++ b/packages/valory/services/polymarket_trader/service.yaml
@@ -134,7 +134,7 @@ models:
       withdrawal_round_timeout: ${WITHDRAWAL_ROUND_TIMEOUT:float:1800.0}
       contract_timeout: ${CONTRACT_TIMEOUT:float:300.0}
       file_hash_to_strategies: ${FILE_HASH_TO_STRATEGIES:dict:{"bafybeidme2uybzyzagky3jtosheqmpgc6b6w4rum7cdxw2fc35nnpwblfe":["kelly_criterion"],"bafybeidahih5c7htr5g5e4nq5wcqfiwse2z6ga27jxsxll7iracehmysim":["fixed_bet"]}}
-      strategies_kwargs: ${STRATEGIES_KWARGS:dict:{"floor_balance":0,"default_max_bet_size":2500000,"absolute_min_bet_size":1000000,"absolute_max_bet_size":2500000,"n_bets":1,"min_edge":0.01,"max_edge":0.15,"min_oracle_prob":0.1,"fee_per_trade":10000,"grid_points":500}}
+      strategies_kwargs: ${STRATEGIES_KWARGS:dict:{"floor_balance":0,"default_max_bet_size":2500000,"absolute_min_bet_size":1000000,"absolute_max_bet_size":2500000,"n_bets":1,"min_edge":0.01,"max_edge":0.30,"min_oracle_prob":0.1,"fee_per_trade":10000,"grid_points":500}}
       use_subgraph_for_redeeming: ${USE_SUBGRAPH_FOR_REDEEMING:bool:true}
       use_mech_marketplace: ${USE_MECH_MARKETPLACE:bool:true}
       mech_marketplace_config: ${MECH_MARKETPLACE_CONFIG:dict:{"mech_marketplace_address":"0x343F2B005cF6D70bA610CD9F1F1927049414B582","priority_mech_address":"0x1DCbC9368327776F8B20Dc041D40b8076C8AC173","priority_mech_staking_instance_address":"0x0000000000000000000000000000000000000000","priority_mech_service_id":25,"requester_staking_instance_address":"0x0000000000000000000000000000000000000000","response_timeout":300}}


### PR DESCRIPTION
## What

Widen the Polymarket trader's edge cap `max_edge` from **0.15 -> 0.30** in `polymarket_trader/service.yaml` (`STRATEGIES_KWARGS`). Omen (`trader_pearl`) is untouched. No FSM change; only the `polymarket_trader` service CID re-locks.

## Why

At `max_edge=0.15` the live edge gate admits **~0 bets/day** in the current market regime -- the forecaster has drifted more overconfident over time (median execution edge ~0.18 -> ~0.36 since January; the share of bets landing in `[0.01, 0.15]` fell ~31% -> ~10%). The trader is effectively silent. Widening to 0.30 roughly **doubles** admitted volume so the service actually trades.

## Tradeoff (please read before merging)

This is a **volume-over-ROI trial, not a profit change.** The `max_edge` ROI sweep shows widening is **not** ROI-positive in the current regime -- the extra bets it admits are net-negative:

| max_edge | last-30d capital-weighted ROI |
|---|---|
| 0.15 | ~-4.8% (least-bad) |
| 0.30 | ~-12.9% |

So 0.30 buys activity at a documented ROI cost. It is a **defensive, monitored trial** to keep the trader active while the durable fix -- upstream **forecaster calibration** (a high `p_side` must actually be right) -- is developed. A downstream edge cap cannot fix an overconfident forecaster.

## Rollback

- Operated deployments: `STRATEGIES_KWARGS` env flip (immediate).
- Pearl: a follow-up release (reaches all users; no per-agent switch).

## Monitoring

Track capital-weighted ROI / bets-day / win-rate vs the ~-5.4% pooled baseline weekly; revert if the current-regime ROI degradation outweighs the volume benefit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
