### PR TITLE
chore: drop unused olas_mech_subgraph override from polymarket_trader

### DIFF
--- a/packages/packages.json
+++ b/packages/packages.json
@@ -19,7 +19,7 @@
         "skill/valory/chatui_abci/0.1.0": "bafybeig4qckyl7exilbd4egapsttvfrecfu4buywx632gixuvkwcjqqssu",
         "agent/valory/trader/0.1.0": "bafybeihrtti72gii23aufe6zeezzydyqusvz4bt3wn6rcvyk6lu5it6g2i",
         "service/valory/trader_pearl/0.1.0": "bafybeico5agjhkwljmiro4563n3rclmai2v7i7oeluxi52hncnpx4r7tve",
-        "service/valory/polymarket_trader/0.1.0": "bafybeiehvfewnlmmt5cnythj3dzhmfu6aj3swjqys36cci34clyajd3edi"
+        "service/valory/polymarket_trader/0.1.0": "bafybeicu443g4b36shsznd4my7yfmfgybp4j3ujnak3gha4mkqrl6rbiym"
     },
     "third_party": {
         "protocol/valory/acn_data_share/0.1.0": "bafybeieqisfr6lhaaesq37lk7vyaxza2h6nucshksgyo2djqfyf2saqo4i",

--- a/packages/valory/services/polymarket_trader/service.yaml
+++ b/packages/valory/services/polymarket_trader/service.yaml
@@ -302,17 +302,6 @@ models:
       error_type: ${NETWORK_SUBGRAPH_ERROR_TYPE:str:dict}
       retries: ${OLAS_AGENTS_SUBGRAPH_RETRIES:int:5}
       url: ${OLAS_AGENTS_SUBGRAPH_URL:str:https://api.subgraph.autonolas.tech/api/proxy/predict-polymarket}
-  olas_mech_subgraph:
-    args:
-      headers: ${HEADERS:dict:{"Content-Type":"application/json"}}
-      method: ${OLAS_MECH_SUBGRAPH_METHOD:str:POST}
-      response_key: ${OLAS_MECH_SUBGRAPH_RESPONSE_KEY:str:data:sender}
-      response_type: ${OLAS_MECH_SUBGRAPH_RESPONSE_TYPE:str:dict}
-      error_key: ${NETWORK_SUBGRAPH_ERROR_KEY:str:errors}
-      error_index: ${NETWORK_SUBGRAPH_ERROR_INDEX:int:0}
-      error_type: ${NETWORK_SUBGRAPH_ERROR_TYPE:str:dict}
-      retries: ${OLAS_MECH_SUBGRAPH_RETRIES:int:5}
-      url: ${OLAS_MECH_SUBGRAPH_URL:str:https://api.subgraph.autonolas.tech/api/proxy/mech}
   gnosis_staking_subgraph:
     args:
       headers: ${HEADERS:dict:{"Content-Type":"application/json"}}


### PR DESCRIPTION
## What

Removes the `olas_mech_subgraph` model override from the Polymarket (Polystrat) service, which was the **only remaining reference** in the repo to the deprecated `https://api.subgraph.autonolas.tech/api/proxy/mech` subgraph. Also bumps the `polymarket_trader` service hash in `packages.json` accordingly.

## Why it's safe (dead config)

`olas_mech_subgraph` is only read on the **non-Polymarket** code path:

```python
# packages/valory/skills/agent_performance_summary_abci/graph_tooling/requests.py
if self.params.is_running_on_polymarket:
    subgraph = self.context.polygon_mech_subgraph   # marketplace-polygon
else:
    subgraph = self.context.olas_mech_subgraph      # <- never reached on Polystrat
```

Polystrat runs with `IS_RUNNING_ON_POLYMARKET=true` (default in `polymarket_trader/service.yaml`), so it **always** uses `polygon_mech_subgraph` and never touches `olas_mech_subgraph`. The override was stale leftover config pointing at the old `/api/proxy/mech` endpoint.

## Why drop rather than re-point

- Matches the existing partial-override pattern in this service — `polygon_mech_subgraph` (the one Polystrat actually uses) has no override block either; it inherits the skill default.
- The model still exists at the skill level, so if it were ever read (e.g. `IS_RUNNING_ON_POLYMARKET=false`), it falls back to the skill default `marketplace-gnosis`, **not** the deleted `/mech` endpoint.
- Re-pointing would leave a dead block that misleadingly implies Polystrat queries a Gnosis mech subgraph.

This unblocks deleting the `/api/proxy/mech` subgraph with zero runtime impact.

## Not affected

- **Omenstrat** (`trader_pearl`): its `olas_mech_subgraph` already points at `marketplace-gnosis` (a different subgraph) and is untouched.
- Skill-level tests mock `context.olas_mech_subgraph` directly and don't read `service.yaml`.

## Verification

- `grep` confirms `/api/proxy/mech` is now referenced nowhere in the repo.
- Service package hash recomputed with the framework's `IPFSHashOnly.hash_directory` (method validated against an unchanged package first) and updated in `packages.json`; on-disk dir now matches the recorded hash.
- `service.yaml` still parses (multi-doc).

🤖 Generated with [Claude Code](https://claude.com/claude-code)