### PR TITLE
chore: temporary Snyk classification test (DO NOT MERGE)

### DIFF
--- a/.github/workflows/snyk-security.yml
+++ b/.github/workflows/snyk-security.yml
@@ -41,6 +41,17 @@ jobs:
       - name: Snyk Open Source monitor
         run: snyk monitor --remote-repo-url=https://github.com/${{ github.repository }} --file=requirements.txt --package-manager=pip --skip-unresolved
 
+      # TEMPORARY — do not merge. Creates a second, brand-new Snyk project from
+      # the same scan so we can tell whether a project *created* while
+      # --remote-repo-url is present is still metered against the free-plan
+      # private test quota. Every existing project in the org predates that flag
+      # (newest: 2026-07-15; flag landed 2026-07-22), so this has never been
+      # tested. The step above monitors the pre-flag project and acts as the
+      # control: one run, two monitors, one old project and one new.
+      - name: Snyk monitor (flag classification test)
+        run: snyk monitor --remote-repo-url=https://github.com/${{ github.repository }} --file=requirements.txt --package-manager=pip --skip-unresolved --project-name=zz-flagtest
+        continue-on-error: true
+
       - name: Upload result to GitHub Code Scanning
         uses: github/codeql-action/upload-sarif@v3
         with:


### PR DESCRIPTION
**Draft / diagnostic only — do not merge, will be closed once read.**

## Why

Our Snyk free-plan private test counters are being consumed by scans of **public** repos, which [Snyk's docs](https://docs.snyk.io/snyk-data-and-governance/what-counts-as-a-test) say should be exempt: *"the applicable test limits apply to private repositories only."* Snyk's own API agrees our repos are public — 9 of 10 targets report `is_private: false` — and they meter anyway. At the current rate the Snyk Code bucket caps around Aug 5.

Adding `--remote-repo-url` to every CLI scan (rolled out 2026-07-22) corrected the target classification but changed nothing about the metering.

## What this tests

Every one of the 14 projects in the org was created *before* that flag landed — the newest, `connect`, predates it by a week. So classification **at project creation time**, with the flag present, has never actually been observed.

This PR adds a second `snyk monitor` with a distinct `--project-name`, so one run creates a brand-new post-flag project. The existing monitor step is the control: same run, same scan, one pre-flag project and one post-flag project.

| outcome | reading (baseline 36) | conclusion |
|---|---|---|
| **+1** | 37 | Only the pre-flag project counted → classification is fixed at creation, and deleting/recreating all 14 projects fixes the metering |
| **+2** | 38 | Both counted → the CLI path meters unconditionally, recreation is pointless, move SAST off Snyk |

## After

Read the counter, close this PR, delete the `zz-flagtest` project. Nothing here is intended to land.