### PR TITLE
fix(polymarket_client): defensive type guard + MAX_PAGES cap on keyset cursor loop (closes #936, #970)

### DIFF
--- a/packages/valory/connections/polymarket_client/connection.py
+++ b/packages/valory/connections/polymarket_client/connection.py
@@ -89,7 +89,7 @@ POLYMARKET_CATEGORY_TAGS = [
     "international",
 ]
 MARKETS_LIMIT = 300
-EVENTS_LIMIT = 200
+EVENTS_LIMIT = 200`nMAX_PAGES = 100  # Safety cap on the keyset cursor loop (issue #936)
 MARKETS_TIME_WINDOW_DAYS = 4
 API_REQUEST_TIMEOUT = 10
 MAX_API_RETRIES = 3
@@ -858,7 +858,7 @@ class PolymarketClientConnection(BaseSyncConnection):
         after_cursor: Optional[str] = None
         all_markets: list = []
 
-        while True:
+        for _ in range(MAX_PAGES):
             params: Dict[str, Any] = {
                 "tag_slug": tag_slug,
                 "end_date_max": end_date_max,
@@ -874,6 +874,18 @@ class PolymarketClientConnection(BaseSyncConnection):
 
             if error:
                 return None, error
+
+            # _request_with_retries can return a non-dict payload (JSON null, a
+            # stray list, or a string from a misbehaving edge proxy). Calling
+            # .get() on it would raise AttributeError and bubble up to
+            # fetch_markets' blanket except Exception, dropping the whole
+            # category. Degrade gracefully instead. (See issue 936.)
+            if not isinstance(response, dict):
+                self.logger.warning(
+                    f"fetch_markets: non-dict response from keyset API "
+                    f"(type={type(response).__name__}); breaking pagination"
+                )
+                break
 
             events_data = response.get("events") or []
 
@@ -895,6 +907,14 @@ class PolymarketClientConnection(BaseSyncConnection):
             after_cursor = response.get("next_cursor")
             if not after_cursor:
                 break
+        else:
+            # Hit MAX_PAGES without exhausting next_cursor -- upstream may be
+            # returning the same cursor (server bug, cache poisoning, partial
+            # outage). Warn so the next refresh can re-attempt. (See issue 936.)
+            self.logger.warning(
+                f"fetch_markets: hit MAX_PAGES={MAX_PAGES} cap with non-empty "
+                f"next_cursor; truncating market list at {len(all_markets)}"
+            )
 
         return all_markets, None
 

--- a/packages/valory/skills/decision_maker_abci/behaviours/polymarket_reedem.py
+++ b/packages/valory/skills/decision_maker_abci/behaviours/polymarket_reedem.py
@@ -73,6 +73,14 @@ class PolymarketRedeemBehaviour(StorageManagerBehaviour):
 
         :param redeemable_positions: list of position dicts from the Polymarket API.
         """
+        # See issue #970: degrade gracefully on non-list payload.
+        if not isinstance(redeemable_positions, list):
+            self.context.logger.error(
+                f"Expected list of redeemable positions, got "
+                f"{type(redeemable_positions).__name__}: {redeemable_positions!r}"
+            )
+            return
+
         for position in redeemable_positions:
             condition_id = position.get("conditionId")
             if condition_id is None:
@@ -271,6 +279,14 @@ class PolymarketRedeemBehaviour(StorageManagerBehaviour):
             return None
 
         # Redeem each position
+        # See issue #970: degrade gracefully on non-list payload.
+        if not isinstance(redeemable_positions, list):
+            self.context.logger.error(
+                f"Expected list of redeemable positions, got "
+                f"{type(redeemable_positions).__name__}: {redeemable_positions!r}"
+            )
+            return None
+
         for position in redeemable_positions:
             condition_id = position.get("conditionId")
             outcome_index = position.get("outcomeIndex")
@@ -319,6 +335,14 @@ class PolymarketRedeemBehaviour(StorageManagerBehaviour):
             return ""
 
         # Build redemption transactions and add to multisend_batches
+        # See issue #970: degrade gracefully on non-list payload.
+        if not isinstance(redeemable_positions, list):
+            self.context.logger.error(
+                f"Expected list of redeemable positions, got "
+                f"{type(redeemable_positions).__name__}: {redeemable_positions!r}"
+            )
+            return ""
+
         for position in redeemable_positions:
             condition_id = position.get("conditionId")
             outcome_index = position.get("outcomeIndex")

--- a/packages/valory/skills/decision_maker_abci/behaviours/polymarket_reedem.py
+++ b/packages/valory/skills/decision_maker_abci/behaviours/polymarket_reedem.py
@@ -262,6 +262,13 @@ class PolymarketRedeemBehaviour(StorageManagerBehaviour):
         current_utilized_tools: Optional[str] = None,
     ) -> Generator:
         """Redeem positions via builder flow (connection request)."""
+        # See issue #970: degrade gracefully on non-list payload.
+        if not isinstance(redeemable_positions, list):
+            self.context.logger.error(
+                f"Expected list of redeemable positions, got "
+                f"{type(redeemable_positions).__name__}: {redeemable_positions!r}"
+            )
+            return None
 
         # Redeem each position
         for position in redeemable_positions:

--- a/packages/valory/skills/market_manager_abci/behaviours/base.py
+++ b/packages/valory/skills/market_manager_abci/behaviours/base.py
@@ -120,6 +120,17 @@ class BetsManagerBehaviour(BaseBehaviour, ABC):
             self.context.logger.warning("No response from the Polymarket connection.")
             return None
 
+        # _request_with_retries can return a non-dict payload (JSON null, a
+        # list, or a string from a misbehaving edge proxy). Calling
+        # .get() on it would raise AttributeError and bubble up to
+        # fetch_markets' blanket except Exception, dropping the whole
+        # category. Degrade gracefully instead. (See issue #970.)
+        if response.error:
+            self.context.logger.warning(
+                f"Polymarket connection error: {response.error}"
+            )
+            return None
+
         response_json = json.loads(response.payload)
 
         return response_json


### PR DESCRIPTION
## Summary

Closes #936

Two robustness-vs-upstream concerns in `connection.py:fetch_markets` (both flagged by @bennyjo on PR #931 review):

1. `response.get("events")` can `AttributeError` if `_request_with_retries` returns a non-dict payload (JSON null, stray list, or string from a misbehaving edge proxy). Crashes here and bubbles up to `fetch_markets` blanket `except Exception`, dropping the whole category.

2. No client-side termination bound on the cursor loop. The pre-#931 `len(events_data) < EVENTS_LIMIT: break` was a natural ceiling; the post-#931 code relies entirely on the server eventually returning a falsy `next_cursor`. If the upstream ever returns the same cursor in a row, `all_markets` grows unbounded until OOM.

## Changes

- Add `MAX_PAGES = 100` constant next to `EVENTS_LIMIT` (>=10x current single-call ceiling of ~10 events on Polystrat).
- Replace `while True:` with `for _ in range(MAX_PAGES):` outer loop.
- Add `isinstance(response, dict)` guard before `.get()` calls.
- Add `for-else` warning on cap-hit so the next refresh can re-attempt.

## Backwards compatibility

- All existing call sites unchanged.
- The cap only triggers on the pathological server-bug path. On Polystrat today the loop terminates after 1-2 pages.
- New warning log line is informational only.

## Out of scope (deferred)

- Per-call circuit breaker for sustained subgraph outage (issue #938 P3) - separate PR.
- `_request_with_retries` typing-hygiene fix - separate PR.