### PR TITLE
chore(trader): bump mech_interact_abci to v0.32.7; hoist use_offchain and offchain_deposit_target_calls to top-level params

### DIFF
--- a/packages/packages.json
+++ b/packages/packages.json
@@ -10,16 +10,16 @@
         "contract/valory/mech_prepaid_reader/0.1.0": "bafybeiaitnqi4kc2wiltj3k6a3iujxritwkh5w2a2xoff7dosoqy7p3sou",
         "connection/valory/polymarket_client/0.1.0": "bafybeid4eo37pka4tfhsjs6rb3knrugmokcvihust2dpfrgob56y77xd44",
         "skill/valory/market_manager_abci/0.1.0": "bafybeig3ak2eoimxwuupybde4napyi2jlf7pxk35se2zclikete2ni5hti",
-        "skill/valory/decision_maker_abci/0.1.0": "bafybeiefxkbb3qh35gnsoqq65bi7wvp7yfbb7uiwef747oahgtyicisumu",
-        "skill/valory/trader_abci/0.1.0": "bafybeiduf4gkl6f6dvhiwe5shf7vtc6fyb5ypyyamlkq4sqdw7xpjf6t4m",
-        "skill/valory/tx_settlement_multiplexer_abci/0.1.0": "bafybeiffci4jqgnmjud3j6m5cam7vvjttt6uugfh57az6a4quiwzmk6llm",
+        "skill/valory/decision_maker_abci/0.1.0": "bafybeihgq4jjqyjrxyzzzi7hd7r27vf2lj45h5ljnp57kzg6enz3vtyqvy",
+        "skill/valory/trader_abci/0.1.0": "bafybeibf5d2gaacgrxxxwv4himk3jmuhnh7j4ahezjrxklqiewzgglgiq4",
+        "skill/valory/tx_settlement_multiplexer_abci/0.1.0": "bafybeifjxdbup557ynvbjfo6q2zoeupz3rerzf3uwyntiqvhmoqupy7a7a",
         "skill/valory/staking_abci/0.1.0": "bafybeia6csjgex5zxdt6vymiaengu75lyzjdgfrnp65ewlghthiniquhje",
-        "skill/valory/agent_performance_summary_abci/0.1.0": "bafybeibw4cjxuswzkhilfxwqodxuwpnqxq7e5egfmrmufoigjtu4iyma6u",
-        "skill/valory/check_stop_trading_abci/0.1.0": "bafybeicn32bur353d3msdypfcwq257ucmmg55rzyklxftff2l2uoez62wu",
-        "skill/valory/chatui_abci/0.1.0": "bafybeiga534fdtg7544qf3paaxcunauy46hu4xphmo2k2izjmdncw72pmy",
-        "agent/valory/trader/0.1.0": "bafybeihhfz6we66nkc3xtnozidwjtke2ahzoj6ixetzzj5ztp2gekt6zte",
-        "service/valory/trader_pearl/0.1.0": "bafybeibacz7xudlx3x42bdlntudom2ap37ecjjuhwminh66vv7xgj55poe",
-        "service/valory/polymarket_trader/0.1.0": "bafybeihxgs2r46hcmius2ftqjqk32zxex6pex2ejezb2djxlyrhanlyxda"
+        "skill/valory/agent_performance_summary_abci/0.1.0": "bafybeiaguxjexjxth4e3zajfxvqjprjhn4r6njgq6ddmhkql3uhqdsttp4",
+        "skill/valory/check_stop_trading_abci/0.1.0": "bafybeierqjfa6yq4vmhwsweght4w5vao2f7d732jczuexa7ovy4grhqmui",
+        "skill/valory/chatui_abci/0.1.0": "bafybeicsqursfh4svzecimnfbv77jn4vq3cc42e7bislzxfbqigos4ulgm",
+        "agent/valory/trader/0.1.0": "bafybeib42tl6yicz6k5eaezf2kuulpot2uune3ycm7nm6r573crl4tg2ui",
+        "service/valory/trader_pearl/0.1.0": "bafybeihbyiu23xc7jhjrlz376fsj4sqeaqhkldkk56djtsm45gr3bpsl4m",
+        "service/valory/polymarket_trader/0.1.0": "bafybeibype6hrmmg7kurdy6sbjezfyid2fg74o3davo72kni6ewfgfacpu"
     },
     "third_party": {
         "protocol/valory/acn_data_share/0.1.0": "bafybeieqisfr6lhaaesq37lk7vyaxza2h6nucshksgyo2djqfyf2saqo4i",
@@ -73,7 +73,7 @@
         "skill/valory/registration_abci/0.1.0": "bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi",
         "skill/valory/reset_pause_abci/0.1.0": "bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi",
         "skill/valory/termination_abci/0.1.0": "bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi",
-        "skill/valory/mech_interact_abci/0.1.0": "bafybeifbkpgivxjexlhrptn2iaju7vyzeusevvucsin6tbjwveniykad2q",
+        "skill/valory/mech_interact_abci/0.1.0": "bafybeic5xfxdod5l56o7aojdamojnvi562nql2mlah73bf47d4guz4xnwi",
         "skill/valory/funds_manager/0.1.0": "bafybeicfw7qjtnlcbw6awsvxdahqu42fxsfsd3wy7mbyhcbls4l5pee3by"
     }
 }

