### PR TITLE
chore(polymarket-trader): restore max_edge 0.15 -> 0.30 (re-apply #1004)

### DIFF
--- a/packages/packages.json
+++ b/packages/packages.json
@@ -19,7 +19,7 @@
         "skill/valory/chatui_abci/0.1.0": "bafybeig4qckyl7exilbd4egapsttvfrecfu4buywx632gixuvkwcjqqssu",
         "agent/valory/trader/0.1.0": "bafybeif3ttffq4o6xzrzh7kdgjrx5tmy4sjki7gaw7smbhfnfhqhcny4ym",
         "service/valory/trader_pearl/0.1.0": "bafybeigfo273qta5ofgmidchoy6zy5ai464xi4prydsp4gen2mhgiy7rg4",
-        "service/valory/polymarket_trader/0.1.0": "bafybeifdwuq5dlzb4wnwb45h54zo7owlkj6ogrpw74mqnxtdgokiim67t4"
+        "service/valory/polymarket_trader/0.1.0": "bafybeigmltj5g6ewucxtctvptbbkfpapntpqmq5n6mshfwsbvz776htrzy"
     },
     "third_party": {
         "protocol/valory/acn_data_share/0.1.0": "bafybeieqisfr6lhaaesq37lk7vyaxza2h6nucshksgyo2djqfyf2saqo4i",

--- a/packages/valory/services/polymarket_trader/service.yaml
+++ b/packages/valory/services/polymarket_trader/service.yaml
@@ -134,7 +134,7 @@ models:
       withdrawal_round_timeout: ${WITHDRAWAL_ROUND_TIMEOUT:float:1800.0}
       contract_timeout: ${CONTRACT_TIMEOUT:float:300.0}
       file_hash_to_strategies: ${FILE_HASH_TO_STRATEGIES:dict:{"bafybeidme2uybzyzagky3jtosheqmpgc6b6w4rum7cdxw2fc35nnpwblfe":["kelly_criterion"],"bafybeidahih5c7htr5g5e4nq5wcqfiwse2z6ga27jxsxll7iracehmysim":["fixed_bet"]}}
-      strategies_kwargs: ${STRATEGIES_KWARGS:dict:{"floor_balance":0,"default_max_bet_size":2500000,"absolute_min_bet_size":1000000,"absolute_max_bet_size":2500000,"n_bets":1,"min_edge":0.01,"max_edge":0.15,"min_oracle_prob":0.1,"fee_per_trade":10000,"grid_points":500}}
+      strategies_kwargs: ${STRATEGIES_KWARGS:dict:{"floor_balance":0,"default_max_bet_size":2500000,"absolute_min_bet_size":1000000,"absolute_max_bet_size":2500000,"n_bets":1,"min_edge":0.01,"max_edge":0.30,"min_oracle_prob":0.1,"fee_per_trade":10000,"grid_points":500}}
       use_subgraph_for_redeeming: ${USE_SUBGRAPH_FOR_REDEEMING:bool:true}
       use_mech_marketplace: ${USE_MECH_MARKETPLACE:bool:true}
       mech_marketplace_config: ${MECH_MARKETPLACE_CONFIG:dict:{"mech_marketplace_address":"0x343F2B005cF6D70bA610CD9F1F1927049414B582","priority_mech_address":"0x1DCbC9368327776F8B20Dc041D40b8076C8AC173","priority_mech_staking_instance_address":"0x0000000000000000000000000000000000000000","priority_mech_service_id":25,"requester_staking_instance_address":"0x0000000000000000000000000000000000000000","response_timeout":300,"use_offchain":false,"offchain_url":null,"offchain_deposit_target_calls":10,"auto_deposit_cap_per_cycle":5000000,"offchain_poll_interval_seconds":3.0,"offchain_poll_timeout_seconds":300.0,"offchain_failover_max_retries":2}}


### PR DESCRIPTION
## Summary
- PR #1004 widened polymarket_trader `max_edge` from 0.15 to 0.30. That change was silently reverted during the `main` -> `offchain-epic` sync merge (3bf0e2718) — the conflict resolution kept the branch's stale 0.15 side. PR #1008 then carried the reverted value back to main, so current `main` shows `max_edge=0.15` even though #1004 is in the history.
- Re-applies the exact same two-line change as #1004: service.yaml + regenerated `packages.json` hash. No other config from #1004 was affected (verified).

## Test plan
- [ ] `autonomy packages lock --check` passes (already run locally)
- [ ] CI green (packages hash check, docstrings, deps)
- [ ] Confirm live Polymarket agent picks up widened band once merged