--- a/packages/valory/agents/trader/aea-config.yaml
+++ b/packages/valory/agents/trader/aea-config.yaml
@@ -70,15 +70,15 @@ skills:
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
-- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeiffci4jqgnmjud3j6m5cam7vvjttt6uugfh57az6a4quiwzmk6llm
+- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeifjxdbup557ynvbjfo6q2zoeupz3rerzf3uwyntiqvhmoqupy7a7a
 - valory/market_manager_abci:0.1.0:bafybeig3ak2eoimxwuupybde4napyi2jlf7pxk35se2zclikete2ni5hti
-- valory/decision_maker_abci:0.1.0:bafybeiefxkbb3qh35gnsoqq65bi7wvp7yfbb7uiwef747oahgtyicisumu
-- valory/trader_abci:0.1.0:bafybeiduf4gkl6f6dvhiwe5shf7vtc6fyb5ypyyamlkq4sqdw7xpjf6t4m
+- valory/decision_maker_abci:0.1.0:bafybeihgq4jjqyjrxyzzzi7hd7r27vf2lj45h5ljnp57kzg6enz3vtyqvy
+- valory/trader_abci:0.1.0:bafybeibf5d2gaacgrxxxwv4himk3jmuhnh7j4ahezjrxklqiewzgglgiq4
 - valory/staking_abci:0.1.0:bafybeia6csjgex5zxdt6vymiaengu75lyzjdgfrnp65ewlghthiniquhje
-- valory/check_stop_trading_abci:0.1.0:bafybeicn32bur353d3msdypfcwq257ucmmg55rzyklxftff2l2uoez62wu
-- valory/mech_interact_abci:0.1.0:bafybeifbkpgivxjexlhrptn2iaju7vyzeusevvucsin6tbjwveniykad2q
-- valory/chatui_abci:0.1.0:bafybeiga534fdtg7544qf3paaxcunauy46hu4xphmo2k2izjmdncw72pmy
-- valory/agent_performance_summary_abci:0.1.0:bafybeibw4cjxuswzkhilfxwqodxuwpnqxq7e5egfmrmufoigjtu4iyma6u
+- valory/check_stop_trading_abci:0.1.0:bafybeierqjfa6yq4vmhwsweght4w5vao2f7d732jczuexa7ovy4grhqmui
+- valory/mech_interact_abci:0.1.0:bafybeic5xfxdod5l56o7aojdamojnvi562nql2mlah73bf47d4guz4xnwi
+- valory/chatui_abci:0.1.0:bafybeicsqursfh4svzecimnfbv77jn4vq3cc42e7bislzxfbqigos4ulgm
+- valory/agent_performance_summary_abci:0.1.0:bafybeiaguxjexjxth4e3zajfxvqjprjhn4r6njgq6ddmhkql3uhqdsttp4
 - valory/funds_manager:0.1.0:bafybeicfw7qjtnlcbw6awsvxdahqu42fxsfsd3wy7mbyhcbls4l5pee3by
 customs:
 - valory/kelly_criterion:0.1.0:bafybeidme2uybzyzagky3jtosheqmpgc6b6w4rum7cdxw2fc35nnpwblfe
@@ -259,6 +259,8 @@ models:
       use_mech_marketplace: ${USE_MECH_MARKETPLACE:bool:false}
       policy_store_update_offset: ${int:259200}
       mech_marketplace_config: ${MECH_MARKETPLACE_CONFIG:dict:{"mech_marketplace_address":"0x0000000000000000000000000000000000000000","priority_mech_address":"0x0000000000000000000000000000000000000000","priority_mech_staking_instance_address":"0x0000000000000000000000000000000000000000","priority_mech_service_id":0,"requester_staking_instance_address":"0x0000000000000000000000000000000000000000","response_timeout":300}}
+      use_offchain: ${USE_OFFCHAIN:bool:false}
+      offchain_deposit_target_calls: ${OFFCHAIN_DEPOSIT_TARGET_CALLS:int:10}
       expected_mech_response_time: ${int:300}
       mech_invalid_response: ${str:Invalid Response}
       mech_consecutive_failures_threshold: ${int:2}

--- a/packages/valory/services/polymarket_trader/service.yaml
+++ b/packages/valory/services/polymarket_trader/service.yaml
@@ -8,7 +8,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeichoh5tnk4qctaazcjcrxvpwc5yasodleqoeapnfapwrrdh3tm5gu
 fingerprint_ignore_patterns: []
-agent: valory/trader:0.1.0:bafybeihhfz6we66nkc3xtnozidwjtke2ahzoj6ixetzzj5ztp2gekt6zte
+agent: valory/trader:0.1.0:bafybeib42tl6yicz6k5eaezf2kuulpot2uune3ycm7nm6r573crl4tg2ui
 number_of_agents: 1
 deployment:
   agent:
@@ -137,7 +137,9 @@ models:
       strategies_kwargs: ${STRATEGIES_KWARGS:dict:{"floor_balance":0,"default_max_bet_size":2500000,"absolute_min_bet_size":1000000,"absolute_max_bet_size":2500000,"n_bets":1,"min_edge":0.01,"max_edge":0.30,"min_oracle_prob":0.1,"fee_per_trade":10000,"grid_points":500}}
       use_subgraph_for_redeeming: ${USE_SUBGRAPH_FOR_REDEEMING:bool:true}
       use_mech_marketplace: ${USE_MECH_MARKETPLACE:bool:true}
-      mech_marketplace_config: ${MECH_MARKETPLACE_CONFIG:dict:{"mech_marketplace_address":"0x343F2B005cF6D70bA610CD9F1F1927049414B582","priority_mech_address":"0x1DCbC9368327776F8B20Dc041D40b8076C8AC173","priority_mech_staking_instance_address":"0x0000000000000000000000000000000000000000","priority_mech_service_id":25,"requester_staking_instance_address":"0x0000000000000000000000000000000000000000","response_timeout":300,"use_offchain":false,"offchain_url":null,"offchain_deposit_target_calls":10,"auto_deposit_cap_per_cycle":5000000,"offchain_poll_interval_seconds":3.0,"offchain_poll_timeout_seconds":300.0,"offchain_failover_max_retries":2}}
+      mech_marketplace_config: ${MECH_MARKETPLACE_CONFIG:dict:{"mech_marketplace_address":"0x343F2B005cF6D70bA610CD9F1F1927049414B582","priority_mech_address":"0x1DCbC9368327776F8B20Dc041D40b8076C8AC173","priority_mech_staking_instance_address":"0x0000000000000000000000000000000000000000","priority_mech_service_id":25,"requester_staking_instance_address":"0x0000000000000000000000000000000000000000","response_timeout":300,"offchain_url":null,"auto_deposit_cap_per_cycle":5000000,"offchain_poll_interval_seconds":3.0,"offchain_poll_timeout_seconds":300.0,"offchain_failover_max_retries":2}}
+      use_offchain: ${USE_OFFCHAIN:bool:false}
+      offchain_deposit_target_calls: ${OFFCHAIN_DEPOSIT_TARGET_CALLS:int:10}
       service_endpoint: ${SERVICE_ENDPOINT:str:https://trader.autonolas.tech/}
       rpc_sleep_time: ${RPC_SLEEP_TIME:int:10}
       safe_voting_range: ${SAFE_VOTING_RANGE:int:600}

--- a/packages/valory/services/trader_pearl/service.yaml
+++ b/packages/valory/services/trader_pearl/service.yaml
@@ -8,7 +8,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeibg7bdqpioh4lmvknw3ygnllfku32oca4eq5pqtvdrdsgw6buko7e
 fingerprint_ignore_patterns: []
-agent: valory/trader:0.1.0:bafybeihhfz6we66nkc3xtnozidwjtke2ahzoj6ixetzzj5ztp2gekt6zte
+agent: valory/trader:0.1.0:bafybeib42tl6yicz6k5eaezf2kuulpot2uune3ycm7nm6r573crl4tg2ui
 number_of_agents: 1
 deployment:
   agent:
@@ -135,7 +135,9 @@ models:
       strategies_kwargs: ${STRATEGIES_KWARGS:dict:{"floor_balance":0,"default_max_bet_size":2000000000000000000,"absolute_min_bet_size":25000000000000000,"absolute_max_bet_size":2000000000000000000,"n_bets":1,"min_edge":0.03,"min_oracle_prob":0.5,"fee_per_trade":10000000000000000,"grid_points":500}}
       use_subgraph_for_redeeming: ${USE_SUBGRAPH_FOR_REDEEMING:bool:true}
       use_mech_marketplace: ${USE_MECH_MARKETPLACE:bool:false}
-      mech_marketplace_config: ${MECH_MARKETPLACE_CONFIG:dict:{"mech_marketplace_address":"0x4554fE75c1f5576c1d7F765B2A036c199Adae329","priority_mech_address":"0x0000000000000000000000000000000000000000","priority_mech_staking_instance_address":"0x998dEFafD094817EF329f6dc79c703f1CF18bC90","priority_mech_service_id":975,"requester_staking_instance_address":"0x0000000000000000000000000000000000000000","response_timeout":300,"use_offchain":false,"offchain_url":null,"offchain_deposit_target_calls":10,"auto_deposit_cap_per_cycle":5000000000000000000,"offchain_poll_interval_seconds":3.0,"offchain_poll_timeout_seconds":300.0,"offchain_failover_max_retries":2}}
+      mech_marketplace_config: ${MECH_MARKETPLACE_CONFIG:dict:{"mech_marketplace_address":"0x4554fE75c1f5576c1d7F765B2A036c199Adae329","priority_mech_address":"0x0000000000000000000000000000000000000000","priority_mech_staking_instance_address":"0x998dEFafD094817EF329f6dc79c703f1CF18bC90","priority_mech_service_id":975,"requester_staking_instance_address":"0x0000000000000000000000000000000000000000","response_timeout":300,"offchain_url":null,"auto_deposit_cap_per_cycle":5000000000000000000,"offchain_poll_interval_seconds":3.0,"offchain_poll_timeout_seconds":300.0,"offchain_failover_max_retries":2}}
+      use_offchain: ${USE_OFFCHAIN:bool:false}
+      offchain_deposit_target_calls: ${OFFCHAIN_DEPOSIT_TARGET_CALLS:int:10}
       service_endpoint: ${SERVICE_ENDPOINT:str:https://trader.autonolas.tech/}
       rpc_sleep_time: ${RPC_SLEEP_TIME:int:10}
       safe_voting_range: ${SAFE_VOTING_RANGE:int:600}

--- a/packages/valory/skills/agent_performance_summary_abci/behaviours.py
+++ b/packages/valory/skills/agent_performance_summary_abci/behaviours.py
@@ -575,8 +575,7 @@ class FetchPerformanceSummaryBehaviour(
         )
         cached_total = state.total_deposited_wei
 
-        marketplace_config = self.params.mech_marketplace_config
-        if not marketplace_config.use_offchain:
+        if not self.params.use_offchain:
             # On-chain-only deployment (default for all production
             # traders). cached_total is 0 for any agent that never enabled
             # off-chain accounting, so ROI is bit-identical to pre-migration.

--- a/packages/valory/skills/agent_performance_summary_abci/skill.yaml
+++ b/packages/valory/skills/agent_performance_summary_abci/skill.yaml
@@ -10,7 +10,7 @@ fingerprint:
   achievements_checker/__init__.py: bafybeih7da3glbp2ljghlw4ign2dxotwwkzrrnj4m5yq27zb6osyfutva4
   achievements_checker/base.py: bafybeiegrcxb3d3ivpzm4lsud7kcypphl54yukjuecqlffrkzwdjawrth4
   achievements_checker/bet_payout_checker.py: bafybeigqbcvy7fe3apckuscrp4gs5zljppady6bwe6kgjdxxjryyppo6jm
-  behaviours.py: bafybeih37le4ym4wprmwfpqrsgw4pjuv7pflrf36427xqh3qtr5l6icaoq
+  behaviours.py: bafybeiculb27pfaiykmlmixsrkjfysn4otaf2tojjfzgcgb7m7b4v7hcbi
   dialogues.py: bafybeignoeakzaf7nmdnsjhnjoga3ks6z424qcwmzkol3kikawhnxf6zju
   fsm_specification.yaml: bafybeibjgjldm26nwmidx75ylvr5q7oe4kthiphvceuerkacxd3chj6vuu
   graph_tooling/__init__.py: bafybeicek36kwi7hlbhxz4ry5j662srevbhfrhx7ocb2ihc77hhil2utqu
@@ -36,7 +36,7 @@ fingerprint:
   tests/graph_tooling/test_predictions_helper.py: bafybeidkmubpjfnxys74bjaqd7ptz4gc6ejfwrrmiodmdjwdovdclvdqhu
   tests/graph_tooling/test_queries.py: bafybeih4ybhkq5seb34eqgakfpfrtlijxju3w52cjwvlrbbx2afgai4jm4
   tests/graph_tooling/test_requests.py: bafybeig5nc5ijgvy6kiay3yf5gwjd6mpi5fnhkmzqya37ruglkso2n77fq
-  tests/test_behaviours.py: bafybeid5rfbrtztofbkich6mwjsxid6we7s45amn4r4f3v7fk4wkn3kw5i
+  tests/test_behaviours.py: bafybeih6kcq5sex3hiy4v7keyqcka3u2x4sj4vuueidyepjgplhrhhft2e
   tests/test_dialogues.py: bafybeigezi53b2jukm5ju6z6zvecfjkjtzxcge3ehnzxryuhpambzknc3y
   tests/test_handlers.py: bafybeigybc6zkku7ldtawjcjjdkndiz3alvckxbeyjj23rsmny5ql7leku
   tests/test_models.py: bafybeicoimddbyoh3gkddxdnwknp5etbib25sgpguarode6y4iohuu63oe

--- a/packages/valory/skills/agent_performance_summary_abci/tests/test_behaviours.py
+++ b/packages/valory/skills/agent_performance_summary_abci/tests/test_behaviours.py
@@ -2551,6 +2551,7 @@ class TestFetchOffchainPrepaidWei:
         b = _make_fetch_behaviour()
         ctx, params, synced_data, _ = _mock_context()
         params.mech_marketplace_config = _make_marketplace_config(use_offchain=False)
+        params.use_offchain = False
         shared_state, writes = self._make_shared_state(None)
 
         api_calls: list = []
@@ -2589,6 +2590,7 @@ class TestFetchOffchainPrepaidWei:
         b = _make_fetch_behaviour()
         ctx, params, synced_data, _ = _mock_context()
         params.mech_marketplace_config = _make_marketplace_config(use_offchain=False)
+        params.use_offchain = False
         shared_state, writes = self._make_shared_state(
             OffchainDepositState(total_deposited_wei=5000, last_scanned_block=142)
         )
@@ -2614,6 +2616,7 @@ class TestFetchOffchainPrepaidWei:
         b = _make_fetch_behaviour()
         ctx, params, synced_data, _ = _mock_context()
         params.mech_marketplace_config = _make_marketplace_config(use_offchain=True)
+        params.use_offchain = True
         params.balance_tracker_address = "0x0000000000000000000000000000000000000000"
         shared_state, writes = self._make_shared_state(
             OffchainDepositState(total_deposited_wei=800, last_scanned_block=42)
@@ -2646,6 +2649,7 @@ class TestFetchOffchainPrepaidWei:
         b = _make_fetch_behaviour()
         ctx, params, synced_data, _ = _mock_context()
         params.mech_marketplace_config = _make_marketplace_config(use_offchain=True)
+        params.use_offchain = True
         shared_state, writes = self._make_shared_state(None)
 
         contract_calls_seen: list = []
@@ -2685,6 +2689,7 @@ class TestFetchOffchainPrepaidWei:
         b = _make_fetch_behaviour()
         ctx, params, synced_data, _ = _mock_context()
         params.mech_marketplace_config = _make_marketplace_config(use_offchain=True)
+        params.use_offchain = True
         shared_state, writes = self._make_shared_state(None)
 
         with (
@@ -2711,6 +2716,7 @@ class TestFetchOffchainPrepaidWei:
         b = _make_fetch_behaviour()
         ctx, params, synced_data, _ = _mock_context()
         params.mech_marketplace_config = _make_marketplace_config(use_offchain=True)
+        params.use_offchain = True
         shared_state, writes = self._make_shared_state(None)
 
         def _ledger_api(*_a: Any, **_kw: Any) -> Generator:
@@ -2752,6 +2758,7 @@ class TestFetchOffchainPrepaidWei:
         b = _make_fetch_behaviour()
         ctx, params, synced_data, _ = _mock_context()
         params.mech_marketplace_config = _make_marketplace_config(use_offchain=True)
+        params.use_offchain = True
         shared_state, writes = self._make_shared_state(
             OffchainDepositState(total_deposited_wei=1000, last_scanned_block=99)
         )
@@ -2791,6 +2798,7 @@ class TestFetchOffchainPrepaidWei:
         b = _make_fetch_behaviour()
         ctx, params, synced_data, _ = _mock_context()
         params.mech_marketplace_config = _make_marketplace_config(use_offchain=True)
+        params.use_offchain = True
         shared_state, writes = self._make_shared_state(
             OffchainDepositState(total_deposited_wei=1000, last_scanned_block=99)
         )
@@ -2848,6 +2856,7 @@ class TestFetchOffchainPrepaidWei:
         b = _make_fetch_behaviour()
         ctx, params, synced_data, _ = _mock_context()
         params.mech_marketplace_config = _make_marketplace_config(use_offchain=True)
+        params.use_offchain = True
         shared_state, writes = self._make_shared_state(
             OffchainDepositState(total_deposited_wei=1000, last_scanned_block=99)
         )
@@ -2894,6 +2903,7 @@ class TestFetchOffchainPrepaidWei:
         b = _make_fetch_behaviour()
         ctx, params, synced_data, _ = _mock_context()
         params.mech_marketplace_config = _make_marketplace_config(use_offchain=True)
+        params.use_offchain = True
         shared_state, writes = self._make_shared_state(
             OffchainDepositState(total_deposited_wei=1000, last_scanned_block=99)
         )
@@ -2959,6 +2969,7 @@ class TestFetchOffchainPrepaidWei:
         b = _make_fetch_behaviour()
         ctx, params, synced_data, _ = _mock_context()
         params.mech_marketplace_config = _make_marketplace_config(use_offchain=True)
+        params.use_offchain = True
         shared_state, writes = self._make_shared_state(
             OffchainDepositState(total_deposited_wei=1000, last_scanned_block=99)
         )
@@ -2999,6 +3010,7 @@ class TestFetchOffchainPrepaidWei:
         b = _make_fetch_behaviour()
         ctx, params, synced_data, _ = _mock_context()
         params.mech_marketplace_config = _make_marketplace_config(use_offchain=True)
+        params.use_offchain = True
         shared_state, writes = self._make_shared_state(
             OffchainDepositState(total_deposited_wei=1000, last_scanned_block=500)
         )
@@ -3038,6 +3050,7 @@ class TestFetchOffchainPrepaidWei:
         b = _make_fetch_behaviour()
         ctx, params, synced_data, _ = _mock_context()
         params.mech_marketplace_config = _make_marketplace_config(use_offchain=True)
+        params.use_offchain = True
         shared_state, writes = self._make_shared_state(
             OffchainDepositState(total_deposited_wei=1000, last_scanned_block=99)
         )
@@ -3073,6 +3086,7 @@ class TestFetchOffchainPrepaidWei:
         b = _make_fetch_behaviour()
         ctx, params, synced_data, _ = _mock_context()
         params.mech_marketplace_config = _make_marketplace_config(use_offchain=True)
+        params.use_offchain = True
         shared_state, writes = self._make_shared_state(
             OffchainDepositState(total_deposited_wei=1000, last_scanned_block=99)
         )

--- a/packages/valory/skills/chatui_abci/skill.yaml
+++ b/packages/valory/skills/chatui_abci/skill.yaml
@@ -32,7 +32,7 @@ protocols:
 contracts: []
 skills:
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
-- valory/agent_performance_summary_abci:0.1.0:bafybeibw4cjxuswzkhilfxwqodxuwpnqxq7e5egfmrmufoigjtu4iyma6u
+- valory/agent_performance_summary_abci:0.1.0:bafybeiaguxjexjxth4e3zajfxvqjprjhn4r6njgq6ddmhkql3uhqdsttp4
 handlers:
   abci:
     args: {}

--- a/packages/valory/skills/check_stop_trading_abci/skill.yaml
+++ b/packages/valory/skills/check_stop_trading_abci/skill.yaml
@@ -30,8 +30,8 @@ contracts:
 protocols: []
 skills:
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
-- valory/chatui_abci:0.1.0:bafybeiga534fdtg7544qf3paaxcunauy46hu4xphmo2k2izjmdncw72pmy
-- valory/mech_interact_abci:0.1.0:bafybeifbkpgivxjexlhrptn2iaju7vyzeusevvucsin6tbjwveniykad2q
+- valory/chatui_abci:0.1.0:bafybeicsqursfh4svzecimnfbv77jn4vq3cc42e7bislzxfbqigos4ulgm
+- valory/mech_interact_abci:0.1.0:bafybeic5xfxdod5l56o7aojdamojnvi562nql2mlah73bf47d4guz4xnwi
 - valory/staking_abci:0.1.0:bafybeia6csjgex5zxdt6vymiaengu75lyzjdgfrnp65ewlghthiniquhje
 behaviours:
   main:

--- a/packages/valory/skills/decision_maker_abci/skill.yaml
+++ b/packages/valory/skills/decision_maker_abci/skill.yaml
@@ -179,10 +179,10 @@ skills:
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
 - valory/market_manager_abci:0.1.0:bafybeig3ak2eoimxwuupybde4napyi2jlf7pxk35se2zclikete2ni5hti
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
-- valory/mech_interact_abci:0.1.0:bafybeifbkpgivxjexlhrptn2iaju7vyzeusevvucsin6tbjwveniykad2q
+- valory/mech_interact_abci:0.1.0:bafybeic5xfxdod5l56o7aojdamojnvi562nql2mlah73bf47d4guz4xnwi
 - valory/staking_abci:0.1.0:bafybeia6csjgex5zxdt6vymiaengu75lyzjdgfrnp65ewlghthiniquhje
-- valory/agent_performance_summary_abci:0.1.0:bafybeibw4cjxuswzkhilfxwqodxuwpnqxq7e5egfmrmufoigjtu4iyma6u
-- valory/chatui_abci:0.1.0:bafybeiga534fdtg7544qf3paaxcunauy46hu4xphmo2k2izjmdncw72pmy
+- valory/agent_performance_summary_abci:0.1.0:bafybeiaguxjexjxth4e3zajfxvqjprjhn4r6njgq6ddmhkql3uhqdsttp4
+- valory/chatui_abci:0.1.0:bafybeicsqursfh4svzecimnfbv77jn4vq3cc42e7bislzxfbqigos4ulgm
 behaviours:
   main:
     args: {}
@@ -392,6 +392,8 @@ models:
         priority_mech_service_id: 0
         requester_staking_instance_address: '0x0000000000000000000000000000000000000000'
         response_timeout: 300
+      use_offchain: false
+      offchain_deposit_target_calls: 10
       agent_balance_threshold: 10000000000000000
       expected_mech_response_time: 300
       mech_invalid_response: Invalid Response

--- a/packages/valory/skills/trader_abci/skill.yaml
+++ b/packages/valory/skills/trader_abci/skill.yaml
@@ -57,13 +57,13 @@ skills:
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
 - valory/market_manager_abci:0.1.0:bafybeig3ak2eoimxwuupybde4napyi2jlf7pxk35se2zclikete2ni5hti
-- valory/decision_maker_abci:0.1.0:bafybeiefxkbb3qh35gnsoqq65bi7wvp7yfbb7uiwef747oahgtyicisumu
-- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeiffci4jqgnmjud3j6m5cam7vvjttt6uugfh57az6a4quiwzmk6llm
+- valory/decision_maker_abci:0.1.0:bafybeihgq4jjqyjrxyzzzi7hd7r27vf2lj45h5ljnp57kzg6enz3vtyqvy
+- valory/tx_settlement_multiplexer_abci:0.1.0:bafybeifjxdbup557ynvbjfo6q2zoeupz3rerzf3uwyntiqvhmoqupy7a7a
 - valory/staking_abci:0.1.0:bafybeia6csjgex5zxdt6vymiaengu75lyzjdgfrnp65ewlghthiniquhje
-- valory/check_stop_trading_abci:0.1.0:bafybeicn32bur353d3msdypfcwq257ucmmg55rzyklxftff2l2uoez62wu
-- valory/mech_interact_abci:0.1.0:bafybeifbkpgivxjexlhrptn2iaju7vyzeusevvucsin6tbjwveniykad2q
-- valory/chatui_abci:0.1.0:bafybeiga534fdtg7544qf3paaxcunauy46hu4xphmo2k2izjmdncw72pmy
-- valory/agent_performance_summary_abci:0.1.0:bafybeibw4cjxuswzkhilfxwqodxuwpnqxq7e5egfmrmufoigjtu4iyma6u
+- valory/check_stop_trading_abci:0.1.0:bafybeierqjfa6yq4vmhwsweght4w5vao2f7d732jczuexa7ovy4grhqmui
+- valory/mech_interact_abci:0.1.0:bafybeic5xfxdod5l56o7aojdamojnvi562nql2mlah73bf47d4guz4xnwi
+- valory/chatui_abci:0.1.0:bafybeicsqursfh4svzecimnfbv77jn4vq3cc42e7bislzxfbqigos4ulgm
+- valory/agent_performance_summary_abci:0.1.0:bafybeiaguxjexjxth4e3zajfxvqjprjhn4r6njgq6ddmhkql3uhqdsttp4
 - valory/funds_manager:0.1.0:bafybeicfw7qjtnlcbw6awsvxdahqu42fxsfsd3wy7mbyhcbls4l5pee3by
 behaviours:
   main:
@@ -300,13 +300,13 @@ models:
         priority_mech_service_id: 0
         requester_staking_instance_address: '0x0000000000000000000000000000000000000000'
         response_timeout: 300
-        use_offchain: false
         offchain_url: null
-        offchain_deposit_target_calls: 10
         auto_deposit_cap_per_cycle: 5000000000000000000
         offchain_poll_interval_seconds: 3.0
         offchain_poll_timeout_seconds: 300.0
         offchain_failover_max_retries: 2
+      use_offchain: false
+      offchain_deposit_target_calls: 10
       expected_mech_response_time: 300
       mech_invalid_response: Invalid Response
       mech_consecutive_failures_threshold: 2

--- a/packages/valory/skills/tx_settlement_multiplexer_abci/skill.yaml
+++ b/packages/valory/skills/tx_settlement_multiplexer_abci/skill.yaml
@@ -27,9 +27,9 @@ protocols:
 - valory/ledger_api:1.0.0:bafybeiecq56phjfws36rgrefw6niyo4ezesloodsfis647mpm5ygqo4ysi
 skills:
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
-- valory/decision_maker_abci:0.1.0:bafybeiefxkbb3qh35gnsoqq65bi7wvp7yfbb7uiwef747oahgtyicisumu
+- valory/decision_maker_abci:0.1.0:bafybeihgq4jjqyjrxyzzzi7hd7r27vf2lj45h5ljnp57kzg6enz3vtyqvy
 - valory/staking_abci:0.1.0:bafybeia6csjgex5zxdt6vymiaengu75lyzjdgfrnp65ewlghthiniquhje
-- valory/mech_interact_abci:0.1.0:bafybeifbkpgivxjexlhrptn2iaju7vyzeusevvucsin6tbjwveniykad2q
+- valory/mech_interact_abci:0.1.0:bafybeic5xfxdod5l56o7aojdamojnvi562nql2mlah73bf47d4guz4xnwi
 behaviours:
   main:
     args: {}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,7 @@ check_dependencies_extra_excludes = [
     "urllib3",
 ]
 upstream_pins = [
-    "valory-xyz/mech-interact@v0.32.6",
+    "valory-xyz/mech-interact@v0.32.7",
     "valory-xyz/mech@v0.34.2-rc2",
     "valory-xyz/genai@v7.2.2",
     "valory-xyz/kv-store@v0.7.1",


### PR DESCRIPTION
## Summary

Companion to [valory-xyz/mech-interact#113](https://github.com/valory-xyz/mech-interact/pull/113) ([release v0.32.7](https://github.com/valory-xyz/mech-interact/releases/tag/v0.32.7)).

Two knobs — `use_offchain` and `offchain_deposit_target_calls` — moved out of the nested `MechMarketplaceConfig` dataclass into top-level `MechParams` attributes upstream. This PR wires the change through every trader-side overlay (yamls) and the one Python consumer that read the old nested shape.

## Changes

- **`packages/packages.json`** — `mech_interact_abci` hash bumped to `bafybeic5xfxdod5l56o7aojdamojnvi562nql2mlah73bf47d4guz4xnwi` (v0.32.7). Cascade re-lock through trader_abci, decision_maker_abci, check_stop_trading_abci, chatui_abci, tx_settlement_multiplexer_abci, agent_performance_summary_abci, trader agent, both services.
- **Yaml overlays** (5 files) — hoist to top-level Params args:
  - `agents/trader/aea-config.yaml` — add `use_offchain: ${USE_OFFCHAIN:bool:false}` + `offchain_deposit_target_calls: ${OFFCHAIN_DEPOSIT_TARGET_CALLS:int:10}` next to the `mech_marketplace_config` line. Inline JSON default didn't carry either key already, so no removal there.
  - `services/trader_pearl/service.yaml` and `services/polymarket_trader/service.yaml` — strip both keys from the `${MECH_MARKETPLACE_CONFIG:dict:{…}}` JSON default and add top-level env-var forms next to it.
  - `skills/trader_abci/skill.yaml` — move `use_offchain: false` out of the nested `mech_marketplace_config` block to top-level; `offchain_deposit_target_calls: 10` also top-level.
  - `skills/decision_maker_abci/skill.yaml` — add both as top-level args (didn't have either before).
- **Python consumer swap** — `skills/agent_performance_summary_abci/behaviours.py` (`_fetch_offchain_prepaid_wei` early guard): `self.params.mech_marketplace_config.use_offchain` → `self.params.use_offchain`. Only 1 consumer in this repo (verified via grep).
- **Tests** — `agent_performance_summary_abci/tests/test_behaviours.py`: 14 sites doing `params.mech_marketplace_config = _make_marketplace_config(use_offchain=X)` also get `params.use_offchain = X` on the next line to mirror the runtime shape.

## Operator migration note

**Every deploy-time `MECH_MARKETPLACE_CONFIG` value** (env vars, Propel envs, Pearl middleware, `.env` files, Docker Compose files) **MUST drop the two nested keys and set the replacements at top level:**

```diff
-MECH_MARKETPLACE_CONFIG='{"...","use_offchain":false,"offchain_deposit_target_calls":10,...}'
+MECH_MARKETPLACE_CONFIG='{"..."}'  # drop both keys from the JSON
+USE_OFFCHAIN=false
+OFFCHAIN_DEPOSIT_TARGET_CALLS=10
```

Otherwise `MechParams.__init__` raises a `ValueError` at agent boot with a message naming the replacement env vars (fail-loud migration guard added in v0.32.7).

Pearl-specific: `olas-operate-middleware/operate/services/manage.py:541` already composes `MECH_MARKETPLACE_CONFIG` without either key, so the middleware path is unaffected — but Pearl frontend still needs to set `USE_OFFCHAIN` / `OFFCHAIN_DEPOSIT_TARGET_CALLS` as top-level env vars (proposed FIXED overrides in a follow-up Pearl PR).

## Test plan

- [x] `uv run autonomy packages lock --check` green
- [x] `uv run pytest packages/valory/skills/{agent_performance_summary,mech_interact,trader,decision_maker}_abci/tests/` → **3339 passed**
- [x] `mypy` / `black-check` / `darglint` / `flake8` / `isort-check` all green
- [x] Local live-boot verified: `make run-agent` with `USE_OFFCHAIN=false` + `OFFCHAIN_DEPOSIT_TARGET_CALLS=1` at top level + JSON blob stripped. Agent progressed past `MechParams.__init__` (both `_ensure` calls succeeded, `validate_offchain_params()` ran cleanly), HTTP server bound to `:8716`, `/healthcheck` responding, FSM waiting on Tendermint. No hoist-related error in the boot log.
- [ ] CI green on this PR
- [ ] Migration verified on Pearl preview / staging

## Companion PRs (other consumers)

- `optimus` — needs the same hash bump + yaml hoist (nested `mech_marketplace_config` in `skills/optimus_abci/skill.yaml:350,352`)
- `agents-fun` — needs the same
- `market-resolver` — needs the same PLUS strip inline-JSON in `agents/market_resolver/aea-config.yaml:235`

Each surface's crash mode is now explicit — the fail-loud `ValueError` in v0.32.7 names what to change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)